### PR TITLE
mysql_role: add examples for "members_must_exist" argument

### DIFF
--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -258,6 +258,26 @@ EXAMPLES = r'''
     subtract_privs: yes
     priv:
       'db1.*': DELETE
+
+- name: add some members to a role and skip not-existent users
+    community.mysql.mysql_role:
+    state: present
+    name: foo
+    append_members: yes
+    members_must_exist: no
+    members:
+    - 'existing_user@localhost'
+    - 'not_existing_user@localhost'
+
+- name: detach some members from a role and ignore not-existent users
+    community.mysql.mysql_role:
+    state: present
+    name: foo
+    detach_members: yes
+    members_must_exist: no
+    members:
+    - 'existing_user@localhost'
+    - 'not_existing_user@localhost'
 '''
 
 RETURN = '''#'''

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -259,7 +259,7 @@ EXAMPLES = r'''
     priv:
       'db1.*': DELETE
 
-- name: add some members to a role and skip not-existent users
+- name: Add some members to a role and skip not-existent users
   community.mysql.mysql_role:
     state: present
     name: foo

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -260,7 +260,7 @@ EXAMPLES = r'''
       'db1.*': DELETE
 
 - name: add some members to a role and skip not-existent users
-    community.mysql.mysql_role:
+  community.mysql.mysql_role:
     state: present
     name: foo
     append_members: yes
@@ -270,7 +270,7 @@ EXAMPLES = r'''
     - 'not_existing_user@localhost'
 
 - name: detach some members from a role and ignore not-existent users
-    community.mysql.mysql_role:
+  community.mysql.mysql_role:
     state: present
     name: foo
     detach_members: yes

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -269,7 +269,7 @@ EXAMPLES = r'''
     - 'existing_user@localhost'
     - 'not_existing_user@localhost'
 
-- name: detach some members from a role and ignore not-existent users
+- name: Detach some members from a role and ignore not-existent users
   community.mysql.mysql_role:
     state: present
     name: foo


### PR DESCRIPTION
### mysql_role
add documentation for the `members_must_exist` argument

see PR #369, issue #366 