### PR TITLE
[stable-2] mysql_replication: add deprecation warning about future replacement of Is_Slave and Is_Master return values, add alternatives (#147)

### DIFF
--- a/changelogs/fragments/147-mysql_replication_deprecate_ret_vals.yml
+++ b/changelogs/fragments/147-mysql_replication_deprecate_ret_vals.yml
@@ -1,0 +1,5 @@
+major_changes:
+- mysql_replication - add deprecation warning that the ``Is_Slave`` and ``Is_Master`` return values will be replaced with ``Is_Primary`` and ``Is_Replica`` in ``community.mysql`` 3.0.0 (https://github.com/ansible-collections/community.mysql/pull/147).
+
+minor_changes:
+- mysql_replication - add the ``Is_Primary`` and ``Is_Replica`` alternatives to the ``Is_Slave`` and ``Is_Master`` return values as a preparation for replacement in ``community.mysql`` 3.0.0 (https://github.com/ansible-collections/community.mysql/pull/147).

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -524,9 +524,17 @@ def main():
     if mode in "getmaster":
         status = get_master_status(cursor)
         if not isinstance(status, dict):
-            status = dict(Is_Master=False, msg="Server is not configured as mysql master")
+            status = dict(Is_Master=False, Is_Primary=False,
+                          msg="Server is not configured as mysql master")
         else:
             status['Is_Master'] = True
+            status['Is_Primary'] = True
+
+        module.deprecate('"Is_Master" and "Is_Slave" return values are deprecated '
+                         'and will be replaced with "Is_Primary" and "Is_Replica" '
+                         'in the next major release. Use "Is_Primary" and "Is_Replica" instead.',
+                         version='3.0.0', collection_name='community.mysql')
+
         module.exit_json(queries=executed_queries, **status)
 
     elif mode in ("getreplica", "getslave"):
@@ -536,13 +544,16 @@ def main():
 
         status = get_replica_status(cursor, connection_name, channel, replica_term)
         if not isinstance(status, dict):
-            # TODO: announce it and replace with Replica
-            # in the next major release. Maybe a warning?
-            status = dict(Is_Slave=False, msg="Server is not configured as mysql replica")
+            status = dict(Is_Slave=False, Is_Replica=False, msg="Server is not configured as mysql replica")
         else:
-            # TODO: announce it and replace with Replica
-            # in the next major release. Maybe a warning?
             status['Is_Slave'] = True
+            status['Is_Replica'] = True
+
+        module.deprecate('"Is_Master" and "Is_Slave" return values are deprecated '
+                         'and will be replaced with "Is_Primary" and "Is_Replica" '
+                         'in the next major release. Use "Is_Primary" and "Is_Replica" instead.',
+                         version='3.0.0', collection_name='community.mysql')
+
         module.exit_json(queries=executed_queries, **status)
 
     elif mode in "changemaster":

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_channel.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_channel.yml
@@ -61,7 +61,7 @@
 
     - assert:
         that:
-        - replica_status.Is_Slave == true
+        - replica_status.Is_Replica == true
         - replica_status.Master_Host == '{{ mysql_host }}'
         - replica_status.Exec_Master_Log_Pos == mysql_primary_status.Position
         - replica_status.Master_Port == {{ mysql_primary_port }}
@@ -73,7 +73,7 @@
 
     - assert:
         that:
-        - replica_status.Is_Slave == true
+        - replica_status.Is_Replica == true
         - replica_status.Source_Host == '{{ mysql_host }}'
         - replica_status.Exec_Source_Log_Pos == mysql_primary_status.Position
         - replica_status.Source_Port == {{ mysql_primary_port }}

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -59,7 +59,7 @@
 
     - assert:
         that:
-        - mysql_primary_status.Is_Master == true
+        - mysql_primary_status.Is_Primary == true
         - mysql_primary_status.Position != 0
         - mysql_primary_status is not changed
 
@@ -148,7 +148,7 @@
 
     - assert:
         that:
-        - replica_status.Is_Slave == true
+        - replica_status.Is_Replica == true
         - replica_status.Master_Host == '{{ mysql_host }}'
         - replica_status.Exec_Master_Log_Pos == mysql_primary_status.Position
         - replica_status.Master_Port == {{ mysql_primary_port }}


### PR DESCRIPTION
(cherry picked from commit 853db5a2a415cb2b9dbcea0c0c65aec64e9a2f82)

##### SUMMARY
Backport of https://github.com/ansible-collections/community.mysql/pull/147