### PR TITLE
Disable hostname check

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -63,10 +63,11 @@ jobs:
         python:
           - 3.6
         connector:
+          - pymysql==0.7.10
           - pymysql==0.9.3
           - mysqlclient==2.0.1
-        include:
-          - mysql: 5.7.31
+        exclude:
+          - mysql: 8.0.21
             connector: pymysql==0.7.10
     steps:
 

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   mysql_version_file: "./ansible_collections/community/mysql/tests/integration/targets/setup_mysql/defaults/main.yml"
+  connector_version_file: "./ansible_collections/community/mysql/tests/integration/targets/setup_mysql/vars/main.yml"
 
 jobs:
   sanity:
@@ -61,6 +62,12 @@ jobs:
           - devel
         python:
           - 3.6
+        connector:
+          - pymysql==0.9.3
+          - mysqlclient==2.0.1
+        include:
+          - mysql: 5.7.31
+            connector: pymysql==0.7.10
     steps:
 
       - name: Check out code
@@ -78,6 +85,9 @@ jobs:
 
       - name: Set MySQL version (${{ matrix.mysql }})
         run: "sed -i 's/^mysql_version:.*/mysql_version: \"${{ matrix.mysql }}\"/g' ${{ env.mysql_version_file }}"
+
+      - name: Set Connector version (${{ matrix.connector }})
+        run: "sed -i 's/^python_packages:.*/python_packages: [${{ matrix.connector }}]/' ${{ env.connector_version_file }}"
 
       - name: Run integration tests
         run: ansible-test integration --docker -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --diff --coverage

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -48,7 +48,7 @@ jobs:
         working-directory: ./ansible_collections/community/mysql
 
   integration:
