### PR TITLE
mysql_db: fix false warning related to unsafe_login_password

### DIFF
--- a/changelogs/fragments/34-mysql_db_fix_false_warning.yml
+++ b/changelogs/fragments/34-mysql_db_fix_false_warning.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- mysql_db - fix false warning related to ``unsafe_login_password`` (https://github.com/ansible-collections/community.mysql/issues/33).
+- mysql_db - fix false warning related to ``unsafe_login_password`` option (https://github.com/ansible-collections/community.mysql/issues/33).

--- a/changelogs/fragments/34-mysql_db_fix_false_warning.yml
+++ b/changelogs/fragments/34-mysql_db_fix_false_warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_db - fix false warning related to ``unsafe_login_password``(https://github.com/ansible-collections/community.mysql/issues/33).

--- a/changelogs/fragments/34-mysql_db_fix_false_warning.yml
+++ b/changelogs/fragments/34-mysql_db_fix_false_warning.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- mysql_db - fix false warning related to ``unsafe_login_password``(https://github.com/ansible-collections/community.mysql/issues/33).
+- mysql_db - fix false warning related to ``unsafe_login_password`` (https://github.com/ansible-collections/community.mysql/issues/33).

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -569,7 +569,7 @@ def main():
             skip_lock_tables=dict(type='bool', default=False),
             dump_extra_args=dict(type='str'),
             use_shell=dict(type='bool', default=False),
-            unsafe_login_password=dict(type='bool', default=False),
+            unsafe_login_password=dict(type='bool', default=False, no_log=True),
             restrict_config_file=dict(type='bool', default=False),
             check_implicit_admin=dict(type='bool', default=False),
             config_overrides_defaults=dict(type='bool', default=False),


### PR DESCRIPTION
##### SUMMARY
mysql_db: fix false warning related to `unsafe_login_password`

Fixes https://github.com/ansible-collections/community.mysql/issues/33

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
mysql_db
