### PR TITLE
[stable-2] mysql_info: fix TypeError failure when there are databases that do not contain tables (#205)

### DIFF
--- a/changelogs/fragments/205-mysql_info_fix_failure_when_no_tables_in_db.yml
+++ b/changelogs/fragments/205-mysql_info_fix_failure_when_no_tables_in_db.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_info - fix TypeError failure when there are databases that do not contain tables (https://github.com/ansible-collections/community.mysql/issues/204).

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -86,7 +86,7 @@ def sanitize_requires(tls_requires):
     if tls_requires:
         for key in tls_requires.keys():
             sanitized_requires[key.upper()] = tls_requires[key]
-        if any([key in ["CIPHER", "ISSUER", "SUBJECT"] for key in sanitized_requires.keys()]):
+        if any(key in ["CIPHER", "ISSUER", "SUBJECT"] for key in sanitized_requires.keys()):
             sanitized_requires.pop("SSL", None)
             sanitized_requires.pop("X509", None)
             return sanitized_requires

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -474,6 +474,9 @@ class MySQL_Info(object):
                 self.info['databases'][db['name']] = {}
 
                 if not exclude_fields or 'db_size' not in exclude_fields:
+                    if db['size'] is None:
+                        db['size'] = 0
+
                     self.info['databases'][db['name']]['size'] = int(db['size'])
 
         # If empty dbs are not needed in the returned dict, exit from the method

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -191,3 +191,25 @@
         state: absent
 
     - include: issue-28.yml
+
+    # https://github.com/ansible-collections/community.mysql/issues/204
+    - name: Create database containing only views
+      mysql_db:
+        <<: *mysql_params
+        name: allviews
+
+    - name: Create view
+      mysql_query:
+        <<: *mysql_params
+        login_db: allviews
+        query: 'CREATE VIEW v_today (today) AS SELECT CURRENT_DATE'
+
+    - name: Fetch info
+      mysql_info:
+        <<: *mysql_params
+      register: result
+
+    - name: Check
+      assert:
+        that:
+          result.databases.allviews.size == 0


### PR DESCRIPTION
* mysql_info: fix TypeError failure when there are databases that do not contain tables

* Add changelog fragment

(cherry picked from commit a1f419d5413f198ace0e837d01e68ee1abb142fc)

##### SUMMARY
Backport of https://github.com/ansible-collections/community.mysql/pull/205 and https://github.com/ansible-collections/community.mysql/pull/207

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request