-    name: "Integration (Python: ${{ matrix.python }}, Ansible: ${{ matrix.ansible }}, MySQL: ${{ matrix.mysql }})"
+    name: "Integration (Python: ${{ matrix.python }}, Ansible: ${{ matrix.ansible }}, MySQL: ${{ matrix.mysql }}, Connector: ${{ matrix.connector }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/changelogs/fragments/35-disable-hostname-check.yml
+++ b/changelogs/fragments/35-disable-hostname-check.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add new ``check_hostname`` option (https://github.com/ansible-collections/community.mysql/issues/28)

--- a/changelogs/fragments/35-disable-hostname-check.yml
+++ b/changelogs/fragments/35-disable-hostname-check.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - add new ``check_hostname`` option (https://github.com/ansible-collections/community.mysql/issues/28)
+  - mysql modules - add the ``check_hostname`` option (https://github.com/ansible-collections/community.mysql/issues/28).

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -65,6 +65,7 @@ options:
   check_hostname:
     description:
       - Whether to validate the server host name when an SSL connection is required.
+      - Setting this to False disables hostname verification. Use with caution.
       - Requires pymysql >= 0.7.11. MySQLdb does not support this option.
     type: bool
 requirements:

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -69,6 +69,7 @@ options:
       - Requires pymysql >= 0.7.11.
       - This optoin has no effect on MySQLdb.
     type: bool
+    version_added: '1.1.0'
 requirements:
    - PyMySQL (Python 2.7 and Python 3.X), or
    - MySQLdb (Python 2.x)

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -66,7 +66,8 @@ options:
     description:
       - Whether to validate the server host name when an SSL connection is required.
       - Setting this to False disables hostname verification. Use with caution.
-      - Requires pymysql >= 0.7.11. MySQLdb does not support this option.
+      - Requires pymysql >= 0.7.11.
+      - This optoin has no effect on MySQLdb.
     type: bool
 requirements:
    - PyMySQL (Python 2.7 and Python 3.X), or

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -65,7 +65,7 @@ options:
   check_hostname:
     description:
       - Whether to validate the server host name when an SSL connection is required.
-      - Setting this to False disables hostname verification. Use with caution.
+      - Setting this to C(false) disables hostname verification. Use with caution.
       - Requires pymysql >= 0.7.11.
       - This optoin has no effect on MySQLdb.
     type: bool

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -62,6 +62,11 @@ options:
       - The path to the client private key.
     type: path
     aliases: [ ssl_key ]
+  check_hostname:
+    description:
+      - Whether to validate the server host name when an SSL connection is required.
+      - Requires pymysql >= 0.7.11. MySQLdb does not support this option.
+    type: bool
 requirements:
    - PyMySQL (Python 2.7 and Python 3.X), or
    - MySQLdb (Python 2.x)

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -87,8 +87,6 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
                 config['ssl']['check_hostname'] = check_hostname
             else:
                 module.fail_json(msg='To use check_hostname, pymysql >= 0.7.11 is required on the target host')
-        else:
-            module.fail_json(msg='Connector %s does not support the check_hostname option' % mysql_driver.__name__)
 
     if _mysql_cursor_param == 'cursor':
         # In case of PyMySQL driver:

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -10,6 +10,7 @@
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
 from __future__ import (absolute_import, division, print_function)
+from functools import reduce
 __metaclass__ = type
 
 import os
@@ -37,8 +38,8 @@ def parse_from_mysql_config_file(cnf):
 
 
 def mysql_connect(module, login_user=None, login_password=None, config_file='', ssl_cert=None,
-                  ssl_key=None, ssl_ca=None, db=None, cursor_class=None,
-                  connect_timeout=30, autocommit=False, config_overrides_defaults=False):
+                  ssl_key=None, ssl_ca=None, db=None, cursor_class=None, connect_timeout=30,
+                  autocommit=False, config_overrides_defaults=False, check_hostname=None):
     config = {}
 
     if config_file and os.path.exists(config_file):
@@ -51,10 +52,10 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
                 module.params['login_port'] = cp.getint('client', 'port', fallback=module.params['login_port'])
             except Exception as e:
                 if "got an unexpected keyword argument 'fallback'" in e.message:
-                    module.fail_json('To use config_overrides_defaults, '
+                    module.fail_json(msg='To use config_overrides_defaults, '
                                      'it needs Python 3.5+ as the default interpreter on a target host')
 
-    if ssl_ca is not None or ssl_key is not None or ssl_cert is not None:
+    if ssl_ca is not None or ssl_key is not None or ssl_cert is not None or check_hostname is not None:
         config['ssl'] = {}
 
     if module.params['login_unix_socket']:
@@ -79,6 +80,15 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         config['db'] = db
     if connect_timeout is not None:
         config['connect_timeout'] = connect_timeout
+    if check_hostname is not None:
+        if mysql_driver.__name__ == "pymysql":
+            version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
+            if reduce(lambda x, y: int(x)*100 + int(y), version_tuple) >= 711:
+                config['ssl']['check_hostname'] = check_hostname
+            else:
+                module.fail_json(msg='To use check_hostname, pymysql >= 0.7.11 is required on the target host')
+        else:
+            module.fail_json(msg='Connector %s does not support the check_hostname option' % mysql_driver.__name__)
 
     if _mysql_cursor_param == 'cursor':
         # In case of PyMySQL driver:
@@ -107,4 +117,5 @@ def mysql_common_argument_spec():
         client_cert=dict(type='path', aliases=['ssl_cert']),
         client_key=dict(type='path', aliases=['ssl_key']),
         ca_cert=dict(type='path', aliases=['ssl_ca']),
+        check_hostname=dict(type='bool', default=None),
     )

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -83,7 +83,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if check_hostname is not None:
         if mysql_driver.__name__ == "pymysql":
             version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
-            if reduce(lambda x, y: int(x)*100 + int(y), version_tuple) >= 711:
+            if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 711:
                 config['ssl']['check_hostname'] = check_hostname
             else:
                 module.fail_json(msg='To use check_hostname, pymysql >= 0.7.11 is required on the target host')

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -509,6 +509,7 @@ def main():
     ssl_cert = module.params['client_cert']
     ssl_key = module.params['client_key']
     ssl_ca = module.params['ca_cert']
+    check_hostname = module.params['check_hostname']
     config_file = module.params['config_file']
     filter_ = module.params['filter']
     exclude_fields = module.params['exclude_fields']
@@ -526,6 +527,7 @@ def main():
     try:
         cursor, db_conn = mysql_connect(module, login_user, login_password,
                                         config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                        check_hostname=check_hostname,
                                         connect_timeout=connect_timeout, cursor_class='DictCursor')
     except Exception as e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. "

--- a/tests/integration/targets/setup_mysql/tasks/install.yml
+++ b/tests/integration/targets/setup_mysql/tasks/install.yml
@@ -18,6 +18,13 @@
   environment:
     DEBIAN_FRONTEND: noninteractive
 
+- name: "{{ role_name }} | install | install packages required by mysql connector"
+  apt:
+    name: "{{ install_python_prereqs }}"
+    state: present
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
 - name: "{{ role_name }} | install | install python packages"
   pip:
     name: "{{ python_packages }}"

--- a/tests/integration/targets/setup_mysql/vars/main.yml
+++ b/tests/integration/targets/setup_mysql/vars/main.yml
@@ -15,7 +15,6 @@ percona_mysql_packages:
   - percona-server-client-{{ percona_client_version }}
 
 python_packages: [pymysql == 0.9.3]
-  # - mysqlclient == 2.0.1  #  temporary fix pinning to 0.9.3 to ensure warnings are handled (https://github.com/ansible-collections/community.mysql/pull/9#issuecomment-663040948)
 
 install_prereqs:
   - libaio1

--- a/tests/integration/targets/setup_mysql/vars/main.yml
+++ b/tests/integration/targets/setup_mysql/vars/main.yml
@@ -14,12 +14,17 @@ percona_mysql_repos:
 percona_mysql_packages:
   - percona-server-client-{{ percona_client_version }}
 
-python_packages:
-  - pymysql==0.9.3  #  temporary fix pinning to 0.9.3 to ensure warnings are handled (https://github.com/ansible-collections/community.mysql/pull/9#issuecomment-663040948)
+python_packages: [pymysql == 0.9.3]
+  # - mysqlclient == 2.0.1  #  temporary fix pinning to 0.9.3 to ensure warnings are handled (https://github.com/ansible-collections/community.mysql/pull/9#issuecomment-663040948)
 
 install_prereqs:
   - libaio1
   - libnuma1
+
+install_python_prereqs:
+  - python3-dev
+  - default-libmysqlclient-dev
+  - build-essential
 
 mysql_tarball: "mysql-{{ mysql_version }}-linux-glibc2.12-x86_64.tar.{{ mysql_compression_extension }}"
 mysql_src: "https://dev.mysql.com/get/Downloads/MySQL-{{ mysql_major_version }}/{{ mysql_tarball }}"

--- a/tests/integration/targets/test_mysql_db/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_db/defaults/main.yml
@@ -12,3 +12,6 @@ db_user2: 'datauser2'
 tmp_dir: '/tmp'
 db_latin1_name: 'db_latin1'
 file4: 'latin1_file'
+
+user_name_1: 'db_user1'
+user_password_1: 'gadfFDSdtTU^Sdfuj'

--- a/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
@@ -71,7 +71,7 @@
   assert:
     that:
     - result is failed
-    - result.msg is search("Can't connect to MySQL server on '{{ fake_host }}'")
+    - result.msg is search("Can't connect to MySQL server on '{{ fake_host }}'") or result.msg is search("Unknown MySQL server host '{{ fake_host }}'")
 
 # Clean up
 - name: Remove test db

--- a/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
@@ -30,6 +30,7 @@
         <<: *mysql_params
         name: "{{ user_name_1 }}"
         password: "{{ user_password_1 }}"
+        priv: '*.*:ALL,GRANT'
         tls_requires:
           SSL:
 
@@ -53,7 +54,7 @@
     - name: attempt connection with newly created user ignoring hostname
       mysql_db:
         name: '{{ db_name }}'
-        state: present
+        state: absent
         login_user: '{{ user_name_1 }}'
         login_password: '{{ user_password_1 }}'
         login_host: 127.0.0.1

--- a/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
@@ -51,6 +51,11 @@
           - result is failed
       when: pymysql_version.stdout != ""
 
+    - assert:
+        that:
+          - result is succeeded
+      when: pymysql_version.stdout == ""
+
     - name: attempt connection with newly created user ignoring hostname
       mysql_db:
         name: '{{ db_name }}'
@@ -66,7 +71,7 @@
 
     - assert:
         that:
-          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg
 
     - name: Drop mysql user
       mysql_user:

--- a/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
@@ -1,0 +1,75 @@
+---
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    - shell: pip show pymysql | awk '/Version/ {print $2}'
+      register: pymysql_version
+
+    - name: get server certificate
+      copy:
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        dest: /tmp/cert.pem
+      delegate_to: localhost
+
+    - name: Drop mysql user if exists
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        state: absent
+      ignore_errors: yes
+
+    - name: create user with ssl requirement
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        tls_requires:
+          SSL:
+
+    - name: attempt connection with newly created user (expect failure)
+      mysql_db:
+        name: '{{ db_name }}'
+        state: absent
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is failed
+      when: pymysql_version.stdout != ""
+
+    - name: attempt connection with newly created user ignoring hostname
+      mysql_db:
+        name: '{{ db_name }}'
+        state: present
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+        check_hostname: no
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+
+    - name: Drop mysql user
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        host: 127.0.0.1
+        state: absent

--- a/tests/integration/targets/test_mysql_db/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/main.yml
@@ -322,3 +322,5 @@
 
 - include: config_overrides_defaults.yml
   when: ansible_python.version_info[0] >= 3
+
+- include: issue-28.yml

--- a/tests/integration/targets/test_mysql_info/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_info/defaults/main.yml
@@ -6,3 +6,6 @@ mysql_host: 127.0.0.1
 mysql_primary_port: 3307
 
 db_name: data
+
+user_name_1: 'db_user1'
+user_password_1: 'gadfFDSdtTU^Sdfuj'

--- a/tests/integration/targets/test_mysql_info/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/issue-28.yml
@@ -49,6 +49,11 @@
           - result is failed
       when: pymysql_version.stdout != ""
 
+    - assert:
+        that:
+          - result is succeeded
+      when: pymysql_version.stdout == ""
+
     - name: attempt connection with newly created user ignoring hostname
       mysql_info:
         filter: version
@@ -63,7 +68,7 @@
 
     - assert:
         that:
-          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg
 
     - name: Drop mysql user
       mysql_user:

--- a/tests/integration/targets/test_mysql_info/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/issue-28.yml
@@ -1,0 +1,73 @@
+---
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    - shell: pip show pymysql | awk '/Version/ {print $2}'
+      register: pymysql_version
+
+    - name: get server certificate
+      copy:
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        dest: /tmp/cert.pem
+      delegate_to: localhost
+
+    - name: Drop mysql user if exists
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        state: absent
+      ignore_errors: yes
+
+    - name: create user with ssl requirement
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        tls_requires:
+          SSL:
+
+    - name: attempt connection with newly created user (expect failure)
+      mysql_info:
+        filter: version
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is failed
+      when: pymysql_version.stdout != ""
+
+    - name: attempt connection with newly created user ignoring hostname
+      mysql_info:
+        filter: version
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+        check_hostname: no
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+
+    - name: Drop mysql user
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        host: 127.0.0.1
+        state: absent

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -189,3 +189,5 @@
         <<: *mysql_params
         name: acme
         state: absent
+
+    - include: issue-28.yml

--- a/tests/integration/targets/test_mysql_query/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_query/defaults/main.yml
@@ -7,3 +7,6 @@ test_db: testdb
 test_table1: test1
 test_table2: test2
 test_script_path: /tmp/test.sql
+
+user_name_1: 'db_user1'
+user_password_1: 'gadfFDSdtTU^Sdfuj'

--- a/tests/integration/targets/test_mysql_query/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/issue-28.yml
@@ -1,0 +1,73 @@
+---
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    - shell: pip show pymysql | awk '/Version/ {print $2}'
+      register: pymysql_version
+
+    - name: get server certificate
+      copy:
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        dest: /tmp/cert.pem
+      delegate_to: localhost
+
+    - name: Drop mysql user if exists
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        state: absent
+      ignore_errors: yes
+
+    - name: create user with ssl requirement
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        tls_requires:
+          SSL:
+
+    - name: attempt connection with newly created user (expect failure)
+      mysql_query:
+        query: 'SHOW DATABASES'
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is failed
+      when: pymysql_version.stdout != ""
+
+    - name: attempt connection with newly created user ignoring hostname
+      mysql_query:
+        query: 'SHOW DATABASES'
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+        check_hostname: no
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+
+    - name: Drop mysql user
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        host: 127.0.0.1
+        state: absent

--- a/tests/integration/targets/test_mysql_query/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/issue-28.yml
@@ -49,6 +49,11 @@
           - result is failed
       when: pymysql_version.stdout != ""
 
+    - assert:
+        that:
+          - result is succeeded
+      when: pymysql_version.stdout == ""
+
     - name: attempt connection with newly created user ignoring hostname
       mysql_query:
         query: 'SHOW DATABASES'
@@ -63,7 +68,7 @@
 
     - assert:
         that:
-          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg
 
     - name: Drop mysql user
       mysql_user:

--- a/tests/integration/targets/test_mysql_query/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/main.yml
@@ -5,3 +5,5 @@
 
 # mysql_query module initial CI tests
 - import_tasks: mysql_query_initial.yml
+
+- include: issue-28.yml

--- a/tests/integration/targets/test_mysql_replication/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_replication/defaults/main.yml
@@ -12,3 +12,6 @@ replication_user: replication_user
 replication_pass: replication_pass
 dump_path: /tmp/dump.sql
 test_channel: test_channel-1
+
+user_name_1: 'db_user1'
+user_password_1: 'gadfFDSdtTU^Sdfuj'

--- a/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
@@ -1,0 +1,77 @@
+---
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    - shell: pip show pymysql | awk '/Version/ {print $2}'
+      register: pymysql_version
+
+    - name: get server certificate
+      copy:
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        dest: /tmp/cert.pem
+      delegate_to: localhost
+
+    - name: Drop mysql user if exists
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        state: absent
+      ignore_errors: yes
+
+    - name: create user with ssl requirement
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        tls_requires:
+          SSL:
+
+  register: mysql_primary_status
+    - name: attempt connection with newly created user (expect failure)
+      mysql_replication:
+        mode: getmaster
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is failed
+      when: pymysql_version.stdout != ""
+
+    - name: attempt connection with newly created user ignoring hostname
+      mysql_replication:
+        mode: getmaster
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+        check_hostname: no
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+
+    - name: Drop mysql user
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ item }}'
+        host: 127.0.0.1
+        state: absent
+      with_items:
+        - "{{ user_name_1 }}"
+        - "{{ user_name_2 }}"

