### PR TITLE
mysql_replication: remove mode values and ret values containing master / slave

### DIFF
--- a/changelogs/fragments/300-mysql_replication_remove_master_slave.yml
+++ b/changelogs/fragments/300-mysql_replication_remove_master_slave.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+- mysql_replication - remove the mode options values containing ``master``/``slave`` and the master_use_gtid option ``slave_pos`` (were replaced with corresponding ``primary``/``replica`` values) (https://github.com/ansible-collections/community.mysql/issues/145).
+- mysql_replication - remove ``Is_Slave`` and ``Is_Master`` return values (were replaced with ``Is_Primary`` and ``Is_Replica`` (https://github.com/ansible-collections    /community.mysql/issues/145).

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -64,11 +64,11 @@
         - mysql_primary_status is not changed
 
     # Test startreplica fails without changeprimary first. This needs fail_on_error
-    - name: Start replica (using deprecated startslave choice) and fail because primary is not specified; failing on error as requested
+    - name: Start replica and fail because primary is not specified; failing on error as requested
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: startslave
+        mode: startreplica
         fail_on_error: yes
       register: result
       ignore_errors: yes
@@ -139,11 +139,11 @@
         - result.queries == ["START SLAVE"] or result.queries == ["START REPLICA"]
 
     # Test getreplica mode:
-    - name: Get replica status using deprecated getslave choice
+    - name: Get replica status
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: getslave
+        mode: getreplica
       register: replica_status
 
     - assert:
@@ -159,7 +159,7 @@
 
     - assert:
         that:
-        - replica_status.Is_Slave == true
+        - replica_status.Is_Replica == true
         - replica_status.Source_Host == '{{ mysql_host }}'
         - replica_status.Exec_Source_Log_Pos == mysql_primary_status.Position
         - replica_status.Source_Port == {{ mysql_primary_port }}
@@ -216,11 +216,11 @@
       when: (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '<=')
 
     # Test stopreplica mode:
-    - name: Stop replica using deprecated stopslave choice
+    - name: Stop replica
       mysql_replication:
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
-        mode: stopslave
+        mode: stopreplica
       register: result
 
     - assert:

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -241,3 +241,19 @@
         that:
         - result is not changed
       when: (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '<=')
+
+    # master / slave related choices were removed in 3.0.0
+    # https://github.com/ansible-collections/community.mysql/pull/252
+    - name: Test invoking the module with unsupported choice
+      mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        mode: stopslave
+        fail_on_error: true
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+        - result.msg == "value of mode must be one of{{ ":" }} getprimary, getreplica, changeprimary, stopreplica, startreplica, resetprimary, resetreplica, resetreplicaall, got{{ ":" }} stopslave"
+        - result is failed


### PR DESCRIPTION
##### SUMMARY
Relates to
https://github.com/ansible-collections/community.mysql/issues/145
https://github.com/ansible-collections/community.mysql/pull/147
https://github.com/ansible-collections/community.mysql/pull/150
https://github.com/ansible-collections/community.mysql/pull/97

Will be release as a breaking change with 3.0.0