### PR TITLE
mysql_user, mysql_role: add argument subtract_privs to revoke privileges explicitly

### DIFF
--- a/changelogs/fragments/333-mysql_user-mysql_role-add-subtract_privileges-argument.yml
+++ b/changelogs/fragments/333-mysql_user-mysql_role-add-subtract_privileges-argument.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "mysql_user and mysql_role: Add the argument ``subtract_privs`` (boolean, default false, mutually exclusive with ``append_privs``). If set, the privileges given in ``priv`` are revoked and existing privileges are kept. (https://github.com/ansible-collections/community.mysql/pull/333)"

--- a/changelogs/fragments/333-mysql_user-mysql_role-add-subtract_privileges-argument.yml
+++ b/changelogs/fragments/333-mysql_user-mysql_role-add-subtract_privileges-argument.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "mysql_user and mysql_role: Add the argument ``subtract_privs`` (boolean, default false, mutually exclusive with ``append_privs``). If set, the privileges given in ``priv`` are revoked and existing privileges are kept. (https://github.com/ansible-collections/community.mysql/pull/333)"
+  - "mysql_user and mysql_role: Add the argument ``subtract_privs`` (boolean, default false, mutually exclusive with ``append_privs``). If set, the privileges given in ``priv`` are revoked and existing privileges are kept (https://github.com/ansible-collections/community.mysql/pull/333)."

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -331,6 +331,9 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     # and revoke existing privileges that were not requested.
                     grant_privs = list(set(new_priv[db_table]) - set(curr_priv[db_table]))
                     revoke_privs = list(set(curr_priv[db_table]) - set(new_priv[db_table]))
+                if grant_privs == ['GRANT']:
+                    # add the existing privileges because 'WITH GRANT OPTION' cannot stand alone
+                    grant_privs.extend(curr_priv[db_table])
 
                 if len(grant_privs) + len(revoke_privs) > 0:
                     msg = "Privileges updated"

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -560,7 +560,7 @@ def sort_column_order(statement):
     return '%s(%s)' % (priv_name, ', '.join(columns))
 
 
