### PR TITLE
Changed += to append because cmd is a list

### DIFF
--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -442,7 +442,7 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
             cmd.append("--defaults-extra-file=%s" % shlex_quote(config_file))
 
     if check_implicit_admin:
-        cmd += " --user=root --password=''"
+        cmd.append("--user=root --password=''")
     else:
         if user:
             cmd.append("--user=%s" % shlex_quote(user))


### PR DESCRIPTION
##### SUMMARY
Using += on a list cause some problems during creation of mysql command

##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
community.myslq
##### ADDITIONAL INFORMATION
`cmd` variables is a list, so you should append new parameters by using append method instead of += operator

Problem appears when `check_implicit_admin` options is enabled during import operation. This leads to generate not valid mysql command:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
/usr/bin/mysql   - - u s e r = r o o t   - - p a s s w o r d = ' ' --socket=/run/mysqld/mysqld.sock
```
After applying this fix mysql command is generated correctly:
```
/usr/bin/mysql  --user=root --password='' --socket=/run/mysqld/mysqld.sock
```