--- a/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
@@ -30,6 +30,7 @@
         <<: *mysql_params
         name: "{{ user_name_1 }}"
         password: "{{ user_password_1 }}"
+        priv: '*.*:ALL,GRANT'
         tls_requires:
           SSL:
 
@@ -68,9 +69,6 @@
     - name: Drop mysql user
       mysql_user:
         <<: *mysql_params
-        name: '{{ item }}'
+        name: '{{ user_name_1 }}'
         host: 127.0.0.1
         state: absent
-      with_items:
-        - "{{ user_name_1 }}"
-        - "{{ user_name_2 }}"

--- a/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
@@ -50,6 +50,11 @@
           - result is failed
       when: pymysql_version.stdout != ""
 
+    - assert:
+        that:
+          - result is succeeded
+      when: pymysql_version.stdout == ""
+
     - name: attempt connection with newly created user ignoring hostname
       mysql_replication:
         mode: getmaster
@@ -64,7 +69,7 @@
 
     - assert:
         that:
-          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg
 
     - name: Drop mysql user
       mysql_user:

--- a/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
@@ -33,7 +33,6 @@
         tls_requires:
           SSL:
 
-  register: mysql_primary_status
     - name: attempt connection with newly created user (expect failure)
       mysql_replication:
         mode: getmaster

