### PR TITLE
Fix wrong impl for mysql

### DIFF
--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -859,8 +859,8 @@ def get_impl(cursor):
     global impl
     cursor.execute("SELECT VERSION()")
     if 'mariadb' in cursor.fetchone()[0].lower():
-        from ansible_collections.community.mysql.plugins.module_utils.implementations.mariadb import user as mysqluser
-        impl = mysqluser
-    else:
-        from ansible_collections.community.mysql.plugins.module_utils.implementations.mysql import user as mariauser
+        from ansible_collections.community.mysql.plugins.module_utils.implementations.mariadb import user as mariauser
         impl = mariauser
+    else:
+        from ansible_collections.community.mysql.plugins.module_utils.implementations.mysql import user as mysqluser
+        impl = mysqluser


### PR DESCRIPTION


##### SUMMARY

If 'mariadb' in version info, the db instance should be mariadb(reverse in code) rather than mysql.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

community.mysql

##### ADDITIONAL INFORMATION

MariaDB output:

```
MariaDB [(none)]> SELECT VERSION() as version;
+----------------------------------------+
| version                                |
+----------------------------------------+
| 10.4.12-MariaDB-1:10.4.12+maria~bionic |
+----------------------------------------+
1 row in set (0.000 sec)
```

MySQL output:

```
MySQL [(none)]> SELECT VERSION() as version;
+---------+
| version |
+---------+
| 5.7.30  |
+---------+
1 row in set (0.01 sec)
```

According to the above output, if 'mariadb' in version info, the db instance should be mariadb(reverse in code) rather than mysql. 