### PR TITLE
mysql_replication: Add aliases to "master" options, add alternatives to "master" state options, add announcement

### DIFF
--- a/changelogs/fragments/150-mysql_replication_master_related.yml
+++ b/changelogs/fragments/150-mysql_replication_master_related.yml
@@ -1,0 +1,6 @@
+minor_changes:
+- mysql_replication - change ``master_`` options to ``primary_`` options to keep compatibility (https://github.com/ansible-collections/community.mysql/pull/150).
+- mysql_replication - add alternative (``primary``) choices to the ``state`` option choices containing ``master`` (https://github.com/ansible-collections/community.mysql/pull/150).
+
+major_changes:
+- mysql_replication - the choices of the ``state`` option containing ``master`` will be finally replaced with the alternative ``primary`` choices in ``community.mysql`` 3.0.0, add deprecation warnings (https://github.com/ansible-collections/community.mysql/pull/150).

--- a/changelogs/fragments/150-mysql_replication_master_related.yml
+++ b/changelogs/fragments/150-mysql_replication_master_related.yml
@@ -1,5 +1,5 @@
 minor_changes:
-- mysql_replication - change ``master_`` options to ``primary_`` options to keep compatibility (https://github.com/ansible-collections/community.mysql/pull/150).
+- mysql_replication - change ``master_`` options to ``primary_`` options, add aliases to keep compatibility (https://github.com/ansible-collections/community.mysql/pull/150).
 - mysql_replication - add alternative (``primary``) choices to the ``state`` option choices containing ``master`` (https://github.com/ansible-collections/community.mysql/pull/150).
 
 major_changes:

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -142,7 +142,7 @@ options:
   primary_auto_position:
     description:
     - Whether the host uses GTID based replication or not.
-    - Same as the MASTER_AUTO_POSITION mysql variable.
+    - Same as the C(MASTER_AUTO_POSITION) mysql variable.
     type: bool
     default: false
     aliases: [master_auto_position]

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -162,7 +162,7 @@ options:
   primary_delay:
     description:
     - Time lag behind the primary's state (in seconds).
-    - Same as the MASTER_DELAY mysql variable.
+    - Same as the C(MASTER_DELAY) mysql variable.
     - Available from MySQL 5.6.
     - For more information see U(https://dev.mysql.com/doc/refman/8.0/en/replication-delayed.html).
     type: int

--- a/tests/integration/targets/test_mysql_replication/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_replication/defaults/main.yml
@@ -7,7 +7,7 @@ mysql_replica2_port: 3309
 
 test_db: test_db
 test_table: test_table
-test_master_delay: 60
+test_primary_delay: 60
 replication_user: replication_user
 replication_pass: replication_pass
 dump_path: /tmp/dump.sql

--- a/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
@@ -36,7 +36,7 @@
 
     - name: attempt connection with newly created user (expect failure)
       mysql_replication:
-        mode: getmaster
+        mode: getprimary
         login_user: '{{ user_name_1 }}'
         login_password: '{{ user_password_1 }}'
         login_host: 127.0.0.1
@@ -57,7 +57,7 @@
 
     - name: attempt connection with newly created user ignoring hostname
       mysql_replication:
-        mode: getmaster
+        mode: getprimary
         login_user: '{{ user_name_1 }}'
         login_password: '{{ user_password_1 }}'
         login_host: 127.0.0.1

--- a/tests/integration/targets/test_mysql_replication/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/main.yml
@@ -9,13 +9,13 @@
 # Initial CI tests of mysql_replication module:
 - import_tasks: mysql_replication_initial.yml
 
-# Tests of master_delay parameter:
-- import_tasks: mysql_replication_master_delay.yml
+# Tests of primary_delay parameter:
+- import_tasks: mysql_replication_primary_delay.yml
 
 # Tests of channel parameter:
 - import_tasks: mysql_replication_channel.yml
 
-# Tests of resetmaster mode:
-- import_tasks: mysql_replication_resetmaster_mode.yml
+# Tests of resetprimary mode:
+- import_tasks: mysql_replication_resetprimary_mode.yml
 
 - include: issue-28.yml

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_channel.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_channel.yml
@@ -8,26 +8,26 @@
       login_host: 127.0.0.1
 
   block:
-    # Get master log file and log pos:
-    - name: Get master status
+    # Get primary log file and log pos:
+    - name: Get primary status
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_primary_port }}'
-        mode: getmaster
+        mode: getprimary
       register: mysql_primary_status
 
-    # Test changemaster mode:
+    # Test changeprimary mode:
     - name: Run replication with channel
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica2_port }}'
-        mode: changemaster
-        master_host: '{{ mysql_host }}'
-        master_port: '{{ mysql_primary_port }}'
-        master_user: '{{ replication_user }}'
-        master_password: '{{ replication_pass }}'
-        master_log_file: '{{ mysql_primary_status.File }}'
-        master_log_pos: '{{ mysql_primary_status.Position }}'
+        mode: changeprimary
+        primary_host: '{{ mysql_host }}'
+        primary_port: '{{ mysql_primary_port }}'
+        primary_user: '{{ replication_user }}'
+        primary_password: '{{ replication_pass }}'
+        primary_log_file: '{{ mysql_primary_status.File }}'
+        primary_log_pos: '{{ mysql_primary_status.Position }}'
         channel: '{{ test_channel }}'
       register: result
 

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -49,12 +49,12 @@
     - name: Restore the dump to replica2
       shell: '{{ mysql_command }} -P{{ mysql_replica2_port }} < {{ dump_path }}'
 
-    # Test getmaster mode:
-    - name: Get master status
+    # Test getprimary mode:
+    - name: Get primary status
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_primary_port }}'
-        mode: getmaster
+        mode: getprimary
       register: mysql_primary_status
 
     - assert:
@@ -63,8 +63,8 @@
         - mysql_primary_status.Position != 0
         - mysql_primary_status is not changed
 
-    # Test startreplica fails without changemaster first. This needs fail_on_error
-    - name: Start replica (using deprecated startslave choice) and fail because master is not specified; failing on error as requested
+    # Test startreplica fails without changeprimary first. This needs fail_on_error
+    - name: Start replica (using deprecated startslave choice) and fail because primary is not specified; failing on error as requested
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
@@ -103,21 +103,21 @@
         that:
         - result is not failed
 
-    # Test changemaster mode:
-    # master_ssl_ca will be set as '' to check the module's behaviour for #23976,
+    # Test changeprimary mode:
+    # primary_ssl_ca will be set as '' to check the module's behaviour for #23976,
     # must be converted to an empty string
     - name: Run replication
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: changemaster
-        master_host: '{{ mysql_host }}'
-        master_port: '{{ mysql_primary_port }}'
-        master_user: '{{ replication_user }}'
-        master_password: '{{ replication_pass }}'
-        master_log_file: '{{ mysql_primary_status.File }}'
-        master_log_pos: '{{ mysql_primary_status.Position }}'
-        master_ssl_ca: ''
+        mode: changeprimary
+        primary_host: '{{ mysql_host }}'
+        primary_port: '{{ mysql_primary_port }}'
+        primary_user: '{{ replication_user }}'
+        primary_password: '{{ replication_pass }}'
+        primary_log_file: '{{ mysql_primary_status.File }}'
+        primary_log_pos: '{{ mysql_primary_status.Position }}'
+        primary_ssl_ca: ''
       register: result
 
     - assert:
@@ -179,7 +179,7 @@
       pause:
         seconds: 2
 
-    # Test master log pos has been changed:
+    # Test primary log pos has been changed:
     - name: Get replica status
       mysql_replication:
         <<: *mysql_params

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_primary_delay.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_primary_delay.yml
@@ -9,13 +9,13 @@
 
   block:
 
-    # Test master_delay mode:
+    # Test primary_delay mode:
     - name: Run replication
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: changemaster
-        master_delay: '{{ test_master_delay }}'
+        mode: changeprimary
+        primary_delay: '{{ test_primary_delay }}'
       register: result
 
     - assert:
@@ -31,7 +31,7 @@
         mode: startreplica
       register: result
 
-    # Check master_delay:
+    # Check primary_delay:
     - name: Get standby status
       mysql_replication:
         <<: *mysql_params
@@ -41,5 +41,5 @@
 
     - assert:
         that:
-        - replica_status.SQL_Delay == {{ test_master_delay }}
+        - replica_status.SQL_Delay == {{ test_primary_delay }}
         - replica_status is not changed

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_resetprimary_mode.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_resetprimary_mode.yml
@@ -22,20 +22,20 @@
         login_port: '{{ mysql_replica1_port }}'
         mode: resetreplicaall
 
-    # Get master initial status:
-    - name: Get master status
+    # Get primary initial status:
+    - name: Get primary status
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_primary_port }}'
-        mode: getmaster
+        mode: getprimary
       register: mysql_primary_initial_status
 
-    # Test resetmaster mode:
-    - name: Reset master
+    # Test resetprimary mode:
+    - name: Reset primary
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_primary_port }}'
-        mode: resetmaster
+        mode: resetprimary
       register: result
 
     - assert:
@@ -43,12 +43,12 @@
         - result is changed
         - result.queries == ["RESET MASTER"]
 
-    # Get master final status:
-    - name: Get master status
+    # Get primary final status:
+    - name: Get primary status
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_primary_port }}'
-        mode: getmaster
+        mode: getprimary
       register: mysql_primary_final_status
 
     - assert:


### PR DESCRIPTION
##### SUMMARY
Relates to https://github.com/ansible-collections/community.mysql/issues/145

mysql_replication:
1) add aliases to "master_" options
2) add alternatives to "master" choices of  `state` options
3) add deprecation warnings and announcement

Important: this does NOT contain any breaking changes. I ran the not touched tests with the changes - they passed. Then changed, the changed ones also passed (but you can recheck if any doubts, just checkout to the first commit of the PR).