--- a/tests/integration/targets/test_mysql_replication/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/main.yml
@@ -17,3 +17,5 @@
 
 # Tests of resetmaster mode:
 - import_tasks: mysql_replication_resetmaster_mode.yml
+
+- include: issue-28.yml

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -165,6 +165,9 @@
         that:
         - slave_status.Exec_Master_Log_Pos != mysql_primary_status.Position
 
+    - shell: pip show pymysql | awk '/Version/ {print $2}'
+      register: pymysql_version
+
     - name: Start slave that is already running
       mysql_replication:
         <<: *mysql_params
@@ -176,6 +179,7 @@
     - assert:
         that:
         - result is not changed
+      when: (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '<=')
 
     # Test stopslave mode:
     - name: Stop slave
@@ -202,3 +206,4 @@
     - assert:
         that:
         - result is not changed
+      when: (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '<=')

--- a/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
@@ -52,6 +52,11 @@
           - result is failed
       when: pymysql_version.stdout != ""
 
+    - assert:
+        that:
+          - result is succeeded
+      when: pymysql_version.stdout == ""
+
     - name: attempt connection with newly created user ignoring hostname
       mysql_user:
         name: "{{ user_name_2 }}"
@@ -68,7 +73,7 @@
 
     - assert:
         that:
-          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg
 
     - name: Drop mysql user
       mysql_user:

