### PR TITLE
Deprecate REQUIRESSL privilege

### DIFF
--- a/changelogs/fragments/101-drop-requiressl-support.yml
+++ b/changelogs/fragments/101-drop-requiressl-support.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - mysql_user - deprecate the ``REQUIRESSL`` privilege (https://github.com/ansible-collections/community.mysql/issues/101).
+major_changes:
+  - mysql_user - the ``REQUIRESSL`` is an alias for the ``ssl`` key in the ``tls_requires`` option in ``community.mysql`` 2.0.0 and support will be dropped altogether in ``community.mysql`` 3.0.0 (https://github.com/ansible-collections/community.mysql/issues/121).

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -968,18 +968,18 @@ def convert_priv_dict_to_str(priv):
 
 
 def handle_requiressl_in_priv_string(module, priv, tls_requires):
-    if "REQUIRESSL" in priv:
-        module.deprecate('The "REQUIRESSL" privilege is deprecated, use the "tls_requires" option instead.', version='3.0.0', collection_name='community.mysql')
-        priv_groups = re.search(r"(.*?)(\*\.\*:)([^/]*)(.*)", priv)
-        if priv_groups.group(3) == "REQUIRESSL":
-            priv = priv_groups.group(1) + priv_groups.group(4) or None
-        else:
-            inner_priv_groups = re.search(r"(.*?),?REQUIRESSL,?(.*)", priv_groups.group(3))
-            priv = priv_groups.group(1) + priv_groups.group(2) + ','.join((inner_priv_groups.group(1), inner_priv_groups.group(3))) + priv_groups.group(4)
-        if not tls_requires:
-            tls_requires = {"SSL": None}
-        else:
-            module.warn('Ignoring "REQUIRESSL" privilege as "tls_requires" is defined and it takes precedence.')
+    module.deprecate('The "REQUIRESSL" privilege is deprecated, use the "tls_requires" option instead.',
+                     version='3.0.0', collection_name='community.mysql')
+    priv_groups = re.search(r"(.*?)(\*\.\*:)([^/]*)(.*)", priv)
+    if priv_groups.group(3) == "REQUIRESSL":
+        priv = priv_groups.group(1) + priv_groups.group(4) or None
+    else:
+        inner_priv_groups = re.search(r"(.*?),?REQUIRESSL,?(.*)", priv_groups.group(3))
+        priv = priv_groups.group(1) + priv_groups.group(2) + ','.join((inner_priv_groups.group(1), inner_priv_groups.group(3))) + priv_groups.group(4)
+    if not tls_requires:
+        tls_requires = {"SSL": None}
+    else:
+        module.warn('Ignoring "REQUIRESSL" privilege as "tls_requires" is defined and it takes precedence.')
     return priv, tls_requires
 
 
@@ -1174,6 +1174,9 @@ def main():
 
     if priv and isinstance(priv, dict):
         priv = convert_priv_dict_to_str(priv)
+
+    if "REQUIRESSL" in priv:
+        priv, tls_requires = handle_requiressl_in_priv_string(module, priv, tls_requires)
 
     if mysql_driver is None:
         module.fail_json(msg=mysql_driver_fail_msg)

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -975,9 +975,14 @@ def handle_requiressl_in_priv_string(module, priv, tls_requires):
         priv = priv_groups.group(1) + priv_groups.group(4) or None
     else:
         inner_priv_groups = re.search(r"(.*?),?REQUIRESSL,?(.*)", priv_groups.group(3))
-        priv = priv_groups.group(1) + priv_groups.group(2) + ','.join((inner_priv_groups.group(1), inner_priv_groups.group(3))) + priv_groups.group(4)
+        priv = '{0}{1}{2}{3}'.format(
+            priv_groups.group(1),
+            priv_groups.group(2),
+            ','.join(filter(None, (inner_priv_groups.group(1), inner_priv_groups.group(2)))),
+            priv_groups.group(4)
+        )
     if not tls_requires:
-        tls_requires = {"SSL": None}
+        tls_requires = "SSL"
     else:
         module.warn('Ignoring "REQUIRESSL" privilege as "tls_requires" is defined and it takes precedence.')
     return priv, tls_requires

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -972,10 +972,10 @@ def handle_requiressl_in_priv_string(module, priv, tls_requires):
         module.deprecate('The "REQUIRESSL" privilege is deprecated, use the "tls_requires" option instead.', version='3.0.0', collection_name='community.mysql')
         priv_groups = re.search(r"(.*?)(\*\.\*:)([^/]*)(.*)", priv)
         if priv_groups.group(3) == "REQUIRESSL":
-            priv = priv_groups.group(1)+priv_groups.group(4) or None
+            priv = priv_groups.group(1) + priv_groups.group(4) or None
         else:
             inner_priv_groups = re.search(r"(.*?),?REQUIRESSL,?(.*)", priv_groups.group(3))
-            priv = priv_groups.group(1)+priv_groups.group(2)+','.join((inner_priv_groups.group(1), inner_priv_groups.group(3)))+priv_groups.group(4)
+            priv = priv_groups.group(1) + priv_groups.group(2) + ','.join((inner_priv_groups.group(1), inner_priv_groups.group(3))) + priv_groups.group(4)
         if not tls_requires:
             tls_requires = {"SSL": None}
         else:

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -1175,7 +1175,7 @@ def main():
     if priv and isinstance(priv, dict):
         priv = convert_priv_dict_to_str(priv)
 
-    if "REQUIRESSL" in priv:
+    if priv and "REQUIRESSL" in priv:
         priv, tls_requires = handle_requiressl_in_priv_string(module, priv, tls_requires)
 
     if mysql_driver is None:

--- a/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
@@ -49,7 +49,7 @@
 
     - assert:
         that:
-          - result is failed and 'Access denied for user' in result.msg
+          - result is failed and ('Access denied for user' in result.msg or 'command denied to user' in result.msg)
 
     - name: create user with equivalent ssl requirement in tls_requires (expect unchanged)
       mysql_user:

--- a/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
@@ -50,6 +50,7 @@
     - assert:
         that:
           - result is failed and 'Access denied for user' in result.msg
+      when: pymysql_version.stdout != ""  # MySQLdb always uses SSL if possible
 
     - name: create user with equivalent ssl requirement in tls_requires (expect unchanged)
       mysql_user:

--- a/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
@@ -18,6 +18,15 @@
         dest: /tmp/cert.pem
       delegate_to: localhost
 
+    - name: get server version
+      mysql_info:
+        <<: *mysql_params
+        filter: version
+      register: db_version
+
+    - set_fact:
+        old_user_mgmt: "{{ db_version.version.major <= 5 and db_version.version.minor <= 6 or db_version.version.major == 10 and db_version.version.minor < 2 | bool }}"
+
     - name: Drop mysql user if exists
       mysql_user:
         <<: *mysql_params
@@ -35,22 +44,17 @@
         password: "{{ user_password_1 }}"
         priv: '*.*:SELECT,CREATE USER,REQUIRESSL,GRANT'
 
-    - name: attempt connection with newly created user not using TLS (expect access denied)
-      mysql_user:
-        name: "{{ user_name_2 }}"
-        password: "{{ user_password_2 }}"
-        host: 127.0.0.1
-        login_user: '{{ user_name_1 }}'
-        login_password: '{{ user_password_1 }}'
-        login_host: 127.0.0.1
-        login_port: '{{ mysql_primary_port }}'
-      ignore_errors: yes
+    - name: verify REQUIRESSL is assigned to the user
+      mysql_query:
+        <<: *mysql_params
+        query: "SHOW {{ what }} '{{ user_name_1}}'@'localhost'"
       register: result
+      vars:
+        what: "{{ 'GRANTS FOR' if old_user_mgmt else 'CREATE USER' }}"
 
     - assert:
         that:
-          - result is failed and 'Access denied for user' in result.msg
-      when: pymysql_version.stdout != ""  # MySQLdb always uses SSL if possible
+          - result is succeeded and 'REQUIRE SSL' in (result.query_result | string)
 
     - name: create user with equivalent ssl requirement in tls_requires (expect unchanged)
       mysql_user:

--- a/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
@@ -1,0 +1,110 @@
+---
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    - shell: pip show pymysql | awk '/Version/ {print $2}'
+      register: pymysql_version
+
+    - name: get server certificate
+      copy:
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        dest: /tmp/cert.pem
+      delegate_to: localhost
+
+    - name: Drop mysql user if exists
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ item }}'
+        state: absent
+      ignore_errors: yes
+      with_items:
+        - "{{ user_name_1 }}"
+        - "{{ user_name_2 }}"
+
+    - name: create user with REQUIRESSL privilege
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        priv: '*.*:USAGE,REQUIRESSL,GRANT'
+
+    - name: attempt connection with newly created user not using TLS (expect access denied)
+      mysql_user:
+        name: "{{ user_name_2 }}"
+        password: "{{ user_password_2 }}"
+        host: 127.0.0.1
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        login_host: 127.0.0.1
+        login_port: '{{ mysql_primary_port }}'
+      ignore_errors: yes
+      register: result
+
+    - assert:
+        that:
+          - result is failed and 'Access denied for user' in result.msg
+
+    - name: create user with equivalent ssl requirement in tls_requires (expect unchanged)
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        priv: '*.*:USAGE,GRANT'
+        tls_requires:
+          SSL:
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: create the same user again, with REQUIRESSL privilege once more
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        priv: '*.*:USAGE,REQUIRESSL,GRANT'
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: create user with both REQUIRESSL privilege and an incompatible tls_requires option
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        priv: '*.*:USAGE,REQUIRESSL,GRANT'
+        tls_requires:
+          X509:
+
+    - name: create same user again without REQUIRESSL privilege
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        priv: '*.*:USAGE,GRANT'
+        tls_requires:
+          X509:
+      register: result
+
+    - assert:
+        that: result is not changed
+
+    - name: Drop mysql user
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ item }}'
+        host: 127.0.0.1
+        state: absent
+      with_items:
+        - "{{ user_name_1 }}"
+        - "{{ user_name_2 }}"

