### PR TITLE
mysql_user: add proper handling of INSERT, UPDATE, REFERENCES on columns

### DIFF
--- a/changelogs/fragments/107-mysql_user_fix_grant_on_col_handling.yml
+++ b/changelogs/fragments/107-mysql_user_fix_grant_on_col_handling.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_user - fix handling of INSERT, UPDATE, REFERENCES on columns (https://github.com/ansible-collections/community.mysql/issues/106).

--- a/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
@@ -93,6 +93,39 @@
         that:
         - result is not changed
 
+    - name: Grant privs on columns
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_3 }}'
+        priv:
+          'data3.test_table_issue99': 'SELECT (a, b), INSERT (a, b), UPDATE'
+      register: result
+
+    - assert:
+        that:
+        - result is changed
+
+    - name: Grant same privs on columns again, note that the column order is different
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_3 }}'
+        priv:
+          'data3.test_table_issue99': 'SELECT (a, b), UPDATE, INSERT (b, a)'
+      register: result
+
+    - assert:
+        that:
+        - result is not changed
+
+    - name: Run command to show privileges for user (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ user_name_3 }}'@'localhost'\""
+      register: result
+
+    - name: Assert user has giving privileges
+      assert:
+        that:
+          - "'GRANT SELECT (`A`, `B`), INSERT (`A`, `B`), UPDATE' in result.stdout"
+
     ##########
     # Clean up
     - name: Drop test databases

--- a/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
@@ -124,7 +124,7 @@
     - name: Assert user has giving privileges
       assert:
         that:
-          - "'GRANT SELECT (`A`, `B`), INSERT (`A`, `B`), UPDATE' in result.stdout"
+          - "'GRANT SELECT (`A`, `B`), INSERT (`A`, `B`), UPDATE' in result.stdout" or "'GRANT SELECT (A, B), INSERT (A, B), UPDATE' in result.stdout"
 
     ##########
     # Clean up

--- a/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
@@ -124,7 +124,14 @@
     - name: Assert user has giving privileges
       assert:
         that:
-          - "'GRANT SELECT (`A`, `B`), INSERT (`A`, `B`), UPDATE' in result.stdout OR 'GRANT SELECT (A, B), INSERT (A, B), UPDATE' in result.stdout"
+          - "'GRANT SELECT (`A`, `B`), INSERT (`A`, `B`), UPDATE' in result.stdout"
+      when: "'(`A`, `B`)' in result.stdout"
+
+    - name: Assert user has giving privileges
+      assert:
+        that:
+          - "'GRANT SELECT (A, B), INSERT (A, B), UPDATE' in result.stdout"
+      when: "'(A, B)' in result.stdout"
 
     ##########
     # Clean up

--- a/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
@@ -131,7 +131,7 @@
       assert:
         that:
           - "'GRANT SELECT (A, B), INSERT (A, B), UPDATE' in result.stdout"
-      when: "'(A, B)' in result.stdout"
+      when: "'(`A`, `B`)' not in result.stdout"
 
     ##########
     # Clean up

--- a/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
@@ -124,7 +124,7 @@
     - name: Assert user has giving privileges
       assert:
         that:
-          - "'GRANT SELECT (`A`, `B`), INSERT (`A`, `B`), UPDATE' in result.stdout" or "'GRANT SELECT (A, B), INSERT (A, B), UPDATE' in result.stdout"
+          - "'GRANT SELECT (`A`, `B`), INSERT (`A`, `B`), UPDATE' in result.stdout OR 'GRANT SELECT (A, B), INSERT (A, B), UPDATE' in result.stdout"
 
     ##########
     # Clean up

--- a/tests/unit/plugins/modules/test_mysql_user.py
+++ b/tests/unit/plugins/modules/test_mysql_user.py
@@ -55,9 +55,9 @@ def test_supports_identified_by_password(function_return, cursor_output, cursor_
         (['SELECT (A', 'B)', 'UPDATE'], 'SELECT', (0, 1)),
         (['INSERT', 'SELECT (A', 'B)', 'UPDATE'], 'SELECT', (1, 2)),
         (['INSERT (A, B)', 'SELECT (A', 'B)', 'UPDATE'], 'INSERT', (0, 0)),
-        (['INSERT (A',  'B)', 'SELECT (A', 'B)', 'UPDATE'], 'INSERT', (0, 1)),
-        (['INSERT (A',  'B)', 'SELECT (A', 'B)', 'UPDATE'], 'SELECT', (2, 3)),
-        (['INSERT (A',  'B)', 'SELECT (A', 'C', 'B)', 'UPDATE'], 'SELECT', (2, 4)),
+        (['INSERT (A', 'B)', 'SELECT (A', 'B)', 'UPDATE'], 'INSERT', (0, 1)),
+        (['INSERT (A', 'B)', 'SELECT (A', 'B)', 'UPDATE'], 'SELECT', (2, 3)),
+        (['INSERT (A', 'B)', 'SELECT (A', 'C', 'B)', 'UPDATE'], 'SELECT', (2, 4)),
     ]
 )
 def test_has_grant_on_col(input_list, grant, output_tuple):


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.mysql/issues/106

SELECT (a, b) handling was added in https://github.com/ansible-collections/community.mysql/pull/100

This PR also adds handling of GRANT INSERT, UPDATE, REFERENCES on columns

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/modules/mysql_user.py`