--- a/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
@@ -30,6 +30,7 @@
         <<: *mysql_params
         name: "{{ user_name_1 }}"
         password: "{{ user_password_1 }}"
+        priv: '*.*:ALL,GRANT'
         tls_requires:
           SSL:
 

--- a/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
@@ -1,0 +1,88 @@
+---
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    - name: get server certificate
+      copy:
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        dest: /tmp/cert.pem
+      delegate_to: localhost
+
+    - name: Drop mysql user if exists
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        state: absent
+      ignore_errors: yes
+
+    - name: create user with ssl requirement
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        tls_requires:
+          SSL:
+
+    - mysql_info:
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+        filter: version
+      ignore_errors: yes
+
+    - name: attempt connection with newly created user (expect failure)
+      mysql_user:
+        name: "{{ user_name_2 }}"
+        password: "{{ user_password_2 }}"
+        host: 127.0.0.1
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+      register: result
+      ignore_errors: yes
+
+    - pause:
+        seconds: 600
+
+    - assert:
+        that:
+          - result is failed
+
+    - name: attempt connection with newly created user ignoring hostname
+      mysql_user:
+        name: "{{ user_name_2 }}"
+        password: "{{ user_password_2 }}"
+        host: 127.0.0.1
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+        check_hostname: no
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+
+    - name: Drop mysql user
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ item }}'
+        host: 127.0.0.1
+        state: absent
+      with_items:
+        - "{{ user_name_1 }}"
+        - "{{ user_name_2 }}"

