### PR TITLE
change deprecated parameter pw and db

### DIFF
--- a/changelogs/fragments/116-change_deprecated_connection_ parameters.yml
+++ b/changelogs/fragments/116-change_deprecated_connection_ parameters.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql module utils - change deprecated connection parameters ``passwd`` and ``db`` to ``password`` and ``database`` (https://github.com/ansible-collections/community.mysql/pull/116).

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -79,7 +79,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if login_user is not None:
         config['user'] = login_user
     if login_password is not None:
-        config['passwd'] = login_password
+        config['password'] = login_password
     if ssl_cert is not None:
         config['ssl']['cert'] = ssl_cert
     if ssl_key is not None:

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -87,7 +87,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if ssl_ca is not None:
         config['ssl']['ca'] = ssl_ca
     if db is not None:
-        config['db'] = db
+        config['database'] = db
     if connect_timeout is not None:
         config['connect_timeout'] = connect_timeout
     if check_hostname is not None:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Parameter `db` and `passed` are deprecated in PyMySQL since v1.0.0 and are kept as an alias for `database` and `password`. Warnings will be activated around 2022 (for details see https://github.com/PyMySQL/PyMySQL/issues/939).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

module_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
