### PR TITLE
mysql_user: reinitialize the privs list in privileges_unpack()

### DIFF
--- a/changelogs/fragments/136-mysql_priv_fix_grant_errors.yml
+++ b/changelogs/fragments/136-mysql_priv_fix_grant_errors.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_user - in `privileges_unpack()`, reinitialize the `privs` list on each iteration to prevent syntax errors in `GRANT` statements (https://github.com/ansible-collections/community.mysql/issues/136).

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -882,8 +882,8 @@ def privileges_unpack(priv, mode):
     else:
         quote = '`'
     output = {}
-    privs = []
     for item in priv.strip().split('/'):
+        privs = []
         pieces = item.strip().rsplit(':', 1)
         dbpriv = pieces[0].rsplit(".", 1)
 


### PR DESCRIPTION
##### SUMMARY
In some scenarios, `privileges_unpack()` called `privs.append()` inside a loop without first emptying or reinitializing the `privs` list from the prior iteration. This could result in an invalid `GRANT` statement, which incorrectly included privileges from a previously-built `GRANT` statement.

Reinitialize `privs` on each pass of the loop to prevent this from occurring.

Fixes #136

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user