--- a/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
@@ -33,7 +33,7 @@
         <<: *mysql_params
         name: "{{ user_name_1 }}"
         password: "{{ user_password_1 }}"
-        priv: '*.*:USAGE,REQUIRESSL,GRANT'
+        priv: '*.*:SELECT,CREATE USER,REQUIRESSL,GRANT'
 
     - name: attempt connection with newly created user not using TLS (expect access denied)
       mysql_user:
@@ -49,14 +49,14 @@
 
     - assert:
         that:
-          - result is failed and ('Access denied for user' in result.msg or 'command denied to user' in result.msg)
+          - result is failed and 'Access denied for user' in result.msg
 
     - name: create user with equivalent ssl requirement in tls_requires (expect unchanged)
       mysql_user:
         <<: *mysql_params
         name: "{{ user_name_1 }}"
         password: "{{ user_password_1 }}"
-        priv: '*.*:USAGE,GRANT'
+        priv: '*.*:SELECT,CREATE USER,GRANT'
         tls_requires:
           SSL:
       register: result
@@ -70,7 +70,7 @@
         <<: *mysql_params
         name: "{{ user_name_1 }}"
         password: "{{ user_password_1 }}"
-        priv: '*.*:USAGE,REQUIRESSL,GRANT'
+        priv: '*.*:SELECT,CREATE USER,REQUIRESSL,GRANT'
       register: result
 
     - assert:
