### PR TITLE
mysql modules: fix failing when \!include_dir is in config file

### DIFF
--- a/changelogs/fragments/47-mysql_modules_fix_failings_when_include_dir_in_config_file.yml
+++ b/changelogs/fragments/47-mysql_modules_fix_failings_when_include_dir_in_config_file.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "mysql modules - fix crash when ``!include_dir`` option is in config file (https://github.com/ansible-collections/community.mysql/issues/46)."
+- "mysql modules - fix crash when ``!includedir`` option is in config file (https://github.com/ansible-collections/community.mysql/issues/46)."

--- a/changelogs/fragments/47-mysql_modules_fix_failings_when_include_dir_in_config_file.yml
+++ b/changelogs/fragments/47-mysql_modules_fix_failings_when_include_dir_in_config_file.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "mysql modules - fix crash when ``!include_dir`` option is in config file (https://github.com/ansible-collections/community.mysql/issues/46)."

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -35,7 +35,7 @@ mysql_driver_fail_msg = 'The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python
 def parse_from_mysql_config_file(cnf):
     # Default values of comment_prefix is '#' and ';'.
     # '!' added to prevent a parsing error
-    # when a config file contains !include_dir parameter.
+    # when a config file contains !includedir parameter.
     cp = configparser.ConfigParser(comment_prefixes=('#', ';', '!'))
     cp.read(cnf)
     return cp

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -16,6 +16,7 @@ __metaclass__ = type
 import os
 
 from ansible.module_utils.six.moves import configparser
+from ansible.module_utils._text import to_native
 
 try:
     import pymysql as mysql_driver
@@ -32,7 +33,10 @@ mysql_driver_fail_msg = 'The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python
 
 
 def parse_from_mysql_config_file(cnf):
-    cp = configparser.ConfigParser()
+    # Default values of comment_prefix is '#' and ';'.
+    # '!' added to prevent a parsing error
+    # when a config file contains !include_dir parameter.
+    cp = configparser.ConfigParser(comment_prefixes=('#', ';', '!'))
     cp.read(cnf)
     return cp
 
@@ -44,16 +48,22 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
 
     if config_file and os.path.exists(config_file):
         config['read_default_file'] = config_file
-        cp = parse_from_mysql_config_file(config_file)
-        # Override some commond defaults with values from config file if needed
-        if cp and cp.has_section('client') and config_overrides_defaults:
+
+        if config_overrides_defaults:
             try:
-                module.params['login_host'] = cp.get('client', 'host', fallback=module.params['login_host'])
-                module.params['login_port'] = cp.getint('client', 'port', fallback=module.params['login_port'])
+                cp = parse_from_mysql_config_file(config_file)
             except Exception as e:
-                if "got an unexpected keyword argument 'fallback'" in e.message:
-                    module.fail_json(msg='To use config_overrides_defaults, '
-                                     'it needs Python 3.5+ as the default interpreter on a target host')
+                module.fail_json(msg="Failed to parse %s: %s" % (config_file, to_native(e)))
+
+            # Override some commond defaults with values from config file if needed
+            if cp and cp.has_section('client'):
+                try:
+                    module.params['login_host'] = cp.get('client', 'host', fallback=module.params['login_host'])
+                    module.params['login_port'] = cp.getint('client', 'port', fallback=module.params['login_port'])
+                except Exception as e:
+                    if "got an unexpected keyword argument 'fallback'" in e.message:
+                        module.fail_json(msg='To use config_overrides_defaults, '
+                                             'it needs Python 3.5+ as the default interpreter on a target host')
 
     if ssl_ca is not None or ssl_key is not None or ssl_cert is not None or check_hostname is not None:
         config['ssl'] = {}

--- a/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
@@ -11,6 +11,9 @@
 - name: Add fake port to config file
   shell: 'echo "port = {{ fake_port }}" >> {{ config_file }}'
 
+- name: Add blank line
+  shell: 'echo "" >> {{ config_file }}'
+
 - name: Create include_dir
   file:
     path: '{{ include_dir }}'
@@ -18,7 +21,10 @@
     mode: '0777'
 
 - name: Add include_dir
