### PR TITLE
mysql_role: remove redundant connection closing (fixes #329)

### DIFF
--- a/changelogs/fragments/329-mysql_role-remove-redudant-connection-closing.yml
+++ b/changelogs/fragments/329-mysql_role-remove-redudant-connection-closing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "mysql_role - remove redundant connection closing (https://github.com/ansible-collections/community.mysql/pull/330)."

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -1057,8 +1057,6 @@ def main():
     except Exception as e:
         module.fail_json(msg=to_native(e))
 
-    # Exit
-    db_conn.close()
     module.exit_json(changed=changed)
 
 


### PR DESCRIPTION
fix #329

the connection is already closed during garbage collection: https://github.com/ansible-collections/community.mysql/blob/main/plugins/module_utils/mysql.py#L113-L116