### PR TITLE
mysql_role: don't add members to a role when creating the role and "detach_members: true" is set

### DIFF
--- a/changelogs/fragments/367-mysql_role-fix-deatch-members.yml
+++ b/changelogs/fragments/367-mysql_role-fix-deatch-members.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "mysql_role: don't add members to a role when creating the role and \"detach_members: true\" is set"

--- a/changelogs/fragments/367-mysql_role-fix-deatch-members.yml
+++ b/changelogs/fragments/367-mysql_role-fix-deatch-members.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "mysql_role: don't add members to a role when creating the role and \"detach_members: true\" is set"
+  - "mysql_role - don't add members to a role when creating the role and ``detach_members: true`` is set (https://github.com/ansible-collections/community.mysql/pull/367)."

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -1067,6 +1067,8 @@ def main():
             if not role.exists:
                 if subtract_privs:
                     priv = None  # avoid granting unwanted privileges
+                if detach_members:
+                    members = None  # avoid adding unwanted members
                 changed = role.add(members, priv, module.check_mode, admin,
                                    set_default_role_all)
 

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -128,6 +128,7 @@ seealso:
 
 author:
   - Andrew Klychkov (@Andersson007)
+  - Felix Hamme (@betanummeric)
 
 extends_documentation_fragment:
   - community.mysql.mysql

--- a/tests/integration/targets/test_mysql_role/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_role/defaults/main.yml
@@ -15,3 +15,4 @@ nonexistent: user3
 role0: role0
 role1: role1
 role2: role2
+role3: role3

--- a/tests/integration/targets/test_mysql_role/tasks/mysql_role_initial.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/mysql_role_initial.yml
@@ -1248,6 +1248,32 @@
       that:
       - result is not changed
 
+  - name: '"detach" users when creating a new role'
+    <<: *task_params
+    mysql_role:
+      <<: *mysql_params
+      name: '{{ role3 }}'
+      state: present
+      detach_members: yes
+      members:
+        - '{{ user1 }}@localhost'
+
+  - name: Check the role was created
+    assert:
+      that:
+        - result is changed
+
+  - name: Check grants
+    <<: *task_params
+    mysql_query:
+      <<: *mysql_params
+      query: "SHOW GRANTS FOR {{ user1 }}@localhost"
+
+  - name: asssert detach_members did not add a user to the role
+    assert:
+      that:
+        - "'{{ role3 }}' not in result.query_result.0.0['Grants for {{ user1 }}@localhost']"
+
   # ##########
   # Test privs
   # ##########
@@ -1561,3 +1587,4 @@
     loop:
     - '{{ role0 }}'
     - test
+    - '{{ role3 }}'


### PR DESCRIPTION
BUGFIX: fixes #366 (the "adding unwanted members" part)

##### SUMMARY

In the *mysql_role* module, if the argument `detach_members` is true, the role should be revoked from the users specified in the `members` argument (if necessary). This PR fixes this behavior for when the role does not exist and is created (avoid granting the role to the users).