### PR TITLE
mysql_user: added flush privileges to write dynamic privs into db

### DIFF
--- a/changelogs/fragments/338-mysql_user_fix_missing_dynamic_privileges.yml
+++ b/changelogs/fragments/338-mysql_user_fix_missing_dynamic_privileges.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "mysql_user: fix missing dynamic privileges after revoke and grant privileges to user (https://github.com/ansible-collections/community.mysql/issues/120)."
+  - "mysql_user - fix missing dynamic privileges after revoke and grant privileges to user (https://github.com/ansible-collections/community.mysql/issues/120)."

--- a/changelogs/fragments/338-mysql_user_fix_missing_dynamic_privileges.yml
+++ b/changelogs/fragments/338-mysql_user_fix_missing_dynamic_privileges.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "mysql_user: fix missing dynamic privileges after revoke and grant privileges to user (https://github.com/ansible-collections/community.mysql/issues/120)."

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -625,6 +625,7 @@ def privileges_revoke(cursor, user, host, db_table, priv, grant_option, maria_ro
 
     query = ' '.join(query)
     cursor.execute(query, params)
+    cursor.execute("FLUSH PRIVILEGES")
 
 
 def privileges_grant(cursor, user, host, db_table, priv, tls_requires, maria_role=False):


### PR DESCRIPTION
Fixes https://github.com/ansible-collections/community.mysql/issues/120

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added Flush Privileges after the revoke all privileges to write consitent the dynamic privileges which are required for cluster creation

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- mysql_user.py
- user.py
- privileges_revoke function

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Without this fix a user with all privileges is only on every second run allowed to create a cluster or replicaset on the host.
Mysqlsh with dba.checkInstanceConfiguration() is failing because these rights are missing:
 `CLONE_ADMIN, CONNECTION_ADMIN, GROUP_REPLICATION_ADMIN, PERSIST_RO_VARIABLES_ADMIN, REPLICATION_APPLIER, REPLICATION_SLAVE_ADMIN, ROLE_ADMIN, SYSTEM_VARIABLES_ADMIN`
After a new run with `priv: "*.*:ALL,GRANT"` the dba.checkInstanceConfiguration() check is successfull.
More Details could be found in the issue #120 
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

