### PR TITLE
mysql_replication: deprecation of slave related options, adding alternatives

### DIFF
--- a/changelogs/fragments/97-mysql_replication_deprecate_offending_terminology.yml
+++ b/changelogs/fragments/97-mysql_replication_deprecate_offending_terminology.yml
@@ -1,2 +1,5 @@
 minor_changes:
 - mysql_replication - deprecate offending terminology, add alternative choices to the ``mode`` option (https://github.com/ansible-collections/community.mysql/issues/78).
+
+major_changes:
+- mysql_replication - the word ``SLAVE`` in messages returned by the module will be changed to ``REPLICA`` in the next major release (https://github.com/ansible-collections/community.mysql/issues/98).

--- a/changelogs/fragments/97-mysql_replication_deprecate_offending_terminology.yml
+++ b/changelogs/fragments/97-mysql_replication_deprecate_offending_terminology.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - deprecate offending terminology, add alternative choices to the ``mode`` option (https://github.com/ansible-collections/community.mysql/issues/78).

--- a/changelogs/fragments/97-mysql_replication_deprecate_offending_terminology.yml
+++ b/changelogs/fragments/97-mysql_replication_deprecate_offending_terminology.yml
@@ -2,4 +2,5 @@ minor_changes:
 - mysql_replication - deprecate offending terminology, add alternative choices to the ``mode`` option (https://github.com/ansible-collections/community.mysql/issues/78).
 
 major_changes:
-- mysql_replication - the word ``SLAVE`` in messages returned by the module will be changed to ``REPLICA`` in the next major release (https://github.com/ansible-collections/community.mysql/issues/98).
+- mysql_replication - the word ``SLAVE`` in messages returned by the module will be changed to ``REPLICA`` in ``community.mysql`` 2.0.0 (https://github.com/ansible-collections/community.mysql/issues/98).
+- mysql_replication - the mode options values ``getslave``, ``startslave``, ``stopslave``, ``resetslave``, ``resetslaveall` and the master_use_gtid option ``slave_pos`` are deprecated (see the alternative values) and will be removed in ``community.mysql`` 3.0.0 (https://github.com/ansible-collections/community.mysql/pull/97).

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -507,8 +507,8 @@ def main():
     if uses_replica_terminology(cursor):
         replica_term = 'REPLICA'
         if master_use_gtid == 'slave_pos':
-            module.warn('master_use_gtid "slave_pos" value is deprecated. '
-                        'Please, use "replica_pos" instead.')
+            module.deprecate('master_use_gtid "slave_pos" value is deprecated, use "replica_pos" instead.',
+                             version='3.0.0', collection_name='community.mysql')
             master_use_gtid = 'replica_pos'
     else:
         replica_term = 'SLAVE'
@@ -525,8 +525,8 @@ def main():
 
     elif mode in ("getreplica", "getslave"):
         if mode == "getslave":
-            module.warn('"getslave" option is deprecated. '
-                        'Please, use "getreplica" instead.')
+            module.deprecate('"getslave" option is deprecated, use "getreplica" instead.',
+                             version='3.0.0', collection_name='community.mysql')
 
         status = get_replica_status(cursor, connection_name, channel, replica_term)
         if not isinstance(status, dict):
@@ -584,8 +584,8 @@ def main():
         module.exit_json(queries=executed_queries, **result)
     elif mode in ("startreplica", "startslave"):
         if mode == "startslave":
-            module.warn('"startslave" option is deprecated. '
-                        'Please, use "startreplica" instead.')
+            module.deprecate('"startslave" option is deprecated, use "startreplica" instead.',
+                             version='3.0.0', collection_name='community.mysql')
 
         started = start_replica(module, cursor, connection_name, channel, fail_on_error, replica_term)
         if started is True:
@@ -594,8 +594,8 @@ def main():
             module.exit_json(msg="Slave already started (Or cannot be started)", changed=False, queries=executed_queries)
     elif mode in ("stopreplica", "stopslave"):
         if mode == "stopslave":
-            module.warn('"stopslave" option is deprecated. '
-                        'Please, use "stopreplica" instead.')
+            module.deprecate('"stopslave" option is deprecated, use "stopreplica" instead.',
+                             version='3.0.0', collection_name='community.mysql')
 
         stopped = stop_replica(module, cursor, connection_name, channel, fail_on_error, replica_term)
         if stopped is True:
@@ -610,8 +610,8 @@ def main():
             module.exit_json(msg="Master already reset", changed=False, queries=executed_queries)
     elif mode in ("resetreplica", "resetslave"):
         if mode == "resetslave":
-            module.warn('"resetslave" option is deprecated. '
-                        'Please, use "resetreplica" instead.')
+            module.deprecate('"resetslave" option is deprecated, use "resetreplica" instead.',
+                             version='3.0.0', collection_name='community.mysql')
 
         reset = reset_replica(module, cursor, connection_name, channel, fail_on_error, replica_term)
         if reset is True:
@@ -620,8 +620,8 @@ def main():
             module.exit_json(msg="Slave already reset", changed=False, queries=executed_queries)
     elif mode in ("resetreplicaall", "resetslaveall"):
         if mode == "resetslaveall":
-            module.warn('"resetslaveall" option is deprecated. '
-                        'Please, use "resetreplicaall" instead.')
+            module.deprecate('"resetslaveall" option is deprecated, use "resetreplicaall" instead.',
+                             version='3.0.0', collection_name='community.mysql')
 
         reset = reset_replica_all(module, cursor, connection_name, channel, fail_on_error, replica_term)
         if reset is True:

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_channel.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_channel.yml
@@ -50,12 +50,12 @@
         - result is changed
         - result.queries == ["START SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["START REPLICA FOR CHANNEL '{{ test_channel }}'"]
 
-    # Test getslave mode:
+    # Test getreplica mode:
     - name: Get standby status with channel
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica2_port }}'
-        mode: getslave
+        mode: getreplica
         channel: '{{ test_channel }}'
       register: slave_status
 

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_channel.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_channel.yml
@@ -36,12 +36,12 @@
         - result is changed
         - result.queries == ["CHANGE MASTER TO MASTER_HOST='{{ mysql_host }}',MASTER_USER='{{ replication_user }}',MASTER_PASSWORD='********',MASTER_PORT={{ mysql_primary_port }},MASTER_LOG_FILE='{{ mysql_primary_status.File }}',MASTER_LOG_POS={{ mysql_primary_status.Position }} FOR CHANNEL '{{ test_channel }}'"]
 
-    # Test startslave mode:
-    - name: Start slave with channel
+    # Test startreplica mode:
+    - name: Start replica with channel
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica2_port }}'
-        mode: startslave
+        mode: startreplica
         channel: '{{ test_channel }}'
       register: result
 
@@ -57,39 +57,39 @@
         login_port: '{{ mysql_replica2_port }}'
         mode: getreplica
         channel: '{{ test_channel }}'
-      register: slave_status
+      register: replica_status
 
     - assert:
         that:
-        - slave_status.Is_Slave == true
-        - slave_status.Master_Host == '{{ mysql_host }}'
-        - slave_status.Exec_Master_Log_Pos == mysql_primary_status.Position
-        - slave_status.Master_Port == {{ mysql_primary_port }}
-        - slave_status.Last_IO_Errno == 0
-        - slave_status.Last_IO_Error == ''
-        - slave_status.Channel_Name == '{{ test_channel }}'
-        - slave_status is not changed
+        - replica_status.Is_Slave == true
+        - replica_status.Master_Host == '{{ mysql_host }}'
+        - replica_status.Exec_Master_Log_Pos == mysql_primary_status.Position
+        - replica_status.Master_Port == {{ mysql_primary_port }}
+        - replica_status.Last_IO_Errno == 0
+        - replica_status.Last_IO_Error == ''
+        - replica_status.Channel_Name == '{{ test_channel }}'
+        - replica_status is not changed
       when: mysql8022_and_higher == false
 
     - assert:
         that:
-        - slave_status.Is_Slave == true
-        - slave_status.Source_Host == '{{ mysql_host }}'
-        - slave_status.Exec_Source_Log_Pos == mysql_primary_status.Position
-        - slave_status.Source_Port == {{ mysql_primary_port }}
-        - slave_status.Last_IO_Errno == 0
-        - slave_status.Last_IO_Error == ''
-        - slave_status.Channel_Name == '{{ test_channel }}'
-        - slave_status is not changed
+        - replica_status.Is_Slave == true
+        - replica_status.Source_Host == '{{ mysql_host }}'
+        - replica_status.Exec_Source_Log_Pos == mysql_primary_status.Position
+        - replica_status.Source_Port == {{ mysql_primary_port }}
+        - replica_status.Last_IO_Errno == 0
+        - replica_status.Last_IO_Error == ''
+        - replica_status.Channel_Name == '{{ test_channel }}'
+        - replica_status is not changed
       when: mysql8022_and_higher == true
 
 
-    # Test stopslave mode:
-    - name: Stop slave with channel
+    # Test stopreplica mode:
+    - name: Stop replica with channel
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica2_port }}'
-        mode: stopslave
+        mode: stopreplica
         channel: '{{ test_channel }}'
       register: result
 
@@ -99,11 +99,11 @@
         - result.queries == ["STOP SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["STOP REPLICA FOR CHANNEL '{{ test_channel }}'"]
 
     # Test reset
-    - name: Reset slave with channel
+    - name: Reset replica with channel
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica2_port }}'
-        mode: resetslave
+        mode: resetreplica
         channel: '{{ test_channel }}'
       register: result
 
@@ -113,11 +113,11 @@
         - result.queries == ["RESET SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["RESET REPLICA FOR CHANNEL '{{ test_channel }}'"]
 
     # Test reset all
-    - name: Reset slave all with channel
+    - name: Reset replica all with channel
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica2_port }}'
-        mode: resetslaveall
+        mode: resetreplicaall
         channel: '{{ test_channel }}'
       register: result
 

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -138,12 +138,12 @@
         - result is changed
         - result.queries == ["START SLAVE"] or result.queries == ["START REPLICA"]
 
-    # Test getslave mode:
+    # Test getreplica mode:
     - name: Get standby status
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: getslave
+        mode: getreplica
       register: slave_status
 
     - assert:
@@ -184,7 +184,7 @@
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: getslave
+        mode: getreplica
       register: slave_status
 
     # mysql_primary_status.Position is not actual and it has been changed by the prev step,

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -63,8 +63,8 @@
         - mysql_primary_status.Position != 0
         - mysql_primary_status is not changed
 
-    # Test startslave fails without changemaster first. This needs fail_on_error
-    - name: Start slave and fail because master is not specified; failing on error as requested
+    # Test startreplica fails without changemaster first. This needs fail_on_error
+    - name: Start replica (using deprecated startslave choice) and fail because master is not specified; failing on error as requested
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
@@ -77,12 +77,12 @@
         that:
         - result is failed
 
-    # Test startslave doesn't fail if fail_on_error: no
-    - name: Start slave and fail without propagating it to ansible as we were asked not to
+    # Test startreplica doesn't fail if fail_on_error: no
+    - name: Start replica and fail without propagating it to ansible as we were asked not to
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: startslave
+        mode: startreplica
         fail_on_error: no
       register: result
 
@@ -90,13 +90,13 @@
         that:
         - result is not failed
 
-    # Test startslave doesn't fail if there is no fail_on_error.
+    # Test startreplica doesn't fail if there is no fail_on_error.
     # This is suboptimal because nothing happens, but it's the old behavior.
-    - name: Start slave and fail without propagating it to ansible as previous versions did not fail on error
+    - name: Start replica and fail without propagating it to ansible as previous versions did not fail on error
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: startslave
+        mode: startreplica
       register: result
 
     - assert:
@@ -125,12 +125,12 @@
         - result is changed
         - result.queries == ["CHANGE MASTER TO MASTER_HOST='{{ mysql_host }}',MASTER_USER='{{ replication_user }}',MASTER_PASSWORD='********',MASTER_PORT={{ mysql_primary_port }},MASTER_LOG_FILE='{{ mysql_primary_status.File }}',MASTER_LOG_POS={{ mysql_primary_status.Position }},MASTER_SSL_CA=''"]
 
-    # Test startslave mode:
-    - name: Start slave
+    # Test startreplica mode:
+    - name: Start replica
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: startslave
+        mode: startreplica
       register: result
 
     - assert:
@@ -139,33 +139,33 @@
         - result.queries == ["START SLAVE"] or result.queries == ["START REPLICA"]
 
     # Test getreplica mode:
-    - name: Get standby status
+    - name: Get replica status using deprecated getslave choice
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: getreplica
-      register: slave_status
+        mode: getslave
+      register: replica_status
 
     - assert:
         that:
-        - slave_status.Is_Slave == true
-        - slave_status.Master_Host == '{{ mysql_host }}'
-        - slave_status.Exec_Master_Log_Pos == mysql_primary_status.Position
-        - slave_status.Master_Port == {{ mysql_primary_port }}
-        - slave_status.Last_IO_Errno == 0
-        - slave_status.Last_IO_Error == ''
-        - slave_status is not changed
+        - replica_status.Is_Slave == true
+        - replica_status.Master_Host == '{{ mysql_host }}'
+        - replica_status.Exec_Master_Log_Pos == mysql_primary_status.Position
+        - replica_status.Master_Port == {{ mysql_primary_port }}
+        - replica_status.Last_IO_Errno == 0
+        - replica_status.Last_IO_Error == ''
+        - replica_status is not changed
       when: mysql8022_and_higher == false
 
     - assert:
         that:
-        - slave_status.Is_Slave == true
-        - slave_status.Source_Host == '{{ mysql_host }}'
-        - slave_status.Exec_Source_Log_Pos == mysql_primary_status.Position
-        - slave_status.Source_Port == {{ mysql_primary_port }}
-        - slave_status.Last_IO_Errno == 0
-        - slave_status.Last_IO_Error == ''
-        - slave_status is not changed
+        - replica_status.Is_Slave == true
+        - replica_status.Source_Host == '{{ mysql_host }}'
+        - replica_status.Exec_Source_Log_Pos == mysql_primary_status.Position
+        - replica_status.Source_Port == {{ mysql_primary_port }}
+        - replica_status.Last_IO_Errno == 0
+        - replica_status.Last_IO_Error == ''
+        - replica_status is not changed
       when: mysql8022_and_higher == true
 
     # Create test table and add data to it:
@@ -175,38 +175,38 @@
     - name: Insert data
       shell: "echo \"INSERT INTO {{ test_table }} (id) VALUES (1), (2), (3); FLUSH LOGS;\" | {{ mysql_command }} -P{{ mysql_primary_port }} {{ test_db }}"
 
-    - name: Small pause to be sure the bin log, which was flushed previously, reached the slave
+    - name: Small pause to be sure the bin log, which was flushed previously, reached the replica
       pause:
         seconds: 2
 
     # Test master log pos has been changed:
-    - name: Get standby status
+    - name: Get replica status
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
         mode: getreplica
-      register: slave_status
+      register: replica_status
 
     # mysql_primary_status.Position is not actual and it has been changed by the prev step,
-    # so slave_status.Exec_Master_Log_Pos must be different:
+    # so replica_status.Exec_Master_Log_Pos must be different:
     - assert:
         that:
-        - slave_status.Exec_Master_Log_Pos != mysql_primary_status.Position
+        - replica_status.Exec_Master_Log_Pos != mysql_primary_status.Position
       when: mysql8022_and_higher == false
 
     - assert:
         that:
-        - slave_status.Exec_Source_Log_Pos != mysql_primary_status.Position
+        - replica_status.Exec_Source_Log_Pos != mysql_primary_status.Position
       when: mysql8022_and_higher == true
 
     - shell: pip show pymysql | awk '/Version/ {print $2}'
       register: pymysql_version
 
-    - name: Start slave that is already running
+    - name: Start replica that is already running
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: startslave
+        mode: startreplica
         fail_on_error: true
       register: result
 
@@ -215,8 +215,8 @@
         - result is not changed
       when: (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '<=')
 
-    # Test stopslave mode:
-    - name: Stop slave
+    # Test stopreplica mode:
+    - name: Stop replica using deprecated stopslave choice
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
@@ -228,12 +228,12 @@
         - result is changed
         - result.queries == ["STOP SLAVE"] or result.queries == ["STOP REPLICA"]
 
-    # Test stopslave mode:
-    - name: Stop slave that is no longer running
+    # Test stopreplica mode:
+    - name: Stop replica that is no longer running
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: stopslave
+        mode: stopreplica
         fail_on_error: true
       register: result
 

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_master_delay.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_master_delay.yml
@@ -36,7 +36,7 @@
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: getslave
+        mode: getreplica
       register: slave_status
 
     - assert:

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_master_delay.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_master_delay.yml
@@ -24,11 +24,11 @@
         - result.queries == ["CHANGE MASTER TO MASTER_DELAY=60"]
 
     # Auxiliary step:
-    - name: Start slave
+    - name: Start replica
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: startslave
+        mode: startreplica
       register: result
 
     # Check master_delay:
@@ -37,9 +37,9 @@
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
         mode: getreplica
-      register: slave_status
+      register: replica_status
 
     - assert:
         that:
-        - slave_status.SQL_Delay == {{ test_master_delay }}
-        - slave_status is not changed
+        - replica_status.SQL_Delay == {{ test_master_delay }}
+        - replica_status is not changed

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_resetmaster_mode.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_resetmaster_mode.yml
@@ -10,17 +10,17 @@
   block:
 
     # Needs for further tests:
-    - name: Stop slave
+    - name: Stop replica
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: stopslave
+        mode: stopreplica
 
-    - name: Reset slave all
+    - name: Reset replica all
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: resetslaveall
+        mode: resetreplicaall
 
     # Get master initial status:
     - name: Get master status


### PR DESCRIPTION
##### SUMMARY
mysql_replication: deprecation of slave related options, adding alternatives
also announce that the word SLAVE will be replaced with REPLICA in the next major release

Relates to https://github.com/ansible-collections/community.mysql/issues/78 and https://github.com/ansible-collections/community.mysql/issues/98

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
mysql_replication