-def privileges_unpack(priv, mode):
+def privileges_unpack(priv, mode, ensure_usage=True):
     """ Take a privileges string, typically passed as a parameter, and unserialize
     it into a dictionary, the same format as privileges_get() above. We have this
     custom format to avoid using YAML/JSON strings inside YAML playbooks. Example
@@ -606,7 +606,7 @@ def privileges_unpack(priv, mode):
         # Handle cases when there's privs like GRANT SELECT (colA, ...) in privs.
         output[pieces[0]] = normalize_col_grants(output[pieces[0]])
 
-    if '*.*' not in output:
+    if ensure_usage and '*.*' not in output:
         output['*.*'] = ['USAGE']
 
     return output

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -333,7 +333,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     revoke_privs = list(set(curr_priv[db_table]) - set(new_priv[db_table]))
                 if grant_privs == ['GRANT']:
                     # USAGE grants no privileges, it is only needed because 'WITH GRANT OPTION' cannot stand alone
-                    grant_privs.extend('USAGE')
+                    grant_privs.append('USAGE')
 
                 if len(grant_privs) + len(revoke_privs) > 0:
                     msg = "Privileges updated: granted %s, revoked %s" % (grant_privs, revoke_privs)

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -332,8 +332,8 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     grant_privs = list(set(new_priv[db_table]) - set(curr_priv[db_table]))
                     revoke_privs = list(set(curr_priv[db_table]) - set(new_priv[db_table]))
                 if grant_privs == ['GRANT']:
-                    # add the existing privileges because 'WITH GRANT OPTION' cannot stand alone
-                    grant_privs.extend(curr_priv[db_table])
+                    # USAGE grants no privileges, it is only needed because 'WITH GRANT OPTION' cannot stand alone
+                    grant_privs.extend('USAGE')
 
                 if len(grant_privs) + len(revoke_privs) > 0:
                     msg = "Privileges updated: granted %s, revoked %s" % (grant_privs, revoke_privs)

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -336,7 +336,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     grant_privs.extend(curr_priv[db_table])
 
                 if len(grant_privs) + len(revoke_privs) > 0:
-                    msg = "Privileges updated"
+                    msg = "Privileges updated: granted %s, revoked %s" % (grant_privs, revoke_privs)
                     if module.check_mode:
                         return (True, msg)
                     if len(revoke_privs) > 0:

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -60,6 +60,7 @@ options:
       - Revoke the privileges defined by the I(priv) option and keep other existing privileges.
         If set, invalid privileges in I(priv) are ignored.
         Mutually exclusive with I(append_privs).
+    version_added: '3.2.0'
     type: bool
     default: no
 

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -1034,7 +1034,7 @@ def main():
             module.fail_json(msg=to_native(e))
 
         try:
-            priv = privileges_unpack(priv, mode)
+            priv = privileges_unpack(priv, mode, ensure_usage=not subtract_privs)
         except Exception as e:
             module.fail_json(msg='Invalid privileges string: %s' % to_native(e))
 
@@ -1063,6 +1063,8 @@ def main():
     try:
         if state == 'present':
             if not role.exists:
+                if subtract_privs:
+                    priv = None  # avoid granting unwanted privileges
                 changed = role.add(members, priv, module.check_mode, admin,
                                    set_default_role_all)
 

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -58,6 +58,7 @@ options:
   subtract_privs:
     description:
       - Revoke the privileges defined by the I(priv) option and keep other existing privileges.
+        If set, invalid privileges in I(priv) are ignored.
         Mutually exclusive with I(append_privs).
     type: bool
     default: no

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -51,7 +51,14 @@ options:
   append_privs:
     description:
       - Append the privileges defined by the I(priv) option to the existing ones
-        for this role instead of overwriting them.
+        for this role instead of overwriting them. Mutually exclusive with I(subtract_privs).
+    type: bool
+    default: no
+
+  subtract_privs:
+    description:
+      - Revoke the privileges defined by the I(priv) option and keep other existing privileges.
+        Mutually exclusive with I(append_privs).
     type: bool
     default: no
 
@@ -233,6 +240,14 @@ EXAMPLES = r'''
     name: business
     members:
     - marketing
+
+- name: Ensure the role foo does not have the DELETE privilege 
+  community.mysql.mysql_role:
+    state: present
+    name: foo
+    subtract_privs: yes
+    priv:
+      'db1.*': DELETE
 '''
 
 RETURN = '''#'''
@@ -821,9 +836,9 @@ class Role():
         return True
 
     def update(self, users, privs, check_mode=False,
-               append_privs=False, append_members=False,
-               detach_members=False, admin=False,
-               set_default_role_all=True):
+               append_privs=False, subtract_privs=False,
+               append_members=False, detach_members=False,
+               admin=False, set_default_role_all=True):
         """Update a role.
 
         Update a role if needed.
@@ -837,6 +852,8 @@ class Role():
             check_mode (bool): If True, just checks and does nothing.
             append_privs (bool): If True, adds new privileges passed through privs
                 not touching current privileges.
+            subtract_privs (bool): If True, revoke the privileges passed through privs
+                not touching other existing privileges.
             append_members (bool): If True, adds new members passed through users
                 not touching current members.
             detach_members (bool): If True, removes members passed through users from a role.
@@ -861,7 +878,7 @@ class Role():
         if privs:
             changed, msg = user_mod(self.cursor, self.name, self.host,
                                     None, None, None, None, None, None,
-                                    privs, append_privs, None,
+                                    privs, append_privs, subtract_privs, None,
                                     self.module, role=True, maria_role=self.is_mariadb)
 
         if admin:
@@ -931,6 +948,7 @@ def main():
         admin=dict(type='str'),
         priv=dict(type='raw'),
         append_privs=dict(type='bool', default=False),
+        subtract_privs=dict(type='bool', default=False),
         members=dict(type='list', elements='str'),
         append_members=dict(type='bool', default=False),
         detach_members=dict(type='bool', default=False),
@@ -945,6 +963,7 @@ def main():
             ('admin', 'members'),
             ('admin', 'append_members'),
             ('admin', 'detach_members'),
+            ('append_privs', 'subtract_privs'),
         ),
     )
 
@@ -958,6 +977,7 @@ def main():
     connect_timeout = module.params['connect_timeout']
     config_file = module.params['config_file']
     append_privs = module.params['append_privs']
+    subtract_privs = module.boolean(module.params['subtract_privs'])
     members = module.params['members']
     append_members = module.params['append_members']
     detach_members = module.params['detach_members']
@@ -1047,7 +1067,7 @@ def main():
                                    set_default_role_all)
 
             else:
