### PR TITLE
Clarified error message about missing python modules

### DIFF
--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -81,8 +81,8 @@ notes:
      for newer versions of Fedora; see M(ansible.builtin.dnf).
    - Be sure you have mysqlclient, PyMySQL, or MySQLdb library installed on the target machine
      for the Python interpreter Ansible discovers.  For example if ansible discovers and uses Python 3, you need to install
-     the Python 3 version of PyMySQL.  If ansible discovers and uses Python 2, you need to install the Python 2 version
-     of either PyMySQL or MySQL-python.
+     the Python 3 version of PyMySQL or mysqlclient.  If ansible discovers and uses Python 2, you need to install the Python 2
+     version of either PyMySQL or MySQL-python.
    - If you have trouble, it may help to force Ansible to use the Python interpreter you need by specifying
      C(ansible_python_interpreter).  For more information, see
      U(https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html).

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -79,12 +79,13 @@ notes:
      The Python package may be installed with apt-get install python-pymysql (Ubuntu; see M(ansible.builtin.apt)) or
      yum install python2-PyMySQL (RHEL/CentOS/Fedora; see M(ansible.builtin.yum)). You can also use dnf install python2-PyMySQL
      for newer versions of Fedora; see M(ansible.builtin.dnf).
-   - Be sure you have PyMySQL or MySQLdb library installed on the target machine
+   - Be sure you have mysqlclient, PyMySQL, or MySQLdb library installed on the target machine
      for the Python interpreter Ansible discovers.  For example if ansible discovers and uses Python 3, you need to install
      the Python 3 version of PyMySQL.  If ansible discovers and uses Python 2, you need to install the Python 2 version
      of either PyMySQL or MySQL-python.
-   - If you have trouble, it may help to force Ansible to use Python 3 by specifying C(ansible_python_interpreter).
-     For more information, see U(https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html).
+   - If you have trouble, it may help to force Ansible to use the Python interpreter you need by specifying
+     C(ansible_python_interpreter).  For more information, see
+     U(https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html).
    - Both C(login_password) and C(login_user) are required when you are
      passing credentials. If none are present, the module will attempt to read
      the credentials from C(~/.my.cnf), and finally fall back to using the MySQL

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -80,8 +80,10 @@ notes:
      yum install python2-PyMySQL (RHEL/CentOS/Fedora; see M(ansible.builtin.yum)). You can also use dnf install python2-PyMySQL
      for newer versions of Fedora; see M(ansible.builtin.dnf).
    - Be sure you have PyMySQL or MySQLdb library installed on the target machine
-     for the Python interpreter Ansible uses, for example, if it is Python 3,
-     you must install the library for Python 3. You can also change the interpreter.
+     for the Python interpreter Ansible discovers.  For example if ansible discovers and uses Python 3, you need to install
+     the Python 3 version of PyMySQL.  If ansible discovers and uses Python 2, you need to install the Python 2 version
+     of either PyMySQL or MySQL-python.
+   - If you have trouble, it may help to force Ansible to use Python 3 by specifying C(ansible_python_interpreter).
      For more information, see U(https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html).
    - Both C(login_password) and C(login_user) are required when you are
      passing credentials. If none are present, the module will attempt to read

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -29,7 +29,7 @@ except ImportError:
     except ImportError:
         mysql_driver = None
 
-mysql_driver_fail_msg = 'The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) module is required.'
+mysql_driver_fail_msg = 'A MySQL module is required: for Python 2.7 either PyMySQL or MySQL-python, or for Python 3.X PyMySQL.  Consider setting ansible_python_interpreter to use the intended Python version.'
 
 
 def parse_from_mysql_config_file(cnf):

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -29,7 +29,7 @@ except ImportError:
     except ImportError:
         mysql_driver = None
 
-mysql_driver_fail_msg = 'A MySQL module is required: for Python 2.7 either mysqlclient, PyMySQL, or MySQL-python, or for Python 3.X mysqlclient or PyMySQL.  Consider setting ansible_python_interpreter to use the intended Python version.'
+mysql_driver_fail_msg = 'A MySQL module is required: for Python 2.7 either PyMySQL, or MySQL-python, or for Python 3.X mysqlclient or PyMySQL.  Consider setting ansible_python_interpreter to use the intended Python version.'
 
 
 def parse_from_mysql_config_file(cnf):

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -29,7 +29,7 @@ except ImportError:
     except ImportError:
         mysql_driver = None
 
-mysql_driver_fail_msg = 'A MySQL module is required: for Python 2.7 either PyMySQL or MySQL-python, or for Python 3.X PyMySQL.  Consider setting ansible_python_interpreter to use the intended Python version.'
+mysql_driver_fail_msg = 'A MySQL module is required: for Python 2.7 either mysqlclient, PyMySQL, or MySQL-python, or for Python 3.X mysqlclient or PyMySQL.  Consider setting ansible_python_interpreter to use the intended Python version.'
 
 
 def parse_from_mysql_config_file(cnf):


### PR DESCRIPTION
This is a tweak to error messages and notes to suggest overriding the discovered interpreter.  There do seem to be problems with relatively recent changes to how mysql is installed by default.  Switching to Python 3 is probably a good idea as a first attempt to resolve issues.

##### SUMMARY

Fixes #272

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
mysql_db

##### ADDITIONAL INFORMATION
