### PR TITLE
Fix error "No database selected" when setting grants

### DIFF
--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -820,7 +820,7 @@ def privileges_grant(cursor, user, host, db_table, priv, tls_requires):
     # specification of db and table often use a % (SQL wildcard)
     db_table = db_table.replace('%', '%%')
     priv_string = ",".join([p for p in priv if p not in ('GRANT', 'REQUIRESSL')])
-    query = ["GRANT %s ON %s" % (priv_string, db_table)]
+    query = ["GRANT %s ON mysql.%s" % (priv_string, db_table)]
     query.append("TO %s@%s")
     params = (user, host)
     if tls_requires and use_old_user_mgmt(cursor):


### PR DESCRIPTION
##### SUMMARY
Database is not specified when setting grants resulting in "No database selected error"

Fixes #29 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user
