### PR TITLE
change deprecated parameter pw and db

### DIFF
--- a/changelogs/fragments/177-change_deprecated_connection_parameters.yml
+++ b/changelogs/fragments/177-change_deprecated_connection_parameters.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql module utils - change deprecated connection parameters ``passwd`` and ``db`` to ``password`` and ``database`` (https://github.com/ansible-collections/community.mysql/pull/177).

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -10,7 +10,7 @@
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
 from __future__ import (absolute_import, division, print_function)
-from functools import reduce
+from packaging import version
 __metaclass__ = type
 
 import os
@@ -92,8 +92,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         config['connect_timeout'] = connect_timeout
     if check_hostname is not None:
         if mysql_driver.__name__ == "pymysql":
-            version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
-            if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 711:
+            if version.parse(mysql_driver.__version__) >= "0.7.11":
                 config['ssl']['check_hostname'] = check_hostname
             else:
                 module.fail_json(msg='To use check_hostname, pymysql >= 0.7.11 is required on the target host')

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -10,7 +10,7 @@
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
 from __future__ import (absolute_import, division, print_function)
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 __metaclass__ = type
 
 import os
@@ -92,7 +92,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         config['connect_timeout'] = connect_timeout
     if check_hostname is not None:
         if mysql_driver.__name__ == "pymysql":
-            if LooseVersion(mysql_driver.__version__) >= LooseVersion("0.7.11"):
+            if parse_version(mysql_driver.__version__) >= parse_version("0.7.11"):
                 config['ssl']['check_hostname'] = check_hostname
             else:
                 module.fail_json(msg='To use check_hostname, pymysql >= 0.7.11 is required on the target host')

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -10,7 +10,7 @@
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
 from __future__ import (absolute_import, division, print_function)
-from packaging import version
+from distutils.version import LooseVersion
 __metaclass__ = type
 
 import os
@@ -92,7 +92,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         config['connect_timeout'] = connect_timeout
     if check_hostname is not None:
         if mysql_driver.__name__ == "pymysql":
-            if version.parse(mysql_driver.__version__) >= "0.7.11":
+            if LooseVersion(mysql_driver.__version__) >= LooseVersion("0.7.11"):
                 config['ssl']['check_hostname'] = check_hostname
             else:
                 module.fail_json(msg='To use check_hostname, pymysql >= 0.7.11 is required on the target host')

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -79,24 +79,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if login_user is not None:
         config['user'] = login_user
     if login_password is not None:
-        if mysql_driver.__name__ == "pymysql":
-            # In case of PyMySQL driver:
-            version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
-            if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 607:
-                # pymysql >= 0.6.7
-                config['password'] = login_password
-            else:
-                # NOTE: This check SHOULD be removed as soon as the minimum support version of PyMySQL for this collection reaches pymysql v0.6.7
-                config['passwd'] = login_password
-        else:
-            # In case of MySQLdb driver
-            version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
-            if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 10308:
-                # mysqlclient >= 1.3.8
-                config['password'] = login_password
-            else:
-                # NOTE: This check SHOULD be removed as soon as the minimum support version of MySQLdb for this collection reaches mysqlclient v1.3.8
-                config['passwd'] = login_password
+        config['password'] = login_password
     if ssl_cert is not None:
         config['ssl']['cert'] = ssl_cert
     if ssl_key is not None:
@@ -104,24 +87,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if ssl_ca is not None:
         config['ssl']['ca'] = ssl_ca
     if db is not None:
-        if mysql_driver.__name__ == "pymysql":
-            # In case of PyMySQL driver:
-            version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
-            if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 607:
-                # pymysql >= 0.6.7
-                config['database'] = db
-            else:
-                # NOTE: This check SHOULD be removed as soon as the minimum support version of PyMySQL for this collection reaches pymysql v0.6.7
-                config['db'] = db
-        else:
-            # In case of MySQLdb driver
-            version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
-            if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 10308:
-                # mysqlclient >= 1.3.8
-                config['database'] = login_password
-            else:
-                # NOTE: This check SHOULD be removed as soon as the minimum support version of MySQLdb for this collection reaches mysqlclient v1.3.8
-                config['db'] = db
+        config['database'] = db
     if connect_timeout is not None:
         config['connect_timeout'] = connect_timeout
     if check_hostname is not None:

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -79,7 +79,24 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if login_user is not None:
         config['user'] = login_user
     if login_password is not None:
-        config['passwd'] = login_password
+        if mysql_driver.__name__ == "pymysql":
+            # In case of PyMySQL driver:
+            version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
+            if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 607:
+                # pymysql >= 0.6.7
+                config['password'] = login_password
+            else:
+                # NOTE: This check SHOULD be removed as soon as the minimum support version of PyMySQL for this collection reaches pymysql v0.6.7
+                config['passwd'] = login_password
+        else:
+            # In case of MySQLdb driver
+            version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
+            if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 10308:
+                # mysqlclient >= 1.3.8
+                config['password'] = login_password
+            else:
+                # NOTE: This check SHOULD be removed as soon as the minimum support version of MySQLdb for this collection reaches mysqlclient v1.3.8
+                config['passwd'] = login_password
     if ssl_cert is not None:
         config['ssl']['cert'] = ssl_cert
     if ssl_key is not None:

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -104,7 +104,24 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if ssl_ca is not None:
         config['ssl']['ca'] = ssl_ca
     if db is not None:
-        config['db'] = db
+        if mysql_driver.__name__ == "pymysql":
+            # In case of PyMySQL driver:
+            version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
+            if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 607:
+                # pymysql >= 0.6.7
+                config['database'] = db
+            else:
+                # NOTE: This check SHOULD be removed as soon as the minimum support version of PyMySQL for this collection reaches pymysql v0.6.7
+                config['db'] = db
+        else:
+            # In case of MySQLdb driver
+            version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
+            if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 10308:
+                # mysqlclient >= 1.3.8
+                config['database'] = login_password
+            else:
+                # NOTE: This check SHOULD be removed as soon as the minimum support version of MySQLdb for this collection reaches mysqlclient v1.3.8
+                config['db'] = db
     if connect_timeout is not None:
         config['connect_timeout'] = connect_timeout
     if check_hostname is not None:

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -10,7 +10,7 @@
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
 from __future__ import (absolute_import, division, print_function)
-from pkg_resources import parse_version
+from functools import reduce
 __metaclass__ = type
 
 import os
@@ -92,7 +92,8 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         config['connect_timeout'] = connect_timeout
     if check_hostname is not None:
         if mysql_driver.__name__ == "pymysql":
-            if parse_version(mysql_driver.__version__) >= parse_version("0.7.11"):
+            version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
+            if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 711:
                 config['ssl']['check_hostname'] = check_hostname
             else:
                 module.fail_json(msg='To use check_hostname, pymysql >= 0.7.11 is required on the target host')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Parameters `db` and `passwd` are deprecated, using `database` and `password` is recommended by the DB-API 2.0.

This MySQL collections support two connectors:

- [PyMySQL](https://github.com/PyMySQL/PyMySQL)
- [MySQLdb aka mysqlclient](https://github.com/PyMySQL/mysqlclient-python)

In **PyMySQL** the change from the short parameter to the new long-form was made with v0.6.7 (and the short forms are kept as an alias for `database` and `password`). Warnings will be activated around 2022 (for details, see PyMySQL/PyMySQL#939).

In **MySQLdb** the change was introduced with v1.3.8 (and the short forms are kept as an alias for `database` and `password`).

FIXES #176

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

module_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

This ought to be a more sensible way than #116.

<!--- Paste verbatim command output below, e.g. before and after your change 
```paste below

```-->
