### PR TITLE
mysql_query: fix false change reports when IF NOT EXISTS clause is used

### DIFF
--- a/changelogs/fragments/322-mysql_query_fix_false_change_report.yml
+++ b/changelogs/fragments/322-mysql_query_fix_false_change_report.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_query - fix false change reports when ``IF EXISTS/IF NOT EXISTS`` clause is used (https://github.com/ansible-collections/community.mysql/issues/268).

--- a/plugins/modules/mysql_query.py
+++ b/plugins/modules/mysql_query.py
@@ -22,9 +22,10 @@ options:
     description:
     - SQL query to run. Multiple queries can be passed using YAML list syntax.
     - Must be a string or YAML list containing strings.
-    - Note that if you use the C(IF EXISTS/IF NOT EXISTS) clauses in your query,
-      the module will report that the state has been changed even if it has not
-      when C(mysqlclient) connector is used.
+    - Note that if you use the C(IF EXISTS/IF NOT EXISTS) clauses in your query
+      and C(mysqlclient) connector, the module will report that
+      the state has been changed even if it has not. If it is important in your
+      workflow, use the C(PyMySQL) connector instead.
     type: raw
     required: yes
   positional_args:

--- a/plugins/modules/mysql_query.py
+++ b/plugins/modules/mysql_query.py
@@ -22,6 +22,9 @@ options:
     description:
     - SQL query to run. Multiple queries can be passed using YAML list syntax.
     - Must be a string or YAML list containing strings.
+    - Note that if you use the C(IF EXISTS/IF NOT EXIST) clauses in your query,
+      the module will report that the state has been changed even if it has not
+      when C(mysqlclient) connector is used.
     type: raw
     required: yes
   positional_args:
@@ -211,7 +214,8 @@ def main():
                 except mysql_driver.Warning:
                     # When something is run with IF NOT EXISTS
                     # and there's "already exists" MySQL warning,
-                    # set the flag as True
+                    # set the flag as True.
+                    # PyMySQL throws the warning, mysqlclinet does NOT.
                     already_exists = True
 
         except Exception as e:

--- a/plugins/modules/mysql_query.py
+++ b/plugins/modules/mysql_query.py
@@ -22,7 +22,7 @@ options:
     description:
     - SQL query to run. Multiple queries can be passed using YAML list syntax.
     - Must be a string or YAML list containing strings.
-    - Note that if you use the C(IF EXISTS/IF NOT EXIST) clauses in your query,
+    - Note that if you use the C(IF EXISTS/IF NOT EXISTS) clauses in your query,
       the module will report that the state has been changed even if it has not
       when C(mysqlclient) connector is used.
     type: raw

--- a/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
@@ -321,6 +321,28 @@
       - result is changed
       - result.rowcount == [2]
 
+  # Issue https://github.com/ansible-collections/community.mysql/issues/268
+  - name: Create table
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: "CREATE TABLE issue268 (id int)"
+      single_transaction: yes
+
+  # Issue https://github.com/ansible-collections/community.mysql/issues/268
+  - name: Create table with IF NOT EXISTS
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: "CREATE TABLE IF NOT EXISTS issue268 (id int)"
+      single_transaction: yes
+    register: result
+
+  # Issue https://github.com/ansible-collections/community.mysql/issues/268
+  - assert:
+      that:
+      - result is not changed
+
   - name: Drop db {{ test_db }}
     mysql_query:
       <<: *mysql_params

--- a/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
@@ -341,7 +341,18 @@
   # Issue https://github.com/ansible-collections/community.mysql/issues/268
   - assert:
       that:
+      # PyMySQL driver throws a warning, so the following is correct
       - result is not changed
+    when: connector.name.0 is search('pymysql')
+
+  # Issue https://github.com/ansible-collections/community.mysql/issues/268
+  - assert:
+      that:
+      # mysqlclient driver throws nothing, so it's impossible to figure out
+      # if the state was changed or not.
+      # We assume that it was for DDL queryes by default in the code
+      - result is changed
+    when: connector.name.0 is search('mysqlclient')
 
   - name: Drop db {{ test_db }}
     mysql_query:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.mysql/issues/268

When there's a statement like `create table IF EXISTS ...` it always reports `changed: yes`.

##### ISSUE TYPE
- Bugfix Pull Request