### PR TITLE
Fixed mysql_replication module doc issue

### DIFF
--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -82,6 +82,7 @@ options:
     description:
     - Same as mysql variable.
     type: bool
+    default: false
   master_ssl_ca:
     description:
     - Same as mysql variable.
@@ -106,6 +107,7 @@ options:
     description:
     - Whether the host uses GTID based replication or not.
     type: bool
+    default: false
   master_use_gtid:
     description:
     - Configures the slave to use the MariaDB Global Transaction ID.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Arguments of mysql_replication module  'master_ssl' and 'master_auto_position' in argument_spec defines default as (False) but documentation defines default as (None) hence added the same.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- mysql_replication
