### PR TITLE
mysql_db: add chdir argument

### DIFF
--- a/changelogs/fragments/0-mysql_db_add_chdir_argument.yml
+++ b/changelogs/fragments/0-mysql_db_add_chdir_argument.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_db - add the ``chdir`` argument to avoid failings when a dump file contains relative paths (https://github.com/ansible-collections/community.mysql/issues/395).

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -150,6 +150,12 @@ options:
     type: bool
     default: no
     version_added: '0.1.0'
+  chdir:
+    description:
+    - Changes the current working directory.
+    - Can be useful, for example, when I(state=import) and a dump file contains relative paths.
+    type: path
+    version_added: '3.4.0'
 
 seealso:
 - module: community.mysql.mysql_info
@@ -562,6 +568,7 @@ def main():
         restrict_config_file=dict(type='bool', default=False),
         check_implicit_admin=dict(type='bool', default=False),
         config_overrides_defaults=dict(type='bool', default=False),
+        chdir=dict(type='path'),
     )
 
     module = AnsibleModule(
@@ -610,6 +617,13 @@ def main():
     restrict_config_file = module.params["restrict_config_file"]
     check_implicit_admin = module.params['check_implicit_admin']
     config_overrides_defaults = module.params['config_overrides_defaults']
+    chdir = module.params['chdir']
+
+    if chdir:
+        try:
+            os.chdir(chdir)
+        except Exception as e:
+            module.fail_json("Cannot change the current directory to %s: %s" % (chdir, e))
 
     if len(db) > 1 and state == 'import':
         module.fail_json(msg="Multiple databases are not supported with state=import")

--- a/tests/integration/targets/test_mysql_db/tasks/state_dump_import.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/state_dump_import.yml
@@ -416,6 +416,51 @@
     that:
       - result is changed
 
+########################
+# Test import with chdir
+
+- name: Create dir
+  file:
+    path: ~/subdir
+    state: directory
+
+- name: Create test dump
+  shell: 'echo "SOURCE ./subdir_test.sql" > ~/original_test.sql'
+
+- name: Create test source
+  shell: 'echo "SELECT 1" > ~/subdir/subdir_test.sql'
+
+- name: Try to restore without chdir argument, must fail
+  mysql_db:
+    login_user: '{{ mysql_user }}'
+    login_password: '{{ mysql_password }}'
+    login_host: 127.0.0.1
+    login_port: '{{ mysql_primary_port }}'
+    name: '{{ db_name }}'
+    state: import
+    target: '~/original_test.sql'
+  ignore_errors: yes
+  register: result
+- assert:
+    that:
+    - result is failed
+    - result.msg is search('Failed to open file')
+
+- name: Restore with chdir argument, must pass
+  mysql_db:
+    login_user: '{{ mysql_user }}'
+    login_password: '{{ mysql_password }}'
+    login_host: 127.0.0.1
+    login_port: '{{ mysql_primary_port }}'
+    name: '{{ db_name }}'
+    state: import
+    target: '~/original_test.sql'
+    chdir: ~/subdir
+  register: result
+- assert:
+    that:
+    - result is succeeded
+
 ##########
 # Clean up
 ##########


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible-collections/community.mysql/issues/395

Add the ``chdir`` argument to avoid failings when a dump file contains relative paths

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mysql_db