### PR TITLE
CI tests: add a note not to use tests as an example of writing roles

### DIFF
--- a/tests/integration/targets/setup_mysql/tasks/main.yml
+++ b/tests/integration/targets/setup_mysql/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - import_tasks: setvars.yml
 - import_tasks: dir.yml
 - import_tasks: install.yml

--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: make sure we have the ansible_os_family and ansible_distribution_version facts
   setup:
     gather_subset: distribution

--- a/tests/integration/targets/test_mysql_db/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for the mysql_db module
 # (c) 2014,  Wayne Rosario <wrosario@ansible.com>
 

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for mysql_info module
 # Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/tests/integration/targets/test_mysql_query/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/main.yml
@@ -1,2 +1,7 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # mysql_query module initial CI tests
 - import_tasks: mysql_query_initial.yml

--- a/tests/integration/targets/test_mysql_replication/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for the mysql_user module
 # (c) 2014,  Wayne Rosario <wrosario@ansible.com>
 

--- a/tests/integration/targets/test_mysql_variables/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - import_tasks: mysql_variables.yml


### PR DESCRIPTION
##### SUMMARY
CI tests: add a note not to use tests as an example of writing roles

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
CI tests