### PR TITLE
mysql_info: fix TypeError failure when there are databases that do not contain tables

### DIFF
--- a/changelogs/fragments/205-mysql_info_fix_failure_when_no_tables_in_db.yml
+++ b/changelogs/fragments/205-mysql_info_fix_failure_when_no_tables_in_db.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_info - fix TypeError failure when there are databases that do not contain tables (https://github.com/ansible-collections/community.mysql/issues/204).

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -474,6 +474,9 @@ class MySQL_Info(object):
                 self.info['databases'][db['name']] = {}
 
                 if not exclude_fields or 'db_size' not in exclude_fields:
+                    if db['size'] is None:
+                        db['size'] = 0
+
                     self.info['databases'][db['name']]['size'] = int(db['size'])
 
         # If empty dbs are not needed in the returned dict, exit from the method

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -191,3 +191,25 @@
         state: absent
 
     - include: issue-28.yml
+
+    # https://github.com/ansible-collections/community.mysql/issues/204
+    - name: Create database containing only views
+      mysql_db:
+        <<: *mysql_params
+        name: allviews
+
+    - name: Create view
+      mysql_query:
+        <<: *mysql_params
+        login_db: allviews
+        query: 'CREATE VIEW v_today (today) AS SELECT CURRENT_DATE'
+
+    - name: Fetch info
+      mysql_info:
+        <<: *mysql_params
+      register: result
+
+    - name: Check
+      assert:
+        that:
+          result.databases.allviews.size == 0


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.mysql/issues/204

As there's no information on view sizes in information_schema.VIEWS, we just put `0`.
```
mysql> show columns from information_schema.views;
+----------------------+---------------------------------+------+-----+---------+-------+
| Field                | Type                            | Null | Key | Default | Extra |
+----------------------+---------------------------------+------+-----+---------+-------+
| TABLE_CATALOG        | varchar(64)                     | NO   |     | NULL    |       |
| TABLE_SCHEMA         | varchar(64)                     | NO   |     | NULL    |       |
| TABLE_NAME           | varchar(64)                     | NO   |     | NULL    |       |
| VIEW_DEFINITION      | longtext                        | YES  |     | NULL    |       |
| CHECK_OPTION         | enum('NONE','LOCAL','CASCADED') | YES  |     | NULL    |       |
| IS_UPDATABLE         | enum('NO','YES')                | YES  |     | NULL    |       |
| DEFINER              | varchar(288)                    | YES  |     | NULL    |       |
| SECURITY_TYPE        | varchar(7)                      | YES  |     | NULL    |       |
| CHARACTER_SET_CLIENT | varchar(64)                     | NO   |     | NULL    |       |
| COLLATION_CONNECTION | varchar(64)                     | NO   |     | NULL    |       |
+----------------------+---------------------------------+------+-----+---------+-------+
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/mysql_info.py