### PR TITLE
mysql_replication: add a reference to how to encrypted connection options

### DIFF
--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -87,35 +87,41 @@ options:
     description:
     - Same as the C(MASTER_SSL) mysql variable.
     - When setting it to C(yes), the connection attempt only succeeds
-      if an encrypted connection can be established. 
-    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
+      if an encrypted connection can be established.
+    - For details, refer to
+      L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html).
     type: bool
     default: false
   master_ssl_ca:
     description:
     - Same as the C(MASTER_SSL_CA) mysql variable.
-    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
+    - For details, refer to
+      L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html).
     type: str
   master_ssl_capath:
     description:
     - Same as the C(MASTER_SSL_CAPATH) mysql variable.
-    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
+    - For details, refer to
+      L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html).
     type: str
   master_ssl_cert:
     description:
     - Same as the C(MASTER_SSL_CERT) mysql variable.
-    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
+    - For details, refer to
+      L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html).
     type: str
   master_ssl_key:
     description:
     - Same as the C(MASTER_SSL_KEY) mysql variable.
-    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
+    - For details, refer to
+      L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html).
     type: str
   master_ssl_cipher:
     description:
     - Same as the C(MASTER_SSL_CIPHER) mysql variable.
     - Specifies a colon-separated list of one or more ciphers permitted by the replica for the replication connection.
-    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
+    - For details, refer to
+      L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html).
     type: str
   master_auto_position:
     description:

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -85,28 +85,37 @@ options:
     type: int
   master_ssl:
     description:
-    - Same as mysql variable.
+    - Same as the C(MASTER_SSL) mysql variable.
+    - When setting it to C(yes), the connection attempt only succeeds
+      if an encrypted connection can be established. 
+    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
     type: bool
     default: false
   master_ssl_ca:
     description:
-    - Same as mysql variable.
+    - Same as the C(MASTER_SSL_CA) mysql variable.
+    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
     type: str
   master_ssl_capath:
     description:
-    - Same as mysql variable.
+    - Same as the C(MASTER_SSL_CAPATH) mysql variable.
+    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
     type: str
   master_ssl_cert:
     description:
-    - Same as mysql variable.
+    - Same as the C(MASTER_SSL_CERT) mysql variable.
+    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
     type: str
   master_ssl_key:
     description:
-    - Same as mysql variable.
+    - Same as the C(MASTER_SSL_KEY) mysql variable.
+    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
     type: str
   master_ssl_cipher:
     description:
-    - Same as mysql variable.
+    - Same as the C(MASTER_SSL_CIPHER) mysql variable.
+    - Specifies a colon-separated list of one or more ciphers permitted by the replica for the replication connection.
+    - Refer to L(MySQL encrypted replication documentation,https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html) for details.
     type: str
   master_auto_position:
     description:
@@ -167,6 +176,9 @@ seealso:
 - name: MySQL replication reference
   description: Complete reference of the MySQL replication documentation.
   link: https://dev.mysql.com/doc/refman/8.0/en/replication.html
+- name: MySQL encrypted replication reference.
+  description: Setting up MySQL replication to use encrypted connection.
+  link: https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-encrypted-connections.html
 - name: MariaDB replication reference
   description: Complete reference of the MariaDB replication documentation.
   link: https://mariadb.com/kb/en/library/setting-up-replication/


### PR DESCRIPTION
##### SUMMARY
As spotted in https://github.com/ansible-collections/community.mysql/pull/117 by @felixfontein ,
the mysql_replication module documentation can be improved

##### ISSUE TYPEt
- Docs Pull Request

##### COMPONENT NAME
`mysql_replication`