### PR TITLE
Add IF EXISTS to DROP USER / ROLE command

### DIFF
--- a/changelogs/fragments/286-mysql_drop_user_role_if_exists.yml
+++ b/changelogs/fragments/286-mysql_drop_user_role_if_exists.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql_role and mysql_user Adds IF EXISTS clause to DROP ROLE and DROP USER statements to make them replication safe on MySQL 5.7+ and MariaDB 10.1+

--- a/changelogs/fragments/286-mysql_drop_user_role_if_exists.yml
+++ b/changelogs/fragments/286-mysql_drop_user_role_if_exists.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - mysql_role and mysql_user Adds IF EXISTS clause to DROP ROLE and DROP USER statements to make them replication safe on MySQL 5.7+ and MariaDB 10.1+
+  - mysql_role and mysql_user - adds IF EXISTS clause to DROP ROLE and DROP USER statements to make them replication safe on MySQL 5.7+ and MariaDB 10.1+ (https://github.com/ansible-collections/community.mysql/pull/286).

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -368,7 +368,7 @@ def user_delete(cursor, user, host, host_all, check_mode):
         hostnames = [host]
 
     for hostname in hostnames:
-        cursor.execute("DROP USER /*!50700 IF EXISTS */ /*M!100100 IF EXISTS */  %s@%s", (user, hostname))
+        cursor.execute("DROP USER /*!50708 IF EXISTS */ /*M!100103 IF EXISTS */  %s@%s", (user, hostname))
 
     return True
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -368,7 +368,7 @@ def user_delete(cursor, user, host, host_all, check_mode):
         hostnames = [host]
 
     for hostname in hostnames:
-        cursor.execute("DROP USER %s@%s", (user, hostname))
+        cursor.execute("DROP USER IF EXIST %s@%s", (user, hostname))
 
     return True
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -368,7 +368,7 @@ def user_delete(cursor, user, host, host_all, check_mode):
         hostnames = [host]
 
     for hostname in hostnames:
-            cursor.execute("DROP USER /*!50700 IF EXISTS */ /*M!100103 IF EXISTS */  %s@%s", (user, hostname))
+            cursor.execute("DROP USER /*!50700 IF EXISTS */ /*M!100100 IF EXISTS */  %s@%s", (user, hostname))
 
     return True
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -368,7 +368,7 @@ def user_delete(cursor, user, host, host_all, check_mode):
         hostnames = [host]
 
     for hostname in hostnames:
-        cursor.execute("DROP USER IF EXISTS %s@%s", (user, hostname))
+            cursor.execute("DROP USER /*!50700 IF EXISTS */ /*M!100103 IF EXISTS */  %s@%s", (user, hostname))
 
     return True
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -368,7 +368,7 @@ def user_delete(cursor, user, host, host_all, check_mode):
         hostnames = [host]
 
     for hostname in hostnames:
-        cursor.execute("DROP USER IF EXIST %s@%s", (user, hostname))
+        cursor.execute("DROP USER IF EXISTS %s@%s", (user, hostname))
 
     return True
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -368,7 +368,7 @@ def user_delete(cursor, user, host, host_all, check_mode):
         hostnames = [host]
 
     for hostname in hostnames:
-            cursor.execute("DROP USER /*!50700 IF EXISTS */ /*M!100100 IF EXISTS */  %s@%s", (user, hostname))
+        cursor.execute("DROP USER /*!50700 IF EXISTS */ /*M!100100 IF EXISTS */  %s@%s", (user, hostname))
 
     return True
 

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -338,7 +338,7 @@ def db_delete(cursor, db):
     if not db:
         return False
     for each_db in db:
-        query = "DROP DATABASE /*!50700 IF EXISTS */ /*M!100100 IF EXISTS */ %s" % mysql_quote_identifier(each_db, 'database')
+        query = "DROP DATABASE %s" % mysql_quote_identifier(each_db, 'database')
         executed_commands.append(query)
         cursor.execute(query)
     return True

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -338,7 +338,7 @@ def db_delete(cursor, db):
     if not db:
         return False
     for each_db in db:
-        query = "DROP DATABASE %s" % mysql_quote_identifier(each_db, 'database')
+        query = "DROP DATABASE /*!50700 IF EXISTS */ /*M!100100 IF EXISTS */ %s" % mysql_quote_identifier(each_db, 'database')
         executed_commands.append(query)
         cursor.execute(query)
     return True

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -741,7 +741,7 @@ class Role():
         if check_mode and self.exists:
             return True
 
-        self.cursor.execute('DROP ROLE /*!50700 IF EXISTS */ /*M!100100 IF EXISTS */ %s', (self.name,))
+        self.cursor.execute('/*M!100005 DROP ROLE */ /*M!100103 IF EXISTS */ /*M!100005 %s */', (self.name,))
         return True
 
     def update_members(self, users, check_mode=False, append_members=False,

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -741,7 +741,7 @@ class Role():
         if check_mode and self.exists:
             return True
 
-        self.cursor.execute('DROP ROLE %s', (self.name,))
+        self.cursor.execute('DROP ROLE /*!50700 IF EXISTS */ /*M!100100 IF EXISTS */ %s', (self.name,))
         return True
 
     def update_members(self, users, check_mode=False, append_members=False,


### PR DESCRIPTION
##### SUMMARY
Add IF EXISTS clause to DROP USER statement

There exists the possibility for a race condition that breaks certain (circular) replication configurations when DROP USER is executed on multiple nodes in the replica set.  Adding IF EXISTS avoids the need to use `sql_log_bin : no` making the statement always replication safe.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/user.py 

##### ADDITIONAL INFORMATION

