### PR TITLE
Do not run same sanity tests twice

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -4,12 +4,12 @@ on:
     paths:
       - 'plugins/**'
       - 'tests/**'
-      - '.github/workflows/ansible-test.yml'
+      - '.github/workflows/ansible-test-plugins.yml'
   pull_request:
     paths:
       - 'plugins/**'
       - 'tests/**'
-      - '.github/workflows/ansible-test.yml'
+      - '.github/workflows/ansible-test-plugins.yml'
   schedule:
     - cron: '0 6 * * *'
 

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -27,9 +27,6 @@ jobs:
           - stable-2.9
           - stable-2.10
           - devel
-        python:
-          - 2.7
-          - 3.8
     steps:
 
       - name: Check out code
@@ -37,10 +34,10 @@ jobs:
         with:
           path: ansible_collections/community/mysql
 
-      - name: Set up Python ${{ matrix.python }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.8
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -71,10 +68,10 @@ jobs:
         with:
           path: ansible_collections/community/mysql
 
-      - name: Set up Python ${{ matrix.python }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.8
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check


### PR DESCRIPTION
##### SUMMARY
The sanity tests for every Ansible version are run twice, because the Python version used to execute ansible-test does not matter (since `--docker` is used).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