--- a/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
@@ -9,6 +9,9 @@
   block:
 
     # ============================================================
+    - shell: pip show pymysql | awk '/Version/ {print $2}'
+      register: pymysql_version
+
     - name: get server certificate
       copy:
         content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
@@ -30,15 +33,6 @@
         tls_requires:
           SSL:
 
-    - mysql_info:
-        login_user: '{{ user_name_1 }}'
-        login_password: '{{ user_password_1 }}'
-        login_host: 127.0.0.1
-        login_port: '{{ mysql_primary_port }}'
-        ca_cert: /tmp/cert.pem
-        filter: version
-      ignore_errors: yes
-
     - name: attempt connection with newly created user (expect failure)
       mysql_user:
         name: "{{ user_name_2 }}"
@@ -52,12 +46,10 @@
       register: result
       ignore_errors: yes
 
-    - pause:
-        seconds: 600
-
     - assert:
         that:
           - result is failed
+      when: pymysql_version.stdout != ""
 
     - name: attempt connection with newly created user ignoring hostname
       mysql_user:

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -37,6 +37,8 @@
 
   block:
 
+    - include: issue-28.yml
+
     - include: create_user.yml user_name={{user_name_1}} user_password={{ user_password_1 }}
 
     - include: resource_limits.yml

--- a/tests/integration/targets/test_mysql_variables/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_variables/defaults/main.yml
@@ -3,3 +3,6 @@
 mysql_user: root
 mysql_password: msandbox
 mysql_primary_port: 3307
