### PR TITLE
module_utils: to add a destructor, in order to explicitly close the connection when the Connection object is GC'd

### DIFF
--- a/changelogs/fragments/44-close-connection.yml
+++ b/changelogs/fragments/44-close-connection.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - mysql modules - patch the ``Connection`` class to add a destructor that ensures connections to the server are explicitly closed (https://github.com/ansible-collections/community.mysql/pull/44).

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -89,6 +89,12 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         if autocommit:
             db_connection.autocommit(True)
 
+    # Monkey patch the Connection class to close the connection when garbage collected
+    def _conn_patch(conn_self):
+        conn_self.close()
+    db_connection.__class__.__del__ = _conn_patch
+    # Patched
+
     if cursor_class == 'DictCursor':
         return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor}), db_connection
     else:


### PR DESCRIPTION
##### SUMMARY
Monkey patching of the Connection class to add a destructor, in order to explicitly close the connection when the Connection object is GC'd.

Potentially fixes #43 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql modules

##### ADDITIONAL INFORMATION
It seems that none of the MySQL modules explicitly close their connections when done. This can cause the server to hold on to stale sockets for arbitrary amounts of time.
In cases where the workload is large enough (see #43) this will cause subsequent mysql tasks to hang indefinitely while they wait for a new listener to become available on the server.
