### PR TITLE
mysql_role: add argument "members_must_exist"

### DIFF
--- a/changelogs/fragments/369_mysql_role-add-members_must_exist.yml
+++ b/changelogs/fragments/369_mysql_role-add-members_must_exist.yml
@@ -1,5 +1,4 @@
 minor_changes:
   - >
-    mysql_role: Add the argument "members_must_exist" (boolean, default true). The assertion that the users supplied in
-    the "members" argument exist is only executed when the new argument "members_must_exist" is true, to allow opt-out.
-    See (https://github.com/ansible-collections/community.mysql/pull/369).
+    mysql_role - add the argument ``members_must_exist`` (boolean, default true). The assertion that the users supplied in
+    the ``members`` argument exist is only executed when the new argument ``members_must_exist`` is ``true``, to allow opt-out (https://github.com/ansible-collections/community.mysql/pull/369).

--- a/changelogs/fragments/369_mysql_role-add-members_must_exist.yml
+++ b/changelogs/fragments/369_mysql_role-add-members_must_exist.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - >
+    mysql_role: Add the argument "members_must_exist" (boolean, default true). The assertion that the users supplied in
+    the "members" argument exist is only executed when the new argument "members_must_exist" is true, to allow opt-out.
+    See (https://github.com/ansible-collections/community.mysql/pull/369).

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -389,6 +389,11 @@ class DbServer():
                 msg = 'User / role `%s` with host `%s` does not exist' % (user[0], user[1])
                 self.module.fail_json(msg=msg)
 
+    def filter_existing_users(self, users):
+        for user in users:
+            if user in self.users:
+                yield user
+
     def __get_users(self):
         """Get users.
 
@@ -1028,8 +1033,10 @@ def main():
 
     if members:
         members = normalize_users(module, members, server.is_mariadb())
-        if members_must_exist and not detach_members:
+        if members_must_exist:
             server.check_users_in_db(members)
+        else:
+            members = list(server.filter_existing_users(members))
 
     # Main job starts here
     role = Role(module, cursor, name, server)

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -116,8 +116,8 @@ options:
 
   members_must_exist:
     description:
-      - When C(yes), the module fails if any user in C(members) does not exist.
-      - When C(no), users in C(members) which don't exist are simply skipped.
+      - When C(yes), the module fails if any user in I(members) does not exist.
+      - When C(no), users in I(members) which don't exist are simply skipped.
     type: bool
     default: yes
 

--- a/tests/integration/targets/test_mysql_role/tasks/mysql_role_initial.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/mysql_role_initial.yml
@@ -1274,6 +1274,71 @@
       that:
         - "'{{ role3 }}' not in result.query_result.0.0['Grants for {{ user1 }}@localhost']"
 
+  # test members_must_exist
+  - name: try failing on not-existing user in check-mode
+    <<: *task_params
+    mysql_role:
+      <<: *mysql_params
+      name: '{{ role0 }}'
+      state: present
+      members_must_exist: yes
+      append_members: yes
+      members:
+        - 'not_existent@localhost'
+    ignore_errors: yes
+    check_mode: yes
+  - name: assert failure
+    assert:
+      that:
+        - result is failed
+
+  - name: try failing on not-existing user in check-mode
+    <<: *task_params
+    mysql_role:
+      <<: *mysql_params
+      name: '{{ role0 }}'
+      state: present
+      members_must_exist: no
+      append_members: yes
+      members:
+        - 'not_existent@localhost'
+    check_mode: yes
+  - name: Check for lack of change
+    assert:
+      that:
+        - result is not changed
+
+  - name: try failing on not-existing user
+    <<: *task_params
+    mysql_role:
+      <<: *mysql_params
+      name: '{{ role0 }}'
+      state: present
+      members_must_exist: yes
+      append_members: yes
+      members:
+        - 'not_existent@localhost'
+    ignore_errors: yes
+  - name: assert failure
+    assert:
+      that:
+        - result is failed
+
+  - name: try failing on not-existing user
+    <<: *task_params
+    mysql_role:
+      <<: *mysql_params
+      name: '{{ role0 }}'
+      state: present
+      members_must_exist: no
+      append_members: yes
+      members:
+        - 'not_existent@localhost'
+  - name: Check for lack of change
+    assert:
+      that:
+        - result is not changed
+
   # ##########
   # Test privs
   # ##########


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mysql_role

##### SUMMARY
Add a new argument "members_must_exist" (boolean, default true).

The assertion that the users supplied in the "members" argument exist is only executed when the new argument "members_must_exist" is true, to allow opt-out.

fixes #366 (the "raising too much errors" part)