### PR TITLE
Add python 3.8 testing

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -61,19 +61,20 @@ jobs:
           - stable-2.9
           - stable-2.10
           - stable-2.11
-          - devel
+          # - devel
         python:
           - 3.6
-          - 3.8
+          # - 3.8
         connector:
           - pymysql==0.7.10
           - pymysql==0.9.3
           - mysqlclient==2.0.1
+        include:
+          - ansible: devel
+            python: 3.8
         exclude:
           - mysql: 8.0.22
             connector: pymysql==0.7.10
-          - ansible: devel
-            python: 3.6
     steps:
 
       - name: Check out code

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -61,9 +61,10 @@ jobs:
           - stable-2.9
           - stable-2.10
           - stable-2.11
-          #- devel
+          - devel
         python:
           - 3.6
+          - 3.8
         connector:
           - pymysql==0.7.10
           - pymysql==0.9.3
@@ -71,6 +72,8 @@ jobs:
         exclude:
           - mysql: 8.0.22
             connector: pymysql==0.7.10
+          - ansible: devel
+            python: 3.6
     steps:
 
       - name: Check out code


### PR DESCRIPTION
##### SUMMARY
Adds Pyton 3.8 integration testing. This supports testing of Ansible devel, for which python 3.8 is a requirement.
Fixes #154 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql collection

