### PR TITLE
pinned pymysql to 0.9.3 to ensure warnings are handled

### DIFF
--- a/tests/integration/targets/setup_mysql/vars/main.yml
+++ b/tests/integration/targets/setup_mysql/vars/main.yml
@@ -15,7 +15,7 @@ percona_mysql_packages:
   - percona-server-client-{{ percona_client_version }}
 
 python_packages:
-  - pymysql
+  - pymysql==0.9.3  #  temporary fix pinning to 0.9.3 to ensure warnings are handled (https://github.com/ansible-collections/community.mysql/pull/9#issuecomment-663040948)
 
 install_prereqs:
   - libaio1


### PR DESCRIPTION
##### SUMMARY
Pinning pymysql to 0.9.3, v0.10.0 changes how warnings are handled, in the interim this will ensure behaviour is as expected (specifically regarding tests), however this is in lieu of a more appropriate fix, which I'll look to follow up with.

##### ISSUE TYPE
- Bugfix Pull Request

