### PR TITLE
Remove parsing of REQUIRE SSL in privileges

### DIFF
--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -746,8 +746,6 @@ def privileges_get(cursor, user, host):
         privileges = [pick(x.strip()) for x in privileges]
         if "WITH GRANT OPTION" in res.group(7):
             privileges.append('GRANT')
-        if 'REQUIRE SSL' in res.group(7):
-            privileges.append('REQUIRESSL')
         db = res.group(2)
         output.setdefault(db, []).extend(privileges)
     return output


### PR DESCRIPTION
This fixes a bug in which a `mysql_user` entry with a `tls_requires` option would always be marked as changed.   

By adding the `REQUIRESSL` option to the current privileges, it gets passed to to the `curr_priv` variable in `user_mod()`, causing the privileges intersection between `curr_priv` and `new_priv` on line 663 to always contain `REQUIRESSL` (because `new_priv` will never never contain `REQUIRESSL` it if we use `tls_requires`).  Therefore the module would always be marked as "changed":  it would always try to remove the REQUIRESSL via `privileges_revoke()` at line 669 and then add it back via the explicit TLS route at lines 673-690).

I'm aware this might not be the optimal solution.  Maybe it would be better to fix the ordering in `user_mod()` by first checking if `tls_requires` implies REQUIRE SSL, if so, add it to `new_priv` (if not already present), and then proceed with modifying the privileges and TLS settings.  However, that might defeat the purpose of having a separate `tls_requires` option in the first place.