### PR TITLE
mysql_user: fix parsing privs when a user has roles assigned to it 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /tests/output/
 /changelogs/.plugin-cache.yaml
+*.swp
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/changelogs/fragments/001-mysql_user_fix_pars_users_with_roles_assigned.yml
+++ b/changelogs/fragments/001-mysql_user_fix_pars_users_with_roles_assigned.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_user - fix parsing privs when a user has roles assigned (https://github.com/ansible-collections/community.mysql/issues/231).

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -417,7 +417,7 @@ def privileges_get(cursor, user, host, maria_role=False):
             res = re.match("""GRANT (.+) ON (.+) TO (['`"]).*\\3""", grant[0])
 
         if res is None:
-            # If a user have roles assigned, we'll have one of priv tuples looking like
+            # If a user has roles assigned, we'll have one of priv tuples looking like
             # GRANT `admin`@`%` TO `user1`@`localhost`
             # which will result None as res value.
             # As we use the mysql_role module to manipulate roles

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -415,8 +415,19 @@ def privileges_get(cursor, user, host, maria_role=False):
             res = re.match("""GRANT (.+) ON (.+) TO (['`"]).*\\3@(['`"]).*\\4( IDENTIFIED BY PASSWORD (['`"]).+\\6)? ?(.*)""", grant[0])
         else:
             res = re.match("""GRANT (.+) ON (.+) TO (['`"]).*\\3""", grant[0])
+
         if res is None:
+            # If a user have roles assigned, we'll have one of priv tuples looking like
+            # GRANT `admin`@`%` TO `user1`@`localhost`
+            # which will result None as res value.
+            # As we use the mysql_role module to manipulate roles
+            # we just ignore such privs below:
+            res = re.match("""GRANT (.+) TO (['`"]).*""", grant[0])
+            if not maria_role and res:
+                continue
+
             raise InvalidPrivsError('unable to parse the MySQL grant string: %s' % grant[0])
+
         privileges = res.group(1).split(",")
         privileges = [pick(x.strip()) for x in privileges]
 

--- a/tests/integration/targets/test_mysql_role/tasks/mysql_role_initial.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/mysql_role_initial.yml
@@ -1540,3 +1540,24 @@
     - '{{ test_db }}'
     - '{{ test_db1 }}'
     - '{{ test_db2 }}'
+
+  - name: Drop users
+    <<: *task_params
+    mysql_user:
+      <<: *mysql_params
+      name: '{{ item }}'
+      state: absent
+    loop:
+    - '{{ user0 }}'
+    - '{{ user1 }}'
+    - '{{ user2 }}'
+
+  - name: Drop roles
+    <<: *task_params
+    mysql_role:
+      <<: *mysql_params
+      name: '{{ item }}'
+      state: absent
+    loop:
+    - '{{ role0 }}'
+    - test

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -288,3 +288,6 @@
     # Test that mysql_user still works with force_context enabled (database set to "mysql")
     # (https://github.com/ansible-collections/community.mysql/issues/265)
     - include: issue-265.yml
+
+    # https://github.com/ansible-collections/community.mysql/issues/231
+    - include: test_user_grants_with_roles_applied.yml

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_grants_with_roles_applied.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_grants_with_roles_applied.yml
@@ -1,0 +1,97 @@
+# https://github.com/ansible-collections/community.mysql/issues/231
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+    - name: Get server version
+      mysql_info:
+        <<: *mysql_params
+      register: srv
+
+    # Skip unsupported versions
+    - meta: end_play
+      when: srv['version']['major'] < 8
+
+    - name: Create test databases
+      mysql_db:
+        <<: *mysql_params
+        name: '{{ item }}'
+        state: present
+      loop:
+      - data1
+      - data2
+      - data3
+
+    - name: Create user with privileges
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_3 }}'
+        password: '{{ user_password_3 }}'
+        priv:
+          "data1.*": "SELECT"
+          "data2.*": "SELECT"
+        state: present
+
+    - name: Run command to show privileges for user (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ user_name_3 }}'@'localhost'\""
+      register: result
+
+    - name: Assert user has giving privileges
+      assert:
+        that:
+          - "'GRANT SELECT ON `data1`.*' in result.stdout"
+          - "'GRANT SELECT ON `data2`.*' in result.stdout"
+
+    - name: Create role
+      mysql_role:
+        <<: *mysql_params
+        name: test
+        members:
+        - '{{ user_name_3 }}@localhost'
+
+    - name: Try to change privs
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_3 }}'
+        priv:
+          "data1.*": "INSERT"
+          "data2.*": "INSERT"
+        state: present
+
+    - name: Run command to show privileges for user (expect privileges in stdout)
+      command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ user_name_3 }}'@'localhost'\""
+      register: result
+
+    - name: Assert user has giving privileges
+      assert:
+        that:
+          - "'GRANT INSERT ON `data1`.*' in result.stdout"
+          - "'GRANT INSERT ON `data2`.*' in result.stdout"
+
+    ##########
+    # Clean up
+    - name: Drop test databases
+      mysql_db:
+        <<: *mysql_params
+        name: '{{ item }}'
+        state: present
+      loop:
+      - data1
+      - data2
+      - data3
+
+    - name: Drop test user
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_3 }}'
+        state: absent
+
+    - name: Drop test role
+      mysql_role:
+        <<: *mysql_params
+        name: test
+        state: absent

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_grants_with_roles_applied.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_grants_with_roles_applied.yml
@@ -24,7 +24,6 @@
       loop:
       - data1
       - data2
-      - data3
 
     - name: Create user with privileges
       mysql_user:
@@ -49,7 +48,7 @@
     - name: Create role
       mysql_role:
         <<: *mysql_params
-        name: test
+        name: test231
         members:
         - '{{ user_name_3 }}@localhost'
 
@@ -82,7 +81,6 @@
       loop:
       - data1
       - data2
-      - data3
 
     - name: Drop test user
       mysql_user:
@@ -93,5 +91,5 @@
     - name: Drop test role
       mysql_role:
         <<: *mysql_params
-        name: test
+        name: test231
         state: absent


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.mysql/issues/231

In essence, i think we can ignore the second priv tuple because we use mysql_role module to manipulate roles:
```
+----------------------------------------------------+
| Grants for user1@localhost                         |
+----------------------------------------------------+
| GRANT USAGE ON *.* TO `user1`@`localhost`          |
| GRANT `admin`@`%` TO `user1`@`localhost`           |
+----------------------------------------------------+
```

##### ISSUE TYPE
- Bugfix Pull Request