### PR TITLE
mysql_db: Fix assert in tests suite

### DIFF
--- a/tests/integration/targets/test_mysql_db/tasks/encoding_dump_import.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/encoding_dump_import.yml
@@ -45,7 +45,7 @@
     encoding: latin1
     target: "{{ latin1_file1 }}"
     state: dump
-  register: dump_result
+  register: result
 
 - assert:
     that:
@@ -78,6 +78,7 @@
     encoding: latin1
     name: '{{ db_latin1_name }}'
     target: "{{ latin1_file1 }}"
+  register: result
 
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY

In the `encoding_dump_import` test suite of the `mysql_db` module, the "assert" tasks check the wrong variable.

- Fix the variable name (L.48) to match the assert (L.52)
- Add the missing `register` (L.81) expected by the next assert (L.85)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
mysql_db
