### PR TITLE
add mysql_full_version and suffix return variable

### DIFF
--- a/changelogs/fragments/115-add_mysql_full_version_suffix_return_var.yml
+++ b/changelogs/fragments/115-add_mysql_full_version_suffix_return_var.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_info - add mysql_full_version and suffix return variable (https://github.com/ansible-collections/community.mysql/issues/114)

--- a/changelogs/fragments/115-add_mysql_full_version_suffix_return_var.yml
+++ b/changelogs/fragments/115-add_mysql_full_version_suffix_return_var.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- mysql_info - add mysql_full_version and suffix return variable (https://github.com/ansible-collections/community.mysql/issues/114)
+- mysql_info - add `full_version` and `suffix` return values (https://github.com/ansible-collections/community.mysql/issues/114).

--- a/changelogs/fragments/115-add_mysql_full_version_suffix_return_var.yml
+++ b/changelogs/fragments/115-add_mysql_full_version_suffix_return_var.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- mysql_info - add `full_version` and `suffix` return values (https://github.com/ansible-collections/community.mysql/issues/114).
+- mysql_info - add `version.full` and `version.suffix` return values (https://github.com/ansible-collections/community.mysql/issues/114).

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -122,7 +122,7 @@ version:
   description: Database server version.
   returned: if not excluded by filter
   type: dict
-  sample: { "version": { "major": 5, "minor": 5, "release": 60, "suffix": "MariaDB", "full_version": "5.5.60-MariaDB" } }
+  sample: { "version": { "major": 5, "minor": 5, "release": 60, "suffix": "MariaDB", "full": "5.5.60-MariaDB" } }
   contains:
     major:
       description: Major server version.

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -57,6 +57,7 @@ seealso:
 
 author:
 - Andrew Klychkov (@Andersson007)
+- Sebastian Gumprich (@rndmh3ro)
 
 extends_documentation_fragment:
 - community.mysql.mysql
@@ -121,7 +122,7 @@ version:
   description: Database server version.
   returned: if not excluded by filter
   type: dict
-  sample: { "version": { "major": 5, "minor": 5, "release": 60 } }
+  sample: { "version": { "major": 5, "minor": 5, "release": 60, "suffix": "MariaDB", "full_version": "5.5.60-MariaDB" } }
   contains:
     major:
       description: Major server version.
@@ -138,6 +139,16 @@ version:
       returned: if not excluded by filter
       type: int
       sample: 60
+    suffix:
+      description: Server suffix, for example MySQL, MariaDB, other or none.
+      returned: if not excluded by filter
+      type: str
+      sample: "MariaDB"
+    full_version:
+      description: Full server version.
+      returned: if not excluded by filter
+      type: str
+      sample: "5.5.60-MariaDB"
 databases:
   description: Information about databases.
   returned: if not excluded by filter
@@ -353,13 +364,30 @@ class MySQL_Info(object):
             for var in res:
                 self.info['settings'][var['Variable_name']] = self.__convert(var['Value'])
 
-            ver = self.info['settings']['version'].split('.')
-            release = ver[2].split('-')[0]
+            # version = ["5", "5," "60-MariaDB]
+            version = self.info['settings']['version'].split('.')
+
+            # full_version = "5.5.60-MariaDB"
+            full_version = self.info['settings']['version']
+
+            # release = "60"
+            release = version[2].split('-')[0]
+
+            # check if a suffix exists by counting the length
+            if len(version[2].split('-')) > 1:
+                # suffix = "MariaDB"
+                suffix = version[2].split('-', 1)[1]
+            else:
+                suffix = ""
 
             self.info['version'] = dict(
-                major=int(ver[0]),
-                minor=int(ver[1]),
+                # major = "5"
+                major=int(version[0]),
+                # minor = "5"
+                minor=int(version[1]),
                 release=int(release),
+                suffix=str(suffix),
+                full_version=str(full_version),
             )
 
     def __get_global_status(self):

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -144,7 +144,7 @@ version:
       returned: if not excluded by filter
       type: str
       sample: "MariaDB"
-    full_version:
+    full:
       description: Full server version.
       returned: if not excluded by filter
       type: str
@@ -368,7 +368,7 @@ class MySQL_Info(object):
             version = self.info['settings']['version'].split('.')
 
             # full_version = "5.5.60-MariaDB"
-            full_version = self.info['settings']['version']
+            full = self.info['settings']['version']
 
             # release = "60"
             release = version[2].split('-')[0]
@@ -387,7 +387,7 @@ class MySQL_Info(object):
                 minor=int(version[1]),
                 release=int(release),
                 suffix=str(suffix),
-                full_version=str(full_version),
+                full=str(full),
             )
 
     def __get_global_status(self):

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -48,7 +48,7 @@
     - assert:
         that:
         - result.changed == false
-        - result.version != {}
+        - "mysql_version in result.version.full_version"
         - result.settings != {}
         - result.global_status != {}
         - result.databases != {}

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -48,7 +48,7 @@
     - assert:
         that:
         - result.changed == false
-        - "mysql_version in result.version.full_version"
+        - "mysql_version in result.version.full"
         - result.settings != {}
         - result.global_status != {}
         - result.databases != {}

--- a/tests/unit/plugins/modules/test_mysql_info.py
+++ b/tests/unit/plugins/modules/test_mysql_info.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+from ansible_collections.community.mysql.plugins.modules.mysql_info import MySQL_Info
+
+
+@pytest.mark.parametrize(
+    'suffix,cursor_output',
+    [
+        ('mysql', '5.5.1-mysql'),
+        ('log', '5.7.31-log'),
+        ('mariadb', '10.5.0-mariadb'),
+        ('', '8.0.22'),
+    ]
+)
+def test_get_info_suffix(suffix, cursor_output):
+    def __cursor_return_value(input_parameter):
+        if input_parameter == "SHOW GLOBAL VARIABLES":
+            cursor.fetchall.return_value = [{"Variable_name": "version", "Value": cursor_output}]
+        else:
+            cursor.fetchall.return_value = MagicMock()
+
+    cursor = MagicMock()
+    cursor.execute.side_effect = __cursor_return_value
+
+    info = MySQL_Info(MagicMock(), cursor)
+
+    assert info.get_info([], [], False)['version']['suffix'] == suffix


### PR DESCRIPTION
##### SUMMARY
This PR adds two new variables: the `suffix` variable that is sometimes added to the version-string and the `full_version`-variable that contains the whole version string (to make it easier to compare versions).

Fixes #114 

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
mysql_info

