### PR TITLE
Remove support for REQUIRESSL privilege

### DIFF
--- a/changelogs/fragments/244-remove-requiressl-privilege.yaml
+++ b/changelogs/fragments/244-remove-requiressl-privilege.yaml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - mysql_user - remove support for the `REQUIRESSL` special privilege as it has ben superseded by the `tls_requires` option (https://github.com/ansible-collections/community.mysql/discussions/121).

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -198,16 +198,6 @@ EXAMPLES = r'''
       FUNCTION my_db.my_function: EXECUTE
     state: present
 
-# Note that REQUIRESSL is a special privilege that should only apply to *.* by itself.
-# Setting this privilege in this manner is deprecated.
-# Use 'tls_requires' instead.
-- name: Modify user to require SSL connections
-  community.mysql.mysql_user:
-    name: bob
-    append_privs: yes
-    priv: '*.*:REQUIRESSL'
-    state: present
-
 - name: Modify user to require TLS connection with a valid client certificate
   community.mysql.mysql_user:
     name: bob
@@ -315,7 +305,6 @@ from ansible_collections.community.mysql.plugins.module_utils.user import (
     convert_priv_dict_to_str,
     get_impl,
     get_mode,
-    handle_requiressl_in_priv_string,
     InvalidPrivsError,
     limit_resources,
     get_valid_privs,
@@ -388,9 +377,6 @@ def main():
 
     if priv and isinstance(priv, dict):
         priv = convert_priv_dict_to_str(priv)
-
-    if priv and "REQUIRESSL" in priv:
-        priv, tls_requires = handle_requiressl_in_priv_string(module, priv, tls_requires)
 
     if mysql_driver is None:
         module.fail_json(msg=mysql_driver_fail_msg)

--- a/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
@@ -37,50 +37,19 @@
         - "{{ user_name_1 }}"
         - "{{ user_name_2 }}"
 
-    - name: create user with REQUIRESSL privilege
-      mysql_user:
-        <<: *mysql_params
-        name: "{{ user_name_1 }}"
-        password: "{{ user_password_1 }}"
-        priv: '*.*:SELECT,CREATE USER,REQUIRESSL,GRANT'
-
-    - name: verify REQUIRESSL is assigned to the user
-      mysql_query:
-        <<: *mysql_params
-        query: "SHOW {{ what }} '{{ user_name_1}}'@'localhost'"
-      register: result
-      vars:
-        what: "{{ 'GRANTS FOR' if old_user_mgmt else 'CREATE USER' }}"
-
-    - assert:
-        that:
-          - result is succeeded and 'REQUIRE SSL' in (result.query_result | string)
-
-    - name: create user with equivalent ssl requirement in tls_requires (expect unchanged)
-      mysql_user:
-        <<: *mysql_params
-        name: "{{ user_name_1 }}"
-        password: "{{ user_password_1 }}"
-        priv: '*.*:SELECT,CREATE USER,GRANT'
-        tls_requires:
-          SSL:
-      register: result
-
-    - assert:
-        that:
-          - result is not changed
-
-    - name: create the same user again, with REQUIRESSL privilege once more
+    - name: create user with REQUIRESSL privilege (expect failure)
       mysql_user:
         <<: *mysql_params
         name: "{{ user_name_1 }}"
         password: "{{ user_password_1 }}"
         priv: '*.*:SELECT,CREATE USER,REQUIRESSL,GRANT'
       register: result
+      ignore_errors: yes
 
     - assert:
         that:
-          - result is not changed
+          - result is failed
+          - result.msg is search('Invalid privileges specified')
 
     - name: create user with both REQUIRESSL privilege and an incompatible tls_requires option
       mysql_user:
@@ -90,19 +59,13 @@
         priv: '*.*:SELECT,CREATE USER,REQUIRESSL,GRANT'
         tls_requires:
           X509:
-
-    - name: create same user again without REQUIRESSL privilege
-      mysql_user:
-        <<: *mysql_params
-        name: "{{ user_name_1 }}"
-        password: "{{ user_password_1 }}"
-        priv: '*.*:SELECT,CREATE USER,GRANT'
-        tls_requires:
-          X509:
       register: result
+      ignore_errors: yes
 
     - assert:
-        that: result is not changed
+        that:
+          - result is failed
+          - result.msg is search('Invalid privileges specified')
 
     - name: Drop mysql user
       mysql_user:

--- a/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
@@ -49,7 +49,7 @@
     - assert:
         that:
           - result is failed
-          - result.msg is search('Invalid privileges specified')
+          - result.msg is search('Error granting privileges')
 
     - name: create user with both REQUIRESSL privilege and an incompatible tls_requires option
       mysql_user:
@@ -65,7 +65,7 @@
     - assert:
         that:
           - result is failed
-          - result.msg is search('Invalid privileges specified')
+          - result.msg is search('Error granting privileges')
 
     - name: Drop mysql user
       mysql_user:

--- a/tests/unit/plugins/module_utils/test_mysql_user.py
+++ b/tests/unit/plugins/module_utils/test_mysql_user.py
@@ -13,8 +13,7 @@ from ansible_collections.community.mysql.plugins.module_utils.user import (
     handle_grant_on_col,
     has_grant_on_col,
     normalize_col_grants,
-    sort_column_order,
-    handle_requiressl_in_priv_string
+    sort_column_order
 )
 from ..utils import dummy_cursor_class
 
@@ -77,71 +76,6 @@ def test_sort_column_order(input_, output):
 def test_handle_grant_on_col(privileges, start, end, output):
     """Tests handle_grant_on_col function."""
     assert handle_grant_on_col(privileges, start, end) == output
-
-
-@pytest.mark.parametrize(
-    'input_tuple,output_tuple',
-    [
-        (('*.*:REQUIRESSL', None), (None, 'SSL')),
-        (('*.*:ALL,REQUIRESSL', None), ('*.*:ALL', 'SSL')),
-        (('*.*:REQUIRESSL,ALL', None), ('*.*:ALL', 'SSL')),
-        (('*.*:ALL,REQUIRESSL,GRANT', None), ('*.*:ALL,GRANT', 'SSL')),
-        (('*.*:ALL,REQUIRESSL,GRANT/a.b:USAGE', None), ('*.*:ALL,GRANT/a.b:USAGE', 'SSL')),
-        (('*.*:REQUIRESSL', 'X509'), (None, 'X509')),
-        (('*.*:ALL,REQUIRESSL', 'X509'), ('*.*:ALL', 'X509')),
-        (('*.*:REQUIRESSL,ALL', 'X509'), ('*.*:ALL', 'X509')),
-        (('*.*:ALL,REQUIRESSL,GRANT', 'X509'), ('*.*:ALL,GRANT', 'X509')),
-        (('*.*:ALL,REQUIRESSL,GRANT/a.b:USAGE', 'X509'), ('*.*:ALL,GRANT/a.b:USAGE', 'X509')),
-        (('*.*:REQUIRESSL', {
-            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
-            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
-            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-        }), (None, {
-            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
-            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
-            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-        })),
-        (('*.*:ALL,REQUIRESSL', {
-            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
-            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
-            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-        }), ('*.*:ALL', {
-            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
-            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
-            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-        })),
-        (('*.*:REQUIRESSL,ALL', {
-            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
-            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
-            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-        }), ('*.*:ALL', {
-            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
-            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
-            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-        })),
-        (('*.*:ALL,REQUIRESSL,GRANT', {
-            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
-            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
-            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-        }), ('*.*:ALL,GRANT', {
-            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
-            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
-            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-        })),
-        (('*.*:ALL,REQUIRESSL,GRANT/a.b:USAGE', {
-            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
-            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
-            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-        }), ('*.*:ALL,GRANT/a.b:USAGE', {
-            'subject': '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland',
-            'cipher': 'ECDHE-ECDSA-AES256-SHA384',
-            'issuer': '/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
-        }))
-    ]
-)
-def test_handle_requiressl_in_priv_string(input_tuple, output_tuple):
-    """Tests the handle_requiressl_in_priv_string funciton."""
-    assert handle_requiressl_in_priv_string(MagicMock(), *input_tuple) == output_tuple
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Remove support for the `REQUIRESSL` privilege as the handling of the connection requirement via privileges is an antipattern and it has been superseded by the `tls_requires` option

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_user


