### PR TITLE
[stable-1] mysql_query: correctly reflect changed status in replace statements

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -255,6 +255,7 @@ Tronde
 tvlooy
 tyll
 UncertaintyP
+unnecessary-username
 vamshi8
 vanne
 vdboor

--- a/changelogs/fragments/193-reflect_changed_status_in_replace_statements.yml
+++ b/changelogs/fragments/193-reflect_changed_status_in_replace_statements.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_query - correctly reflect changed status in replace statements (https://github.com/ansible-collections/community.mysql/pull/193).

--- a/plugins/modules/mysql_query.py
+++ b/plugins/modules/mysql_query.py
@@ -112,7 +112,7 @@ from ansible_collections.community.mysql.plugins.module_utils.mysql import (
 )
 from ansible.module_utils._text import to_native
 
-DML_QUERY_KEYWORDS = ('INSERT', 'UPDATE', 'DELETE')
+DML_QUERY_KEYWORDS = ('INSERT', 'UPDATE', 'DELETE', 'REPLACE')
 # TRUNCATE is not DDL query but it also returns 0 rows affected:
 DDL_QUERY_KEYWORDS = ('CREATE', 'DROP', 'ALTER', 'RENAME', 'TRUNCATE')
 

--- a/tests/integration/targets/test_mysql_query/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_query/defaults/main.yml
@@ -7,6 +7,7 @@ test_db: testdb
 test_table1: test1
 test_table2: test2
 test_table3: test3
+test_table4: test4
 test_script_path: /tmp/test.sql
 
 user_name_1: 'db_user1'

--- a/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
@@ -289,6 +289,38 @@
       - result is failed
       - result.msg is search('the elements in query list must be strings')
 
+  - name: Create {{ test_table4 }}
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'CREATE TABLE {{ test_table4 }} (id int primary key, story text)'
+
+  - name: Insert test data using replace statement
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: "REPLACE INTO {{ test_table4 }} VALUES (1, 'first')"
+      single_transaction: yes
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+      - result.rowcount == [1]
+
+  - name: Replace test data
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: "REPLACE INTO {{ test_table4 }} VALUES (1, 'one')"
+      single_transaction: yes
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+      - result.rowcount == [2]
+
   - name: Drop db {{ test_db }}
     mysql_query:
       <<: *mysql_params


### PR DESCRIPTION
* mysql_query: correctly reflect changed status in replace statements.

* Fix the wrong indent.

(cherry picked from commit 9055bb4c8c95aede61e7ebe4aa21d7c6217b4a80)

##### SUMMARY
Backport of #193 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request