+
+user_name_1: 'db_user1'
+user_password_1: 'gadfFDSdtTU^Sdfuj'

--- a/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
@@ -1,0 +1,76 @@
+---
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    - shell: pip show pymysql | awk '/Version/ {print $2}'
+      register: pymysql_version
+
+    - name: get server certificate
+      copy:
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        dest: /tmp/cert.pem
+      delegate_to: localhost
+
+    - name: Drop mysql user if exists
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        state: absent
+      ignore_errors: yes
+
+    - name: create user with ssl requirement
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        tls_requires:
+          SSL:
+
+    - name: attempt connection with newly created user (expect failure)
+      mysql_variables:
+        variable: '{{ set_name }}'
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is failed
+      when: pymysql_version.stdout != ""
+
+    - name: attempt connection with newly created user ignoring hostname
+      mysql_variables:
+        variable: '{{ set_name }}'
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+        ca_cert: /tmp/cert.pem
+        check_hostname: no
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+
+    - name: Drop mysql user
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ item }}'
+        host: 127.0.0.1
+        state: absent
+      with_items:
+        - "{{ user_name_1 }}"
+        - "{{ user_name_2 }}"

--- a/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
@@ -30,6 +30,7 @@
         <<: *mysql_params
         name: "{{ user_name_1 }}"
         password: "{{ user_password_1 }}"
+        priv: '*.*:ALL,GRANT'
         tls_requires:
           SSL:
 
@@ -68,9 +69,6 @@
     - name: Drop mysql user
       mysql_user:
         <<: *mysql_params
-        name: '{{ item }}'
+        name: '{{ user_name_1 }}'
         host: 127.0.0.1
         state: absent
-      with_items:
-        - "{{ user_name_1 }}"
-        - "{{ user_name_2 }}"

--- a/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
@@ -50,6 +50,11 @@
           - result is failed
       when: pymysql_version.stdout != ""
 
+    - assert:
+        that:
+          - result is succeeded
+      when: pymysql_version.stdout == ""
+
     - name: attempt connection with newly created user ignoring hostname
       mysql_variables:
         variable: '{{ set_name }}'
@@ -64,7 +69,7 @@
 
     - assert:
         that:
-          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg or 'MySQLdb does not support' in result.msg
+          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg
 
     - name: Drop mysql user
       mysql_user:

--- a/tests/integration/targets/test_mysql_variables/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/main.yml
@@ -4,3 +4,5 @@
 ####################################################################
 
 - import_tasks: mysql_variables.yml
