### PR TITLE
Honor the set_default_role_all parameter

### DIFF
--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -769,7 +769,8 @@ class Role():
 
                 self.cursor.execute(*self.q_builder.role_grant(user))
 
-                self.role_impl.set_default_role_all(user)
+                if set_default_role_all:
+                    self.role_impl.set_default_role_all(user)
 
                 changed = True
 


### PR DESCRIPTION
##### SUMMARY

The set_default_role_all parameter is documented, but does nothing. This PR fixes this.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

mysql_role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