@@ -82,7 +82,7 @@
         <<: *mysql_params
         name: "{{ user_name_1 }}"
         password: "{{ user_password_1 }}"
-        priv: '*.*:USAGE,REQUIRESSL,GRANT'
+        priv: '*.*:SELECT,CREATE USER,REQUIRESSL,GRANT'
         tls_requires:
           X509:
 
@@ -91,7 +91,7 @@
         <<: *mysql_params
         name: "{{ user_name_1 }}"
         password: "{{ user_password_1 }}"
-        priv: '*.*:USAGE,GRANT'
+        priv: '*.*:SELECT,CREATE USER,GRANT'
         tls_requires:
           X509:
       register: result

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -37,6 +37,8 @@
 
   block:
 
+    - include: issue-121.yml
+
     - include: issue-28.yml
 
     - include: create_user.yml user_name={{user_name_1}} user_password={{ user_password_1 }}

--- a/tests/unit/plugins/modules/test_mysql_user.py
+++ b/tests/unit/plugins/modules/test_mysql_user.py
@@ -100,7 +100,7 @@ def test_handle_grant_on_col(privileges, start, end, output):
             'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
             'cipher': 'ECDHE-ECDSA-AES256-SHA384',
             'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-            })),
+        })),
         (('*.*:ALL,REQUIRESSL', {
             'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
             'cipher': 'ECDHE-ECDSA-AES256-SHA384',
@@ -109,7 +109,7 @@ def test_handle_grant_on_col(privileges, start, end, output):
             'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
             'cipher': 'ECDHE-ECDSA-AES256-SHA384',
             'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-            })),
+        })),
         (('*.*:REQUIRESSL,ALL', {
             'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
             'cipher': 'ECDHE-ECDSA-AES256-SHA384',
@@ -118,7 +118,7 @@ def test_handle_grant_on_col(privileges, start, end, output):
             'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
             'cipher': 'ECDHE-ECDSA-AES256-SHA384',
             'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-            })),
+        })),
         (('*.*:ALL,REQUIRESSL,GRANT', {
             'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
             'cipher': 'ECDHE-ECDSA-AES256-SHA384',
@@ -127,7 +127,7 @@ def test_handle_grant_on_col(privileges, start, end, output):
             'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
             'cipher': 'ECDHE-ECDSA-AES256-SHA384',
             'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-            })),
+        })),
         (('*.*:ALL,REQUIRESSL,GRANT/a.b:USAGE', {
             'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
             'cipher': 'ECDHE-ECDSA-AES256-SHA384',
@@ -136,7 +136,7 @@ def test_handle_grant_on_col(privileges, start, end, output):
             'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
             'cipher': 'ECDHE-ECDSA-AES256-SHA384',
             'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-            }))
+        }))
     ]
 )
 def test_handle_requiressl_in_priv_string(input_tuple, output_tuple):