-  shell: 'echo "!include_dir {{ include_dir }}" >> {{ config_file }}'
+  lineinfile:
+    path: '{{ config_file }}'
+    line: '!includedir {{ include_dir }}'
+    insertafter: EOF
 
 - name: Create database using fake port to connect to, must fail
   mysql_db:

--- a/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
@@ -3,7 +3,7 @@
     config_file: "/root/.my1.cnf"
     fake_port: 9999
     fake_host: "blahblah.local"
-    include_dir: "/root/.my.cnf.d"
+    include_dir: "/root/mycnf.d"
 
 - name: Create custom config file
   shell: 'echo "[client]" > {{ config_file }}'

--- a/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
@@ -11,7 +11,7 @@
 - name: Add fake port to config file
   shell: 'echo "port = {{ fake_port }}" >> {{ config_file }}'
 
-- name: Get pymysql version for the next include
+- name: Get pymysql version
   shell: pip show pymysql | awk '/Version/ {print $2}'
   register: pymysql_version
 

--- a/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
@@ -11,20 +11,27 @@
 - name: Add fake port to config file
   shell: 'echo "port = {{ fake_port }}" >> {{ config_file }}'
 
+- name: Get pymysql version for the next include
+  shell: pip show pymysql | awk '/Version/ {print $2}'
+  register: pymysql_version
+
 - name: Add blank line
   shell: 'echo "" >> {{ config_file }}'
+  when: (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '>=')
 
 - name: Create include_dir
   file:
     path: '{{ include_dir }}'
     state: directory
     mode: '0777'
+  when: (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '>=')
 
 - name: Add include_dir
   lineinfile:
     path: '{{ config_file }}'
     line: '!includedir {{ include_dir }}'
     insertafter: EOF
+  when: (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '>=')
 
 - name: Create database using fake port to connect to, must fail
   mysql_db:

--- a/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
@@ -3,12 +3,22 @@
     config_file: "/root/.my1.cnf"
     fake_port: 9999
     fake_host: "blahblah.local"
+    include_dir: "/root/.my.cnf.d"
 
 - name: Create custom config file
   shell: 'echo "[client]" > {{ config_file }}'
 
 - name: Add fake port to config file
   shell: 'echo "port = {{ fake_port }}" >> {{ config_file }}'
+
+- name: Create include_dir
+  file:
+    path: '{{ include_dir }}'
+    state: directory
+    mode: '0777'
+
+- name: Add include_dir
+  shell: 'echo "!include_dir {{ include_dir }}" >> {{ config_file }}'
 
 - name: Create database using fake port to connect to, must fail
   mysql_db:

--- a/tests/integration/targets/test_mysql_db/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/main.yml
@@ -320,11 +320,7 @@
 
 - include: encoding_dump_import.yml file=latin1.sql format_msg_type=ASCII
 
-- name: Get pymysql version for the next include
-  shell: pip show pymysql | awk '/Version/ {print $2}'
-  register: pymysql_version
-
 - include: config_overrides_defaults.yml
-  when: ansible_python.version_info[0] >= 3 and (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '>=')
+  when: ansible_python.version_info[0] >= 3
 
 - include: issue-28.yml

--- a/tests/integration/targets/test_mysql_db/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/main.yml
@@ -320,7 +320,11 @@
 
 - include: encoding_dump_import.yml file=latin1.sql format_msg_type=ASCII
 
+- name: Get pymysql version for the next include
+  shell: pip show pymysql | awk '/Version/ {print $2}'
+  register: pymysql_version
+
 - include: config_overrides_defaults.yml
-  when: ansible_python.version_info[0] >= 3
+  when: ansible_python.version_info[0] >= 3 and (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '>=')
 
 - include: issue-28.yml


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.mysql/issues/46

The bug was introduced with https://github.com/ansible-collections/community.general/pull/513

1. The key point of the fix is to force configparser to ignore lines starting with `!`, in particular
```
cp = configparser.ConfigParser(comment_prefixes=('#', ';', '!'))
```
added comment_prefixes=('#', ';', '!')

I reproduced the bug in the CI tests file, then fixed this.

2. Also a few logical improvements added (e.g. don't parse a config file when there's no `config_overrides_defaults` option passed as `true`, etc.)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/module_utils/mysql.py`
