### PR TITLE
[DRAFT] mysql new lookup plugin

### DIFF
--- a/plugins/lookup/mysql.py
+++ b/plugins/lookup/mysql.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+name: mysql
+
+short_description: Fetch data from MySQL table
+
+description:
+  - Fetch data from MySQL table.
+  - For complex queries use M(community.mysql.mysql_query) module.
+
+version_added: '1.3.0'
+
+options:
+  _terms:
+    description:
+      - Tables to fetch data from.
+      - "You can use colons to pass optional column list, for example, 'mytable:col1,col2'."
+    type: str
+    required: yes
+
+  limit:
+    description:
+      - Limits number of selected rows.
+    type: int
+
+  db:
+    description:
+      - Name of database to connect to and fetch data from.
+    type: str
+
+seealso:
+  - module: community.mysql.mysql_query
+
+author:
+  - Andrew Klychkov (@Andersson007)
+
+extends_documentation_fragment:
+  - community.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name:  Fetch data from test_table of acme database
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.mysql.mysql', 'test_table', db='acme') }}"
+
+# The output of the command above can look like:
+# [{'col1': 1, 'col2': 'first_value'}, {'col1': 2, 'col2': 'second_value'}]
+
+- name:  Fetch data from test_table of acme database, fetch only 1 row
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.mysql.mysql', 'test_table', limit=1, db='acme') }}"
+
+# The output of the command above can look like:
+# [{'col1': 1, 'col2': 'first_value'}]
+
+- name:  Fetch data from col1 column only of test_table in acme database
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.mysql.mysql', 'test_table:col1', db='acme') }}"
+
+# The output of the command above can look like:
+# [{'col1': 1}, {'col1': 2}]
+'''
+
+RETURN = r'''
+_raw:
+  description: "List of dictionaries 'column name': 'value' representing returned rows."
+  returned: always
+  type: list
+  sample: [{"column1": "value1", "column2", "value1"},{"column1": "value2", "column2": "value2"}]
+'''
+
+from ansible_collections.community.mysql.plugins.module_utils.mysql import (
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
+from ansible.plugins.lookup import LookupBase
+
+
+def split_table_and_columns(table):
+    tmp = table.split(':')
+    table_name = tmp[0]
+    columns = tmp[1].strip()
+    return table_name, columns
+
+
+class DummyModule():
+    def __init__(self):
+        self.params = {}
+
+    def fail_json(self, msg):
+        raise AnsibleError(msg)
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+
+        if mysql_driver is None:
+            raise AnsibleError(mysql_driver_fail_msg)
+
+        # Get and set arguments
+        self.set_options(direct=kwargs)
+
+        # Initialize a dummy module object
+        module = DummyModule()
+
+        # General connection options
+        db = self.get_option('db')
+        login_user = self.get_option('login_user')
+        login_password = self.get_option('login_password')
+        config_file = self.get_option('config_file')
+        connect_timeout = self.get_option('connect_timeout')
+        check_hostname = self.get_option('check_hostname')
+        ca_cert = self.get_option('ca_cert')
+        client_cert = self.get_option('client_cert')
+        client_key = self.get_option('client_key')
+
+        # Specific options
+        limit = self.get_option('limit')
+
+        # We pass the following parameters to the
+        # mysql_connect function through our dummy module object
+        # because of mysql_connect function implementation
+        module.params['login_host'] = self.get_option('login_host')
+        module.params['login_port'] = self.get_option('login_port')
+        module.params['login_unix_socket'] = self.get_option('login_unix_socket')
+
+        # Connect to DB
+        try:
+            cursor, db_connection = mysql_connect(module,
+                                                  db=db,
+                                                  login_user=login_user,
+                                                  login_password=login_password,
+                                                  config_file=config_file,
+                                                  cursor_class='DictCursor',
+                                                  connect_timeout=connect_timeout,
+                                                  autocommit=False,
+                                                  ssl_ca=ca_cert,
+                                                  ssl_cert=client_cert,
+                                                  ssl_key=client_key,
+                                                  check_hostname=check_hostname)
+
+        except Exception as e:
+            raise AnsibleError("Unable to connect to database, "
+                               "check login_user and "
+                               "login_password are correct. "
+                               "Exception message: %s" % to_native(e))
+
+        # Execute query(s)
+        result = []
+        for table in terms:
+
+            columns = None
+            if ':' in table:
+                table, columns = split_table_and_columns(table)
+
+            if columns:
+                query = "SELECT %s FROM %s" % (columns, table)
+            else:
+                query = "SELECT * FROM %s" % table
+
+            if limit:
+                query += " LIMIT %s" % limit
+
+            try:
+                cursor.execute(query)
+
+                # Fetch data from cursor
+                try:
+                    # TODO: maybe cursor.fetchmany(size)?
+                    res = [dict(row) for row in cursor.fetchall()]
+                    result += res
+
+                except Exception as e:
+                    raise AnsibleError("Cannot fetch rows "
+                                       "from cursor: %s" % to_native(e))
+
+            except Exception as e:
+                raise AnsibleError(
+                    "Cannot execute SQL '%s': "
+                    "%s" % (query, to_native(e))
+                )
+
+        return result

--- a/tests/integration/targets/test_mysql_lookup/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_lookup/defaults/main.yml
@@ -1,0 +1,11 @@
+mysql_user: root
+mysql_password: msandbox
+mysql_primary_port: 3307
+
+test_db: mysql_lookup_db
+table1: test1
+table2: test2
+table3: test3
+
+user_name_1: 'db_user1'
+user_password_1: 'gadfFDSdtTU^Sdfuj'

--- a/tests/integration/targets/test_mysql_lookup/meta/main.yml
+++ b/tests/integration/targets/test_mysql_lookup/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_mysql

--- a/tests/integration/targets/test_mysql_lookup/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_lookup/tasks/main.yml
@@ -1,0 +1,7 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# mysql lookup module initial CI tests
+- import_tasks: mysql_lookup_initial.yml

--- a/tests/integration/targets/test_mysql_lookup/tasks/mysql_lookup_initial.yml
+++ b/tests/integration/targets/test_mysql_lookup/tasks/mysql_lookup_initial.yml
@@ -1,0 +1,64 @@
+# Test code for mysql lookup plugin
+# Copyright: (c) 2021, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+  ######################
+  # Prepare DB for tests
+  ######################
+
+  - name: Create db {{ test_db }}
+    mysql_query:
+      <<: *mysql_params
+      query: 'CREATE DATABASE {{ test_db }}'
+
+  - name: Create {{ table1 }}
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 
+      - 'CREATE TABLE {{ table1 }} (id int)'
+      - 'CREATE TABLE {{ table2 }} (id int, story text)'
+      - 'CREATE TABLE {{ table3 }} (id int)'
+
+  - name: Insert test data
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query:
+      - 'INSERT INTO {{ table1 }} VALUES (1), (2)'
+      - "INSERT INTO {{ table2 }} (id, story) VALUES (3, 'first'), (4, 'second')"
+      - 'INSERT INTO {{ table3 }} VALUES (3)'
+
+  ###################################
+  # Run tests for mysql lookup plugin
+  ###################################
+
+  - name: Fetch data
+    set_fact:
+      fact1: "{{ lookup('community.mysql.mysql', 'test1', db='mysql_lookup_db', login_user='root', login_password='msandbox', login_host='127.0.0.1', login_port=3307) }}"
+      fact2: "{{ lookup('community.mysql.mysql', 'test3', db='mysql_lookup_db', login_user='root', login_password='msandbox', login_host='127.0.0.1', login_port=3307) }}"
+      fact3: "{{ lookup('community.mysql.mysql', 'test2', db='mysql_lookup_db', login_user='root', login_password='msandbox', login_host='127.0.01', login_port=3307) }}"
+      fact4: "{{ lookup('community.mysql.mysql', 'test2:id', db='mysql_lookup_db', login_user='root', login_password='msandbox', login_host='127.0.01', login_port=3307) }}"
+      fact5: "{{ lookup('community.mysql.mysql', 'test2:story', limit=1, db='mysql_lookup_db', login_user='root', login_password='msandbox', login_host='127.0.01', login_port=3307) }}"
+      fact6: "{{ lookup('community.mysql.mysql', 'test1', 'test2', db='mysql_lookup_db', login_user='root', login_password='msandbox', login_host='127.0.0.1', login_port=3307) }}"
+      fact7: "{{ lookup('community.mysql.mysql', 'test1', 'test2:id,story as s', db='mysql_lookup_db', login_user='root', login_password='msandbox', login_host='127.0.0.1', login_port=3307) }}"
+      fact8: "{{ lookup('community.mysql.mysql', 'test1', 'test2:story as s', db='mysql_lookup_db', login_user='root', login_password='msandbox', login_host='127.0.0.1', login_port=3307) }}"
+
+  - assert:
+      that:
+        - "fact1 == [{'id': 1}, {'id': 2}]"
+        - "fact2 == {'id': 3}"
+        - "fact3 == [{'id': 3, 'story': 'first'}, {'id': 4, 'story': 'second'}]"
+        - "fact4 == [{'id': 3}, {'id': 4}]"
+        - "fact5 == {'story': 'first'}"
+        - "fact6 == [{'id': 1}, {'id': 2}, {'id': 3, 'story': 'first'}, {'id': 4, 'story': 'second'}]"
+        - "fact7 == [{'id': 1}, {'id': 2}, {'id': 3, 's': 'first'}, {'id': 4, 's': 'second'}]"
+        - "fact8 == [{'id': 1}, {'id': 2}, {'s': 'first'}, {'s': 'second'}]"


### PR DESCRIPTION
##### SUMMARY
mysql new lookup plugin to fetch data from mysql tables

It returns a list of dictionaries `{col_name: value}`, for example:
```
[
            {
                "id": 3,
                "story": "first"
            },
            {
                "id": 4,
                "story": "second"
            }
]
```

Several important questions to discuss:

1. I've never written plugins before, decided to try BUT do we need such a plugin? Would it be really useful for users? Yes, we have the `mysql_query` module but it's a module, not a plugin. In the plugin form, it can be potentially convenient to use. Don't hesitate to criticize this. If it's not worth enough, it's better not to add this.

2. If it's worth.  Are the interfaces (e.g., the options, return values, etc.) good? Maybe we should return a list of tuples instead of dictionaries (I personally prefer dictionaries)? Maybe we should add more options (however we shouldn't overwhelm it, otherwise the plugin's invocation can be difficult to read)?

3. Maybe we should fetch and return data drastically different way?

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
plugins/lookup/mysql.py