### PR TITLE
Prepare for distutils.version being removed in Python 3.12

### DIFF
--- a/changelogs/fragments/267-prepare_for_distutils_be_removed.yml
+++ b/changelogs/fragments/267-prepare_for_distutils_be_removed.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Collection core functions - use vendored version of ``distutils.version`` included in ansible-core 2.12 if available. This avoids breakage when ``distutils`` is removed from the standard library of Python 3.12. Note that ansible-core 2.11, ansible-base 2.10 and Ansible 2.9 are right now not compatible with Python 3.12, hence this fix does not target these ansible-core/-base/2.9 versions (https://github.com/ansible-collections/community.mysql/pull/267)."

--- a/plugins/module_utils/implementations/mariadb/replication.py
+++ b/plugins/module_utils/implementations/mariadb/replication.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible_collections.community.mysql.plugins.module_utils.mysql import get_server_version
-from distutils.version import LooseVersion
+from ansible_collections.community.mysql.plugins.module_utils.version import LooseVersion
 
 
 def uses_replica_terminology(cursor):

--- a/plugins/module_utils/implementations/mariadb/role.py
+++ b/plugins/module_utils/implementations/mariadb/role.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from distutils.version import LooseVersion
+from ansible_collections.community.mysql.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.mysql.plugins.module_utils.mysql import get_server_version
 
 

--- a/plugins/module_utils/implementations/mariadb/user.py
+++ b/plugins/module_utils/implementations/mariadb/user.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from distutils.version import LooseVersion
+from ansible_collections.community.mysql.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.mysql.plugins.module_utils.mysql import get_server_version
 
 

--- a/plugins/module_utils/implementations/mysql/replication.py
+++ b/plugins/module_utils/implementations/mysql/replication.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible_collections.community.mysql.plugins.module_utils.mysql import get_server_version
-from distutils.version import LooseVersion
+from ansible_collections.community.mysql.plugins.module_utils.version import LooseVersion
 
 
 def uses_replica_terminology(cursor):

--- a/plugins/module_utils/implementations/mysql/role.py
+++ b/plugins/module_utils/implementations/mysql/role.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from distutils.version import LooseVersion
+from ansible_collections.community.mysql.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.mysql.plugins.module_utils.mysql import get_server_version
 
 

--- a/plugins/module_utils/implementations/mysql/user.py
+++ b/plugins/module_utils/implementations/mysql/user.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from distutils.version import LooseVersion
+from ansible_collections.community.mysql.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.mysql.plugins.module_utils.mysql import get_server_version
 
 

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -3,7 +3,7 @@
 # Copyright: (c) 2021, Felix Fontein <felix@fontein.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-"""Provide Version object to compare version numbers."""
+"""Provide version object to compare version numbers."""
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Provide Version object to compare version numbers."""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.six import raise_from
+
+try:
+    from ansible.module_utils.compat.version import LooseVersion
+except ImportError:
+    try:
+        from distutils.version import LooseVersion
+    except ImportError as exc:
+        msg = ('To use this plugin or module with ansible-core < 2.11, '
+               'you need to use Python < 3.12 with distutils.version present')
+        raise_from(ImportError(msg), exc)

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -283,7 +283,7 @@ from ansible_collections.community.mysql.plugins.module_utils.mysql import (
     mysql_common_argument_spec,
 )
 from ansible.module_utils._text import to_native
-from distutils.version import LooseVersion
+from ansible_collections.community.mysql.plugins.module_utils.version import LooseVersion
 
 executed_queries = []
 


### PR DESCRIPTION
##### SUMMARY
Prepare for distutils.version being removed in Python 3.12

Relates to https://github.com/ansible-collections/overview/issues/45#issuecomment-999911221

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request