-                changed = role.update(members, priv, module.check_mode, append_privs,
+                changed = role.update(members, priv, module.check_mode, append_privs, subtract_privs,
                                       append_members, detach_members, admin,
                                       set_default_role_all)
 

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -242,7 +242,7 @@ EXAMPLES = r'''
     members:
     - marketing
 
-- name: Ensure the role foo does not have the DELETE privilege 
+- name: Ensure the role foo does not have the DELETE privilege
   community.mysql.mysql_role:
     state: present
     name: foo

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -71,6 +71,7 @@ options:
       - Revoke the privileges defined by the I(priv) option and keep other existing privileges.
         If set, invalid privileges in I(priv) are ignored.
         Mutually exclusive with I(append_privs).
+    version_added: '3.2.0'
     type: bool
     default: no
   tls_requires:

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -69,6 +69,7 @@ options:
   subtract_privs:
     description:
       - Revoke the privileges defined by the I(priv) option and keep other existing privileges.
+        If set, invalid privileges in I(priv) are ignored.
         Mutually exclusive with I(append_privs).
     type: bool
     default: no

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -443,7 +443,7 @@ def main():
             mode = get_mode(cursor)
         except Exception as e:
             module.fail_json(msg=to_native(e))
-        priv = privileges_unpack(priv, mode)
+        priv = privileges_unpack(priv, mode, ensure_usage=not subtract_privs)
 
     if state == "present":
         if user_exists(cursor, user, host, host_all):
@@ -463,6 +463,8 @@ def main():
             if host_all:
                 module.fail_json(msg="host_all parameter cannot be used when adding a user")
             try:
+                if subtract_privs:
+                    priv = None  # avoid granting unwanted privileges
                 changed = user_add(cursor, user, host, host_all, password, encrypted,
                                    plugin, plugin_hash_string, plugin_auth_string,
                                    priv, tls_requires, module.check_mode)

--- a/tests/integration/targets/test_mysql_role/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_role/defaults/main.yml
@@ -14,3 +14,4 @@ nonexistent: user3
 
 role0: role0
 role1: role1
+role2: role2

--- a/tests/integration/targets/test_mysql_role/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/main.yml
@@ -3,6 +3,11 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 
+- name: alias mysql command to include default options
+  set_fact:
+    mysql_command: "mysql -u{{ mysql_user }} -p{{ mysql_password }} -P{{ mysql_primary_port }} --protocol=tcp"
+
+
 # mysql_role module initial CI tests
 - import_tasks: mysql_role_initial.yml
 

--- a/tests/integration/targets/test_mysql_role/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/main.yml
@@ -5,3 +5,8 @@
 
 # mysql_role module initial CI tests
 - import_tasks: mysql_role_initial.yml
+
+# Test that subtract_privs will only revoke the grants given by priv
+# (https://github.com/ansible-collections/community.mysql/issues/331)
+- include: test_priv_subtract.yml enable_check_mode=no
+- include: test_priv_subtract.yml enable_check_mode=yes

--- a/tests/integration/targets/test_mysql_role/tasks/test_priv_subtract.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/test_priv_subtract.yml
@@ -139,10 +139,17 @@
       command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ role2 }}'\""
       register: result
 
-    - name: Assert that the permissions stayed the same
+    - name: Assert that the permissions stayed the same, with check_mode=='yes'
+      assert:
+        that:
+          - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
+      when: enable_check_mode == 'yes'
+
+    - name: Assert that the permissions stayed the same, with check_mode=='no'
       assert:
         that:
           - "'GRANT SELECT ON `data1`.*' in result.stdout"
+      when: enable_check_mode == 'no'
 
     ##########
     # Clean up

--- a/tests/integration/targets/test_mysql_role/tasks/test_priv_subtract.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/test_priv_subtract.yml
@@ -75,17 +75,17 @@
       command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ role2 }}'\""
       register: result
 
-    - name: Assert that the permissions were not changed if check_mode is set to 'no'
+    - name: Assert that the permissions were not changed if check_mode is set to 'yes'
       assert:
         that:
           - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
-      when: enable_check_mode == 'no'
+      when: enable_check_mode == 'yes'
 
-    - name: Assert that only DELETE was revoked if check_mode is set to 'yes'
+    - name: Assert that only DELETE was revoked if check_mode is set to 'no'
       assert:
         that:
           - "'GRANT SELECT ON `data1`.*' in result.stdout"
-      when: enable_check_mode == 'yes'
+      when: enable_check_mode == 'no'
 
     - name: Try to subtract invalid privileges
       mysql_role:

--- a/tests/integration/targets/test_mysql_role/tasks/test_priv_subtract.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/test_priv_subtract.yml
@@ -1,0 +1,148 @@
+# Test code to ensure that subtracting privileges will not result in unnecessary changes.
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    - name: Create test databases
+      mysql_db:
+        <<: *mysql_params
+        name: '{{ item }}'
+        state: present
+      loop:
+        - data1
+
+    - name: Create a role with an initial set of privileges
+      mysql_role:
+        <<: *mysql_params
+        name: '{{ role2 }}'
+        priv: 'data1.*:SELECT,INSERT'
+        state: present
+
+    - name: Run command to show privileges for role (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ role2 }}'\""
+      register: result
+
+    - name: Assert that the initial set of privileges matches what is expected
+      assert:
+        that:
+          - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
+
+    - name: Subtract privileges that are not in the current privileges, which should be a no-op
+      mysql_role:
+        <<: *mysql_params
+        name: '{{ role2 }}'
+        priv: 'data1.*:DELETE'
+        subtract_privs: yes
+        state: present
+      check_mode: '{{ enable_check_mode }}'
+      register: result
+
+    - name: Assert that there wasn't a change in permissions
+      assert:
+        that:
+          - "result.changed == false"
+
+    - name: Run command to show privileges for role (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ role2 }}'\""
+      register: result
+
+    - name: Assert that the permissions still match what was originally granted
+      assert:
+        that:
+          - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
+
+    - name: Subtract existing and not-existing privileges, but not all
+      mysql_role:
+        <<: *mysql_params
+        name: '{{ role2 }}'
+        priv: 'data1.*:INSERT,DELETE'
+        subtract_privs: yes
+        state: present
+      check_mode: '{{ enable_check_mode }}'
+      register: result
+
+    - name: Assert that there was a change because permissions were/would be revoked on data1.*
+      assert:
+        that:
+          - "result.changed == true"
+
+    - name: Run command to show privileges for role (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ role2 }}'\""
+      register: result
+
+    - name: Assert that the permissions were not changed if check_mode is set to 'no'
+      assert:
+        that:
+          - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
+      when: enable_check_mode == 'no'
+
+    - name: Assert that only DELETE was revoked if check_mode is set to 'yes'
+      assert:
+        that:
+          - "'GRANT SELECT ON `data1`.*' in result.stdout"
+      when: enable_check_mode == 'yes'
+
+    - name: Try to subtract invalid privileges
+      mysql_role:
+        <<: *mysql_params
+        name: '{{ role2 }}'
+        priv: 'data1.*:INVALID'
+        subtract_privs: yes
+        state: present
+      check_mode: '{{ enable_check_mode }}'
+      register: result
+      ignore_errors: true
+
+    - name: Assert that there wasn't a change in privileges if check_mode is set to 'no'
+      assert:
+        that:
+          - result is failed
+          - "'Error granting privileges' in result.msg"
+      when: enable_check_mode == 'no'
+
+    - name: trigger failure by trying to subtract and append privileges at the same time
+      mysql_role:
+        <<: *mysql_params
+        name: '{{ role2 }}'
+        priv: 'data1.*:SELECT'
+        subtract_privs: yes
+        append_privs: yes
+        state: present
+      check_mode: '{{ enable_check_mode }}'
+      register: result
+      ignore_errors: true
+
+    - name: Assert the previous execution failed
+      assert:
+        that:
+          - result is failed
+
+    - name: Run command to show privileges for role (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ role2 }}'\""
+      register: result
+
+    - name: Assert that the permissions stayed the same
+      assert:
+        that:
+          - "'GRANT SELECT ON `data1`.*' in result.stdout"
+
+    ##########
+    # Clean up
+    - name: Drop test databases
+      mysql_db:
+        <<: *mysql_params
+        name: '{{ item }}'
+        state: present
+      loop:
+        - data1
+
+    - name: Drop test role
+      mysql_role:
+        <<: *mysql_params
+        name: '{{ role2 }}'
+        state: absent

--- a/tests/integration/targets/test_mysql_role/tasks/test_priv_subtract.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/test_priv_subtract.yml
@@ -96,13 +96,26 @@
         state: present
       check_mode: '{{ enable_check_mode }}'
       register: result
-      ignore_errors: true
 
-    - name: Assert that there wasn't a change in privileges if check_mode is set to 'no'
+    - name: Assert that there was no change because invalid permissions are ignored
       assert:
         that:
-          - result is failed
-          - "'Error granting privileges' in result.msg"
+          - "result.changed == false"
+
+    - name: Run command to show privileges for role (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ role2 }}'\""
+      register: result
+
+    - name: Assert that the permissions were not changed with check_mode=='yes'
+      assert:
+        that:
+          - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
+      when: enable_check_mode == 'yes'
+
+    - name: Assert that the permissions were not changed with check_mode=='no'
+      assert:
+        that:
+          - "'GRANT SELECT ON `data1`.*' in result.stdout"
       when: enable_check_mode == 'no'
 
     - name: trigger failure by trying to subtract and append privileges at the same time

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -274,6 +274,11 @@
     - include: test_priv_append.yml enable_check_mode=no
     - include: test_priv_append.yml enable_check_mode=yes
 
+    # Test that subtract_privs will only revoke the grants given by priv
+    # (https://github.com/ansible-collections/community.mysql/issues/331)
+    - include: test_priv_subtract.yml enable_check_mode=no
+    - include: test_priv_subtract.yml enable_check_mode=yes
+
     # Tests for the TLS requires dictionary
     - include: tls_requirements.yml
 

--- a/tests/integration/targets/test_mysql_user/tasks/test_priv_subtract.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_priv_subtract.yml
@@ -78,17 +78,17 @@
       command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ user_name_4 }}'@'localhost'\""
       register: result
 
-    - name: Assert that the permissions were not changed if check_mode is set to 'no'
+    - name: Assert that the permissions were not changed if check_mode is set to 'yes'
       assert:
         that:
           - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
-      when: enable_check_mode == 'no'
+      when: enable_check_mode == 'yes'
 
-    - name: Assert that only DELETE was revoked if check_mode is set to 'yes'
+    - name: Assert that only DELETE was revoked if check_mode is set to 'no'
       assert:
         that:
           - "'GRANT SELECT ON `data1`.*' in result.stdout"
-      when: enable_check_mode == 'yes'
+      when: enable_check_mode == 'no'
 
     - name: Try to subtract invalid privileges
       mysql_user:

--- a/tests/integration/targets/test_mysql_user/tasks/test_priv_subtract.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_priv_subtract.yml
@@ -144,10 +144,17 @@
       command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ user_name_4 }}'@'localhost'\""
       register: result
 
-    - name: Assert that the permissions stayed the same
+    - name: Assert that the permissions stayed the same, with check_mode=='yes'
+      assert:
+        that:
+          - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
+      when: enable_check_mode == 'yes'
+
+    - name: Assert that the permissions stayed the same, with check_mode=='no'
       assert:
         that:
           - "'GRANT SELECT ON `data1`.*' in result.stdout"
+      when: enable_check_mode == 'no'
 
     ##########
     # Clean up

--- a/tests/integration/targets/test_mysql_user/tasks/test_priv_subtract.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_priv_subtract.yml
@@ -100,13 +100,26 @@
         state: present
       check_mode: '{{ enable_check_mode }}'
       register: result
-      ignore_errors: true
 
-    - name: Assert that there wasn't a change in privileges if check_mode is set to 'no'
+    - name: Assert that there was no change because invalid permissions are ignored
       assert:
         that:
-          - result is failed
-          - "'Error granting privileges' in result.msg"
+          - "result.changed == false"
+
+    - name: Run command to show privileges for user (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ user_name_4 }}'@'localhost'\""
+      register: result
+
+    - name: Assert that the permissions were not changed with check_mode=='yes'
+      assert:
+        that:
+          - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
+      when: enable_check_mode == 'yes'
+
+    - name: Assert that the permissions were not changed with check_mode=='no'
+      assert:
+        that:
+          - "'GRANT SELECT ON `data1`.*' in result.stdout"
       when: enable_check_mode == 'no'
 
     - name: trigger failure by trying to subtract and append privileges at the same time

--- a/tests/integration/targets/test_mysql_user/tasks/test_priv_subtract.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_priv_subtract.yml
@@ -1,0 +1,153 @@
+# Test code to ensure that subtracting privileges will not result in unnecessary changes.
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    - name: Create test databases
+      mysql_db:
+        <<: *mysql_params
+        name: '{{ item }}'
+        state: present
+      loop:
+      - data1
+
+    - name: Create a user with an initial set of privileges
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_4 }}'
+        password: '{{ user_password_4 }}'
+        priv: 'data1.*:SELECT,INSERT'
+        state: present
+
+    - name: Run command to show privileges for user (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ user_name_4 }}'@'localhost'\""
+      register: result
+
+    - name: Assert that the initial set of privileges matches what is expected
+      assert:
+        that:
+          - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
+
+    - name: Subtract privileges that are not in the current privileges, which should be a no-op
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_4 }}'
+        password: '{{ user_password_4 }}'
+        priv: 'data1.*:DELETE'
+        subtract_privs: yes
+        state: present
+      check_mode: '{{ enable_check_mode }}'
+      register: result
+
+    - name: Assert that there wasn't a change in permissions
+      assert:
+        that:
+          - "result.changed == false"
+
+    - name: Run command to show privileges for user (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ user_name_4 }}'@'localhost'\""
+      register: result
+
+    - name: Assert that the permissions still match what was originally granted
+      assert:
+        that:
+          - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
+
+    - name: Subtract existing and not-existing privileges, but not all
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_4 }}'
+        password: '{{ user_password_4 }}'
+        priv: 'data1.*:INSERT,DELETE'
+        subtract_privs: yes
+        state: present
+      check_mode: '{{ enable_check_mode }}'
+      register: result
+
+    - name: Assert that there was a change because permissions were/would be revoked on data1.*
+      assert:
+        that:
+          - "result.changed == true"
+
+    - name: Run command to show privileges for user (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ user_name_4 }}'@'localhost'\""
+      register: result
+
+    - name: Assert that the permissions were not changed if check_mode is set to 'no'
+      assert:
+        that:
+          - "'GRANT SELECT, INSERT ON `data1`.*' in result.stdout"
+      when: enable_check_mode == 'no'
+
+    - name: Assert that only DELETE was revoked if check_mode is set to 'yes'
+      assert:
+        that:
+          - "'GRANT SELECT ON `data1`.*' in result.stdout"
+      when: enable_check_mode == 'yes'
+
+    - name: Try to subtract invalid privileges
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_4 }}'
+        password: '{{ user_password_4 }}'
+        priv: 'data1.*:INVALID'
+        subtract_privs: yes
+        state: present
+      check_mode: '{{ enable_check_mode }}'
+      register: result
+      ignore_errors: true
+
+    - name: Assert that there wasn't a change in privileges if check_mode is set to 'no'
+      assert:
+        that:
+          - result is failed
+          - "'Error granting privileges' in result.msg"
+      when: enable_check_mode == 'no'
+
+    - name: trigger failure by trying to subtract and append privileges at the same time
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_4 }}'
+        password: '{{ user_password_4 }}'
+        priv: 'data1.*:SELECT'
+        subtract_privs: yes
+        append_privs: yes
+        state: present
+      check_mode: '{{ enable_check_mode }}'
+      register: result
+      ignore_errors: true
+
+    - name: Assert the previous execution failed
+      assert:
+        that:
+          - result is failed
+
+    - name: Run command to show privileges for user (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ user_name_4 }}'@'localhost'\""
+      register: result
+
+    - name: Assert that the permissions stayed the same
+      assert:
+        that:
+          - "'GRANT SELECT ON `data1`.*' in result.stdout"
+
+    ##########
+    # Clean up
+    - name: Drop test databases
+      mysql_db:
+        <<: *mysql_params
+        name: '{{ item }}'
+        state: present
+      loop:
+      - data1
+
+    - name: Drop test user
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_4 }}'
+        state: absent

--- a/tests/integration/targets/test_mysql_user/tasks/test_privs.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_privs.yml
@@ -173,7 +173,7 @@
         state: present
       register: result
 
-    # FIXME: on mariadb 10.5 there's always a change
+    # FIXME: on mariadb >=10.5.2 there's always a change because the REPLICATION CLIENT privilege was renamed to BINLOG MONITOR
     - name: Assert that priv did not change
       assert:
         that:


### PR DESCRIPTION
##### SUMMARY
fixes #331

Add an argument `subtract_privs` (boolean, default false, mutual conflict with `append_privs`) to mysql_user and mysql_role. If true, the privileges specified by the `priv` argument get revoked and unspecified privileges remain unchanged.

##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
mysql_user and mysql_role
