### PR TITLE
Add mysqlclient library reference in doc

### DIFF
--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -91,4 +91,7 @@ notes:
      and later uses the unix_socket authentication plugin by default that
      without using I(login_unix_socket=/var/run/mysqld/mysqld.sock) (the default path)
      causes the error ``Host '127.0.0.1' is not allowed to connect to this MariaDB server``.
+   - Alternatively, you can use the mysqlclient library instead of MySQL-python (MySQLdb)
+     which supports both Python 2.X and Python >=3.5.
+     See U(https://pypi.org/project/mysqlclient/) how to install it.
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #56 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`mysql.py`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```markdown
   - Alternatively, you can use the mysqlclient library instead of MySQL-python (MySQLdb)
     which supports both Python 2.X and Python >=3.5.
     See U(https://pypi.org/project/mysqlclient/) how to install it.
```