+
+- include: issue-28.yml

--- a/tests/integration/targets/test_mysql_variables/tasks/mysql_variables.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/mysql_variables.yml
@@ -159,13 +159,13 @@
         <<: *mysql_params
         variable: max_connect_errors
         value: -1
-      register: result
+      register: oor_result
       ignore_errors: true
 
-    - include: assert_var.yml changed=true output={{ result }} var_name=max_connect_errors var_value=1
+    - include: assert_var.yml changed=true output={{ oor_result }} var_name=max_connect_errors var_value=1
       when: pymysql_version.stdout == ""
 
-    - include: assert_fail_msg.yml output={{ result }}  msg='Truncated incorrect'
+    - include: assert_fail_msg.yml output={{ oor_result }}  msg='Truncated incorrect'
       when: pymysql_version.stdout != ""
 
     # ============================================================
@@ -176,14 +176,10 @@
         <<: *mysql_params
         variable: max_connect_errors
         value: TEST
-      register: result
+      register: nvv_result
       ignore_errors: true
 
-    - include: assert_var.yml changed=true output={{ result }} var_name=max_connect_errors var_value=1
-      when: pymysql_version.stdout == ""
-
-    - include: assert_fail_msg.yml output={{ result }}  msg='Incorrect argument type to variable'
-      when: pymysql_version.stdout != ""
+    - include: assert_fail_msg.yml output={{ nvv_result }}  msg='Incorrect argument type to variable'
 
     # ============================================================
     # Verify mysql_variable fails when setting an unknown variable

--- a/tests/integration/targets/test_mysql_variables/tasks/mysql_variables.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/mysql_variables.yml
@@ -141,7 +141,7 @@
     - name: set mysql variable value to an expression
       mysql_variables:
         <<: *mysql_params
-        variable: max_tmp_tables
+        variable: max_connect_errors
         value: "1024*4"
       register: result
       ignore_errors: true
@@ -151,15 +151,22 @@
     # ============================================================
     # Verify mysql_variable fails when setting an incorrect value (out of range)
     #
+    - shell: pip show pymysql | awk '/Version/ {print $2}'
+      register: pymysql_version
+
     - name: set mysql variable value to a number out of range
       mysql_variables:
         <<: *mysql_params
-        variable: max_tmp_tables
+        variable: max_connect_errors
         value: -1
       register: result
       ignore_errors: true
 
+    - include: assert_var.yml changed=true output={{ result }} var_name=max_connect_errors var_value=1
+      when: pymysql_version.stdout == ""
+
     - include: assert_fail_msg.yml output={{ result }}  msg='Truncated incorrect'
+      when: pymysql_version.stdout != ""
 
     # ============================================================
     # Verify mysql_variable fails when setting an incorrect value (incorrect type)
@@ -167,12 +174,16 @@
     - name: set mysql variable value to a non-valid value number
       mysql_variables:
         <<: *mysql_params
-        variable: max_tmp_tables
+        variable: max_connect_errors
         value: TEST
       register: result
       ignore_errors: true
 
+    - include: assert_var.yml changed=true output={{ result }} var_name=max_connect_errors var_value=1
+      when: pymysql_version.stdout == ""
+
     - include: assert_fail_msg.yml output={{ result }}  msg='Incorrect argument type to variable'
+      when: pymysql_version.stdout != ""
 
     # ============================================================
     # Verify mysql_variable fails when setting an unknown variable


### PR DESCRIPTION
##### SUMMARY
Add option to disable server hostname verification when using SSL connections.

Fixes #28 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mysql module util. By extension the whole collection.

##### ADDITIONAL INFORMATION
This PR introduces the new `check_hostname` option, supported by pymysql >= 0.7.11 which allows the SSL handshake to disregard hostname verification. This is useful in cases where the connection is not using the server's FQDN or in cases of CN mismatch due to problems with the server's certificate. See #28
