### PR TITLE
mysql_replication: fix failing when using primary_use_gtid with replica_ or slave_pos

### DIFF
--- a/changelogs/fragments/0-mysql_replication_replica_pos.yml
+++ b/changelogs/fragments/0-mysql_replication_replica_pos.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_replication - fails when using the `primary_use_gtid` option with `slave_pos` or `replica_pos` (https://github.com/ansible-collections/community.mysql/issues/335).

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -532,6 +532,8 @@ def main():
         replica_term = 'REPLICA'
     else:
         replica_term = 'SLAVE'
+        if primary_use_gtid == 'replica_pos':
+            primary_use_gtid = 'slave_pos'
 
     if mode == 'getprimary':
         status = get_primary_status(cursor)

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -75,6 +75,7 @@
         <<: *mysql_params
         login_port: '{{ mysql_replica1_port }}'
         mode: startreplica
+        primary_use_gtid: replica_pos
         fail_on_error: yes
       register: result
       ignore_errors: yes


### PR DESCRIPTION


##### SUMMARY
Fixes https://github.com/ansible-collections/community.mysql/issues/335

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/mysql_replication.py