### PR TITLE
mysql_user: add "update_password: on_new_username" argument, "password_changed" result field

### DIFF
--- a/changelogs/fragments/365-mysql_user-add-on_new_username-and-password_changed.yml
+++ b/changelogs/fragments/365-mysql_user-add-on_new_username-and-password_changed.yml
@@ -1,0 +1,10 @@
+minor_changes:
+  - >
+    mysql_user: Add the option "on_new_username" to argument "update_password" to reuse the password (plugin and
+    authentication_string) when creating a new user if some user with the same name already exist.
+    If the existing users with the same name have varying passwords, the password from the arguments is used like with
+    "update_password: always". See (https://github.com/ansible-collections/community.mysql/pull/365).
+  - >
+    mysql_user: Add the result field "password_changed" (boolean). It is true, when the user got a new password.
+    When the user was created with "update_password: on_new_username" and an existing password was reused,
+    "password_changed" is false. See (https://github.com/ansible-collections/community.mysql/pull/365).

--- a/changelogs/fragments/365-mysql_user-add-on_new_username-and-password_changed.yml
+++ b/changelogs/fragments/365-mysql_user-add-on_new_username-and-password_changed.yml
@@ -2,7 +2,7 @@ minor_changes:
   - >
     mysql_user: Add the option "on_new_username" to argument "update_password" to reuse the password (plugin and
     authentication_string) when creating a new user if some user with the same name already exists.
-    If the existing users with the same name have varying passwords, the password from the arguments is used like with
+    If the existing user with the same name have varying passwords, the password from the arguments is used like with
     "update_password: always". See (https://github.com/ansible-collections/community.mysql/pull/365).
   - >
     mysql_user: Add the result field "password_changed" (boolean). It is true, when the user got a new password.

--- a/changelogs/fragments/365-mysql_user-add-on_new_username-and-password_changed.yml
+++ b/changelogs/fragments/365-mysql_user-add-on_new_username-and-password_changed.yml
@@ -1,7 +1,7 @@
 minor_changes:
   - >
     mysql_user: Add the option "on_new_username" to argument "update_password" to reuse the password (plugin and
-    authentication_string) when creating a new user if some user with the same name already exist.
+    authentication_string) when creating a new user if some user with the same name already exists.
     If the existing users with the same name have varying passwords, the password from the arguments is used like with
     "update_password: always". See (https://github.com/ansible-collections/community.mysql/pull/365).
   - >

--- a/changelogs/fragments/365-mysql_user-add-on_new_username-and-password_changed.yml
+++ b/changelogs/fragments/365-mysql_user-add-on_new_username-and-password_changed.yml
@@ -7,4 +7,4 @@ minor_changes:
   - >
     mysql_user - Add the result field ``password_changed`` (boolean). It is true, when the user got a new password.
     When the user was created with ``update_password: on_new_username`` and an existing password was reused,
-    "password_changed" is false (https://github.com/ansible-collections/community.mysql/pull/365).
+    ``password_changed`` is false (https://github.com/ansible-collections/community.mysql/pull/365).

--- a/changelogs/fragments/365-mysql_user-add-on_new_username-and-password_changed.yml
+++ b/changelogs/fragments/365-mysql_user-add-on_new_username-and-password_changed.yml
@@ -1,10 +1,10 @@
 minor_changes:
   - >
-    mysql_user: Add the option "on_new_username" to argument "update_password" to reuse the password (plugin and
+    mysql_user - Add the option ``on_new_username`` to argument ``update_password`` to reuse the password (plugin and
     authentication_string) when creating a new user if some user with the same name already exists.
     If the existing user with the same name have varying passwords, the password from the arguments is used like with
-    "update_password: always". See (https://github.com/ansible-collections/community.mysql/pull/365).
+    ``update_password: always`` (https://github.com/ansible-collections/community.mysql/pull/365).
   - >
-    mysql_user: Add the result field "password_changed" (boolean). It is true, when the user got a new password.
-    When the user was created with "update_password: on_new_username" and an existing password was reused,
-    "password_changed" is false. See (https://github.com/ansible-collections/community.mysql/pull/365).
+    mysql_user - Add the result field ``password_changed`` (boolean). It is true, when the user got a new password.
+    When the user was created with ``update_password: on_new_username`` and an existing password was reused,
+    "password_changed" is false (https://github.com/ansible-collections/community.mysql/pull/365).

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -121,11 +121,11 @@ def get_existing_authentication(cursor, user):
         cursor.execute("""select plugin, auth from (
             select plugin, password as auth from mysql.user where user=%(user)s
             union select plugin, authentication_string as auth from mysql.user where user=%(user)s
-            ) x group by plugin, auth
+            ) x group by plugin, auth limit 2
         """, {'user': user})
     else:
         cursor.execute("""select plugin, authentication_string as auth from mysql.user where user=%(user)s
-            group by plugin, authentication_string""", {'user': user})
+            group by plugin, authentication_string limit 2""", {'user': user})
     rows = cursor.fetchall()
     if len(rows) == 1:
         return {'plugin': rows[0][0], 'auth_string': rows[0][1]}

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -911,10 +911,11 @@ class Role():
                                                       set_default_role_all=set_default_role_all)
 
         if privs:
-            changed, msg = user_mod(self.cursor, self.name, self.host,
+            result = user_mod(self.cursor, self.name, self.host,
                                     None, None, None, None, None, None,
                                     privs, append_privs, subtract_privs, None,
                                     self.module, role=True, maria_role=self.is_mariadb)
+            changed = result['changed']
 
         if admin:
             self.role_impl.set_admin(admin)

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -912,9 +912,9 @@ class Role():
 
         if privs:
             result = user_mod(self.cursor, self.name, self.host,
-                                    None, None, None, None, None, None,
-                                    privs, append_privs, subtract_privs, None,
-                                    self.module, role=True, maria_role=self.is_mariadb)
+                              None, None, None, None, None, None,
+                              privs, append_privs, subtract_privs, None,
+                              self.module, role=True, maria_role=self.is_mariadb)
             changed = result['changed']
 
         if admin:

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -119,9 +119,9 @@ options:
       - C(always) will update passwords if they differ. This affects I(password) and the combination of I(plugin), I(plugin_hash_string), I(plugin_auth_string).
       - C(on_create) will only set the password or the combination of plugin, plugin_hash_string, plugin_auth_string for newly created users.
       - "C(on_new_username) works like C(on_create), but it tries to reuse an existing password: If one different user
-        with the same username exists, or multiple different users with the same username and equal ``plugin`` and
-        ``authentication_string`` attribute, the existing ``plugin`` and ``authentication_string`` are used for the
-        new user instead of the C(password), I(plugin), I(plugin_hash_string) or I(plugin_auth_string) argument."
+        with the same username exists, or multiple different users with the same username and equal C(plugin) and
+        C(authentication_string) attribute, the existing C(plugin) and C(authentication_string) are used for the
+        new user instead of the I(password), I(plugin), I(plugin_hash_string) or I(plugin_auth_string) argument."
     type: str
     choices: [ always, on_create, on_new_username ]
     default: always

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -457,13 +457,13 @@ def main():
             try:
                 if update_password == "always":
                     result = user_mod(cursor, user, host, host_all, password, encrypted,
-                                            plugin, plugin_hash_string, plugin_auth_string,
-                                            priv, append_privs, subtract_privs, tls_requires, module)
+                                      plugin, plugin_hash_string, plugin_auth_string,
+                                      priv, append_privs, subtract_privs, tls_requires, module)
 
                 else:
                     result = user_mod(cursor, user, host, host_all, None, encrypted,
-                                            None, None, None,
-                                            priv, append_privs, subtract_privs, tls_requires, module)
+                                      None, None, None,
+                                      priv, append_privs, subtract_privs, tls_requires, module)
                 changed = result['changed']
                 msg = result['msg']
                 password_changed = result['password_changed']
@@ -478,8 +478,8 @@ def main():
                     priv = None  # avoid granting unwanted privileges
                 reuse_existing_password = update_password == 'on_new_username'
                 result = user_add(cursor, user, host, host_all, password, encrypted,
-                                   plugin, plugin_hash_string, plugin_auth_string,
-                                   priv, tls_requires, module.check_mode, reuse_existing_password)
+                                  plugin, plugin_hash_string, plugin_auth_string,
+                                  priv, tls_requires, module.check_mode, reuse_existing_password)
                 changed = result['changed']
                 password_changed = result['password_changed']
                 if changed:

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -118,8 +118,12 @@ options:
     description:
       - C(always) will update passwords if they differ. This affects I(password) and the combination of I(plugin), I(plugin_hash_string), I(plugin_auth_string).
       - C(on_create) will only set the password or the combination of plugin, plugin_hash_string, plugin_auth_string for newly created users.
+      - "C(on_new_username) works like C(on_create), but it tries to reuse an existing password: If one different user
+        with the same username exists, or multiple different users with the same username and equal ``plugin`` and
+        ``authentication_string`` attribute, the existing ``plugin`` and ``authentication_string`` are used for the
+        new user instead of the C(password), I(plugin), I(plugin_hash_string) or I(plugin_auth_string) argument."
     type: str
-    choices: [ always, on_create ]
+    choices: [ always, on_create, on_new_username ]
     default: always
   plugin:
     description:

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -370,7 +370,7 @@ def main():
         append_privs=dict(type='bool', default=False),
         subtract_privs=dict(type='bool', default=False),
         check_implicit_admin=dict(type='bool', default=False),
-        update_password=dict(type='str', default='always', choices=['always', 'on_create'], no_log=False),
+        update_password=dict(type='str', default='always', choices=['always', 'on_create', 'on_new_username'], no_log=False),
         sql_log_bin=dict(type='bool', default=True),
         plugin=dict(default=None, type='str'),
         plugin_hash_string=dict(default=None, type='str'),
@@ -468,9 +468,10 @@ def main():
             try:
                 if subtract_privs:
                     priv = None  # avoid granting unwanted privileges
+                reuse_existing_password = update_password == 'on_new_username'
                 changed = user_add(cursor, user, host, host_all, password, encrypted,
                                    plugin, plugin_hash_string, plugin_auth_string,
-                                   priv, tls_requires, module.check_mode)
+                                   priv, tls_requires, module.check_mode, reuse_existing_password)
                 if changed:
                     msg = "User added"
 

--- a/tests/integration/targets/test_mysql_user/tasks/assert_user_password.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/assert_user_password.yml
@@ -1,0 +1,24 @@
+- name: "applying user {{ username }}@{{ host }} with update_password={{ update_password }}"
+  mysql_user:
+    login_user: '{{ mysql_parameters.login_user }}'
+    login_password: '{{ mysql_parameters.login_password }}'
+    login_host: '{{ mysql_parameters.login_host }}'
+    login_port: '{{ mysql_parameters.login_port }}'
+    state: present
+    name: "{{ username }}"
+    host: "{{ host }}"
+    password: "{{ password }}"
+    update_password: "{{ update_password }}"
+  register: result
+- name: assert a change occurred
+  assert:
+    that:
+      - "result.changed == {{ expect_change }}"
+      - "result.password_changed == {{ expect_password_change }}"
+- name: query the user
+  command: "{{ mysql_command }} -BNe \"SELECT plugin, authentication_string FROM mysql.user where user='{{ username }}' and host='{{ host }}'\""
+  register: existing_user
+- name: assert the password is as set to expect_hash
+  assert:
+    that:
+      - "'mysql_native_password\t{{ expect_password_hash }}' in existing_user.stdout_lines"

--- a/tests/integration/targets/test_mysql_user/tasks/test_update_password.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_update_password.yml
@@ -1,0 +1,128 @@
+# Tests scenarios for both plaintext and encrypted user passwords.
+
+- vars:
+    mysql_parameters:
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+    test_password1: kbB9tcx5WOGVGfzV
+    test_password1_hash: '*AF6A7F9D038475C17EE46564F154104877EE5037'
+    test_password2: XBYjpHmjIctMxl1y
+    test_password2_hash: '*9E22D1B35C68BDDF398B8F28AE482E5A865BAC0A'
+    test_password3: tem33JfR5Yx98BB
+    test_password3_hash: '*C7E7C2710702F20336F8D93BC0670C8FB66BDBC7'
+
+
+  block:
+    - include_tasks: assert_user_password.yml
+      vars:
+        username: "{{ item.username }}"
+        host: '127.0.0.1'
+        update_password: "{{ item.update_password }}"
+        password: "{{ test_password1 }}"
+        expect_change: "{{ item.expect_change }}"
+        expect_password_change: "{{ item.expect_change }}"
+        expect_password_hash: "{{ test_password1_hash }}"
+      loop:
+        # all variants set the password when nothing exists
+        - username: test1
+          update_password: always
+          expect_change: true
+        - username: test2
+          update_password: on_create
+          expect_change: true
+        - username: test3
+          update_password: on_new_username
+          expect_change: true
+
+        # assert idempotency
+        - username: test1
+          update_password: always
+          expect_change: false
+        - username: test2
+          update_password: on_create
+          expect_change: false
+        - username: test3
+          update_password: on_new_username
+          expect_change: false
+
+    # same user, new password
+    - include_tasks: assert_user_password.yml
+      vars:
+        username: "{{ item.username }}"
+        host: '127.0.0.1'
+        update_password: "{{ item.update_password }}"
+        password: "{{ test_password2 }}"
+        expect_change: "{{ item.expect_change }}"
+        expect_password_change: "{{ item.expect_change }}"
+        expect_password_hash: "{{ item.expect_password_hash }}"
+      loop:
+        - username: test1
+          update_password: always
+          expect_change: true
+          expect_password_hash: "{{ test_password2_hash }}"
+        - username: test2
+          update_password: on_create
+          expect_change: false
+          expect_password_hash: "{{ test_password1_hash }}"
+        - username: test3
+          update_password: on_new_username
+          expect_change: false
+          expect_password_hash: "{{ test_password1_hash }}"
+
+    # new user, new password
+    - include_tasks: assert_user_password.yml
+      vars:
+        username: "{{ item.username }}"
+        host: '::1'
+        update_password: "{{ item.update_password }}"
+        password: "{{ item.password }}"
+        expect_change: "{{ item.expect_change }}"
+        expect_password_change: "{{ item.expect_password_change }}"
+        expect_password_hash: "{{ item.expect_password_hash }}"
+      loop:
+        - username: test1
+          update_password: always
+          expect_change: true
+          expect_password_change: true
+          password: "{{ test_password1 }}"
+          expect_password_hash: "{{ test_password1_hash }}"
+        - username: test2
+          update_password: on_create
+          expect_change: true
+          expect_password_change: true
+          password: "{{ test_password2 }}"
+          expect_password_hash: "{{ test_password2_hash }}"
+        - username: test3
+          update_password: on_new_username
+          expect_change: true
+          expect_password_change: false
+          password: "{{ test_password2 }}"
+          expect_password_hash: "{{ test_password1_hash }}"
+
+        # prepare for next test: ensure all users have varying passwords
+        - username: test3
+          update_password: always
+          expect_change: true
+          expect_password_change: true
+          password: "{{ test_password2 }}"
+          expect_password_hash: "{{ test_password2_hash }}"
+
+    # another new user, another new password and multiple existing users with varying passwords
+    - include_tasks: assert_user_password.yml
+      vars:
+        username: "{{ item.username }}"
+        host: '2001:db8::1'
+        update_password: "{{ item.update_password }}"
+        password: "{{ test_password3 }}"
+        expect_change: true
+        expect_password_change: true
+        expect_password_hash: "{{ test_password3_hash }}"
+      loop:
+        - username: test1
+          update_password: always
+        - username: test2
+          update_password: on_create
+        - username: test3
+          update_password: on_new_username


### PR DESCRIPTION
##### SUMMARY
fixes #344

- Add value `on_new_username` to `update_password` argument of module mysql_user.
- Add result field `password_changed` boolean to module mysql_user.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module mysql_user

##### ADDITIONAL INFORMATION

When `update_password: on_new_username` is set, reuse the password (plugin and authentication_string) when creating a new user if some user with the same name already exist. If the existing users with the same name have varying passwords, the password from the arguments is used like with `update_password: always`.

The result field `password_changed` is true, when the user got a new password. When the user was created with `update_password: on_new_username` and an existing password was reused, `password_changed` is false.