--- a/tests/unit/plugins/modules/test_mysql_user.py
+++ b/tests/unit/plugins/modules/test_mysql_user.py
@@ -4,12 +4,17 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 from ansible_collections.community.mysql.plugins.modules.mysql_user import (
     handle_grant_on_col,
     has_grant_on_col,
     normalize_col_grants,
     sort_column_order,
+    handle_requiressl_in_priv_string
 )
 from ..utils import dummy_cursor_class
 
@@ -72,6 +77,71 @@ def test_sort_column_order(input_, output):
 def test_handle_grant_on_col(privileges, start, end, output):
     """Tests handle_grant_on_col function."""
     assert handle_grant_on_col(privileges, start, end) == output
+
+
+@pytest.mark.parametrize(
+    'input_tuple,output_tuple',
+    [
+        (('*.*:REQUIRESSL', None), (None, 'SSL')),
+        (('*.*:ALL,REQUIRESSL', None), ('*.*:ALL', 'SSL')),
+        (('*.*:REQUIRESSL,ALL', None), ('*.*:ALL', 'SSL')),
+        (('*.*:ALL,REQUIRESSL,GRANT', None), ('*.*:ALL,GRANT', 'SSL')),
+        (('*.*:ALL,REQUIRESSL,GRANT/a.b:USAGE', None), ('*.*:ALL,GRANT/a.b:USAGE', 'SSL')),
+        (('*.*:REQUIRESSL', 'X509'), (None, 'X509')),
+        (('*.*:ALL,REQUIRESSL', 'X509'), ('*.*:ALL', 'X509')),
+        (('*.*:REQUIRESSL,ALL', 'X509'), ('*.*:ALL', 'X509')),
+        (('*.*:ALL,REQUIRESSL,GRANT', 'X509'), ('*.*:ALL,GRANT', 'X509')),
+        (('*.*:ALL,REQUIRESSL,GRANT/a.b:USAGE', 'X509'), ('*.*:ALL,GRANT/a.b:USAGE', 'X509')),
+        (('*.*:REQUIRESSL', {
+            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
+            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
+            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
+        }), (None, {
+            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
+            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
+            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
+            })),
+        (('*.*:ALL,REQUIRESSL', {
+            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
+            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
+            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
+        }), ('*.*:ALL', {
+            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
+            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
+            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
+            })),
+        (('*.*:REQUIRESSL,ALL', {
+            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
+            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
+            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
+        }), ('*.*:ALL', {
+            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
+            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
+            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
+            })),
+        (('*.*:ALL,REQUIRESSL,GRANT', {
+            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
+            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
+            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
+        }), ('*.*:ALL,GRANT', {
+            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
+            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
+            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
+            })),
+        (('*.*:ALL,REQUIRESSL,GRANT/a.b:USAGE', {
+            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
+            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
+            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
+        }), ('*.*:ALL,GRANT/a.b:USAGE', {
+            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
+            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
+            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
+            }))
+    ]
+)
+def test_handle_requiressl_in_priv_string(input_tuple, output_tuple):
+    """Tests the handle_requiressl_in_priv_string funciton."""
+    assert handle_requiressl_in_priv_string(MagicMock(), *input_tuple) == output_tuple
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Parse the `priv` string to effectively turn the `REQUIRESSL` privilege into an alias for the equivalent setup in the `tls_requires` option.
Introduce a deprecation notice for the `REQUIRESSL` privilege.

Fixes #89 #121 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_user

