### PR TITLE
Enable and fix integration tests for devel

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -120,7 +120,7 @@ jobs:
         run: "sed -i 's/^python_packages:.*/python_packages: [${{ matrix.connector }}]/' ${{ env.connector_version_file }}"
 
       - name: Run integration tests
-        run: ansible-test integration --docker -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --diff --coverage
+        run: ansible-test integration --docker ubuntu1804 -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --diff --coverage
         working-directory: ./ansible_collections/community/mysql
 
       - name: Generate coverage report.

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -65,7 +65,7 @@ jobs:
           - stable-2.10
           - stable-2.11
           - stable-2.12
-          #- devel
+          - devel
         python:
           - 3.6
           - 3.8

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -120,7 +120,7 @@ jobs:
         run: "sed -i 's/^python_packages:.*/python_packages: [${{ matrix.connector }}]/' ${{ env.connector_version_file }}"
 
       - name: Run integration tests
-        run: ansible-test integration --docker ubuntu1804 -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --diff --coverage
+        run: ansible-test integration --docker -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --diff --coverage
         working-directory: ./ansible_collections/community/mysql
 
       - name: Generate coverage report.

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -58,7 +58,7 @@ jobs:
         db_engine_version:
           - mysql_5.7.31
           - mysql_8.0.22
-          - mariadb_10.2.37
+          - mariadb_10.3.34
           - mariadb_10.5.9
         ansible:
           - stable-2.9

--- a/tests/integration/targets/setup_mysql/defaults/main.yml
+++ b/tests/integration/targets/setup_mysql/defaults/main.yml
@@ -1,4 +1,4 @@
-dbdeployer_version: 1.56.0
+dbdeployer_version: 1.64.0
 dbdeployer_home_dir: /opt/dbdeployer
 
 home_dir: /root

--- a/tests/integration/targets/setup_mysql/tasks/install.yml
+++ b/tests/integration/targets/setup_mysql/tasks/install.yml
@@ -19,13 +19,6 @@
     state: present
   when: install_type == 'mariadb'
 
-- name: "{{ role_name }} | install | update repository targets when MariaDB"
-  replace:
-    path: /etc/apt/sources.list
-    regexp: eoan
-    replace: focal
-  when: install_type == 'mariadb'
-
 - name: "{{ role_name }} | install | add mariadb repositories"
   apt_repository:
     repo: "deb [arch=amd64,arm64] https://downloads.mariadb.com/MariaDB/mariadb-{{ mysql_major_version }}/repo/ubuntu {{ ansible_lsb.codename }} main"

--- a/tests/integration/targets/setup_mysql/tasks/install.yml
+++ b/tests/integration/targets/setup_mysql/tasks/install.yml
@@ -19,6 +19,13 @@
     state: present
   when: install_type == 'mariadb'
 
+- name: "{{ role_name }} | install | update repository targets when MariaDB"
+  replace:
+    path: /etc/apt/sources.list
+    regexp: eoan
+    replace: focal
+  when: install_type == 'mariadb'
+
 - name: "{{ role_name }} | install | add mariadb repositories"
   apt_repository:
     repo: "deb [arch=amd64,arm64] https://downloads.mariadb.com/MariaDB/mariadb-{{ mysql_major_version }}/repo/ubuntu {{ ansible_lsb.codename }} main"

--- a/tests/integration/targets/setup_mysql/vars/main.yml
+++ b/tests/integration/targets/setup_mysql/vars/main.yml
@@ -15,7 +15,6 @@ python_packages: [pymysql == 0.9.3]
 install_prereqs:
   - libaio1
   - libnuma1
-  - libncurses5
 
 install_python_prereqs:
   - python3-dev

--- a/tests/integration/targets/setup_mysql/vars/main.yml
+++ b/tests/integration/targets/setup_mysql/vars/main.yml
@@ -15,6 +15,7 @@ python_packages: [pymysql == 0.9.3]
 install_prereqs:
   - libaio1
   - libnuma1
+  - libncurses5
 
 install_python_prereqs:
   - python3-dev


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.mysql/issues/229

Enable and fix integration tests for devel.

The Ansible default container some time ago updated ubuntu 18.04 ->  ubuntu 20.04. Unfortunately mariadb does not provide package 10.2 for this distribution, so i changed it to 10.3
- https://downloads.mariadb.com/MariaDB/mariadb-10.2/repo/ubuntu/
- https://downloads.mariadb.com/MariaDB/mariadb-10.3/repo/ubuntu/

