### PR TITLE
mysql_db: Improve tests

### DIFF
--- a/tests/integration/targets/test_mysql_db/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_db/defaults/main.yml
@@ -4,7 +4,17 @@ mysql_user: root
 mysql_password: msandbox
 mysql_primary_port: 3307
 
-db_name: 'data'
+# Database names
+db_names:
+  - "data"
+  - "db%"
+
+# Database formats
+db_formats:
+  - { format_type: "sql", file: "dbdata.sql", format_msg_type: "ASCII", file2: "dump2.sql", file3: "dump3.sql", file4: "dump4.sql" }
+  - { format_type: "gz",  file: "dbdata.gz",  format_msg_type: "gzip",  file2: "dump2.gz",  file3: "dump3.gz",  file4: "dump4.gz" }
+  - { format_type: "bz2", file: "dbdata.bz2", format_msg_type: "bzip2", file2: "dump2.bz2", file3: "dump3.bz2", file4: "dump4.bz2" }
+
 db_name2: 'data2'
 db_user1: 'datauser1'
 db_user2: 'datauser2'

--- a/tests/integration/targets/test_mysql_db/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/main.yml
@@ -25,23 +25,41 @@
   set_fact:
     mysql_command: "mysql -u{{ mysql_user }} -p{{ mysql_password }} -P{{ mysql_primary_port }} --protocol=tcp"
 
-- include: state_present_absent.yml
+- name: Check state present/absent
+  include_tasks: state_present_absent.yml
+  vars:
+    db_name: "{{ item }}"
+  loop: "{{ db_names }}"
 
-- include: state_present_absent.yml db_name="db%"
+- name: Check state dump/import
+  include_tasks: state_dump_import.yml
+  vars:
+    db_name: "{{ item.0 }}"
+    file: "{{ item.1.file }}"
+    file2: "{{ item.1.file2 }}"
+    file3: "{{ item.1.file3 }}"
+    file4: "{{ item.1.file4 }}"
+    format_msg_type: "{{ item.1.format_msg_type }}"
+    format_type: "{{ item.1.format_type }}"
+  with_nested:
+    - "{{ db_names }}"
+    - "{{ db_formats }}"
 
-- include: state_dump_import.yml format_type=sql file=dbdata.sql format_msg_type=ASCII file2=dump2.sql file3=dump3.sql file4=dump4.sql
+- name: Check state present/absent with multiple databases
+  include_tasks: multi_db_create_delete.yml
 
-- include: state_dump_import.yml format_type=sql file=dbdata.sql format_msg_type=ASCII file2=dump2.sql file3=dump3.sql file4=dump4.sql db_name="db%"
+- name: Check state dump/import with encoding
+  include_tasks: encoding_dump_import.yml
+  vars:
+    file: "latin1.sql"
+    format_msg_type: "ASCII"
 
-- include: state_dump_import.yml format_type=gz  file=dbdata.gz format_msg_type=gzip file2=dump2.gz file3=dump3.gz file4=dump4.gz
-
-- include: state_dump_import.yml format_type=bz2 file=dbdata.bz2 format_msg_type=bzip2 file2=dump2.bz2 file3=dump3.bz2 file4=dump4.bz2
-
-- include: multi_db_create_delete.yml
-
-- include: encoding_dump_import.yml file=latin1.sql format_msg_type=ASCII
-
-- include: config_overrides_defaults.yml
+- name: Check MySQL config file
+  include_tasks: config_overrides_defaults.yml
   when: ansible_python.version_info[0] >= 3
 
-- include: issue-28.yml
+- name: Check issue 28
+  include_tasks: issue-28.yml
+  vars:
+    db_name: "{{ item }}"
+  loop: "{{ db_names }}"


### PR DESCRIPTION

##### SUMMARY

Tests for `mysql_db` module have recently been improved to test against multiple database names. They also test multiple database formats for dump/import states. This proposal aims to simplify the management of these different parameters.

- Define variables "db_names" and "db_formats" in defaults
- Use of the "vars" option in includes instead of using default parameters (that might be overridden by a previous task)
- Use of the "loop" option in includes instead of duplicating include tasks
- Use a product of db_names and db_formats in state_dump_import test (nested loop)

##### ISSUE TYPE

- Code refactoring Pull Request

##### COMPONENT NAME

mysql_db
