### PR TITLE
[stable-2] Drop support for Ansible 2.9 and ansible-base 2.10 (#343)

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -25,8 +25,6 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.9
-          - stable-2.10
           - stable-2.11
           - stable-2.12
           - stable-2.13
@@ -60,8 +58,6 @@ jobs:
           - 5.7.31
           - 8.0.22
         ansible:
-          - stable-2.9
-          - stable-2.10
           - stable-2.11
           - stable-2.12
           - stable-2.13
@@ -76,10 +72,6 @@ jobs:
         exclude:
           - mysql: 8.0.22
             connector: pymysql==0.7.10
-          - python: 3.8
-            ansible: stable-2.9
-          - python: 3.8
-            ansible: stable-2.10
           - python: 3.8
             ansible: stable-2.11
           - python: 3.6
@@ -131,8 +123,6 @@ jobs:
       fail-fast: true
       matrix:
         ansible:
-          - stable-2.9
-          - stable-2.10
           - stable-2.11
           - stable-2.12
           - stable-2.13

--- a/.github/workflows/ansible-test-roles.yml
+++ b/.github/workflows/ansible-test-roles.yml
@@ -23,8 +23,6 @@ jobs:
         mysql:
           - 2.0.12
         ansible:
-          - stable-2.9
-          - stable-2.10
           - stable-2.11
           - stable-2.12
           - stable-2.13
@@ -33,10 +31,6 @@ jobs:
           - 3.6
           - 3.8
         exclude:
-          - python: 3.8
-            ansible: stable-2.9
-          - python: 3.8
-            ansible: stable-2.10
           - python: 3.8
             ansible: stable-2.11
           - python: 3.6

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ Every voice is important and every idea is valuable. If you have something on yo
   - [mysql_user](https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_user_module.html)
   - [mysql_variables](https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_variables_module.html)
 
-## Tested with Ansible
+## Tested with
 
-- 2.9
-- 2.10
+### ansible-core
+
 - 2.11
 - 2.12
 - 2.13
-- devel
+- current development version
 
 ### Databases
 

--- a/changelogs/fragments/drop_support_of_2.9-2.10.yml
+++ b/changelogs/fragments/drop_support_of_2.9-2.10.yml
@@ -1,0 +1,2 @@
+major_changes:
+- The community.mysql collection no longer supports ``Ansible 2.9`` and ``ansible-base 2.10``. While we take no active measures to prevent usage and there are no plans to introduce incompatible code to the modules, we will stop testing against ``Ansible 2.9`` and ``ansible-base 2.10``. Both will very soon be End of Life and if you are still using them, you should consider upgrading to the ``latest Ansible / ansible-core 2.11 or later`` as soon as possible (https://github.com/ansible-collections/community.mysql/pull/343).

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -8,7 +8,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-# Once we drop support for Ansible 2.9, ansible-base 2.10, and ansible-core 2.11, we can
+# Once we drop support for ansible-core 2.11, we can
 # remove the _version.py file, and replace the following import by
 #
 #     from ansible.module_utils.compat.version import LooseVersion


### PR DESCRIPTION
* Drop support for Ansible 2.9 and ansible-base 2.10

* Improve README

(cherry picked from commit eff87f952bf8adb543bd77eedf7ecd518054f2ca)

##### SUMMARY
Backport of https://github.com/ansible-collections/community.mysql/pull/343