### PR TITLE
Note added regarding the default config file, ~/.my.cnf

### DIFF
--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -98,4 +98,9 @@ notes:
    - Alternatively, you can use the mysqlclient library instead of MySQL-python (MySQLdb)
      which supports both Python 2.X and Python >=3.5.
      See U(https://pypi.org/project/mysqlclient/) how to install it.
+   - The config file, C(~/.my.cnf), if it exists, must contain a C([client]) section as a MySQL connector requirement.
+   - The default config file, C(~/.my.cnf) will be read, if it exists, even if I(config_file) is not specified.
+   - To prevent the default config file from being read, set I(config_file) to be an empty string.
+   - If credentials from the config file (for example, C(/root/.my.cnf)) are not needed to connect to a database server but
+     the file exists and does not contain a C([client]) section, it will be read and will cause the connection to fail.
 '''

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -101,7 +101,7 @@ notes:
    - Alternatively, you can use the mysqlclient library instead of MySQL-python (MySQLdb)
      which supports both Python 2.X and Python >=3.5.
      See U(https://pypi.org/project/mysqlclient/) how to install it.
-   - If credentials from the config file (for example, C(/root/.my.cnf)) are not needed to connect to a database server, but
+   - "If credentials from the config file (for example, C(/root/.my.cnf)) are not needed to connect to a database server, but
      the file exists and does not contain a C([client]) section, before any other valid directives, it will be read and this
-     will cause the connection to fail, to prevent this set it to an empty string, (for example C(config_file: '')).
+     will cause the connection to fail, to prevent this set it to an empty string, (for example C(config_file: ''))."
 '''

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -44,6 +44,9 @@ options:
   config_file:
     description:
       - Specify a config file from which user and password are to be read.
+      - The default config file, C(~/.my.cnf), if it exists, will be read, even if I(config_file) is not specified.
+      - The default config file, C(~/.my.cnf), if it exists, must contain a C([client]) section as a MySQL connector requirement.
+      - To prevent the default config file from being read, set I(config_file) to be an empty string.
     type: path
     default: '~/.my.cnf'
   ca_cert:
@@ -98,9 +101,7 @@ notes:
    - Alternatively, you can use the mysqlclient library instead of MySQL-python (MySQLdb)
      which supports both Python 2.X and Python >=3.5.
      See U(https://pypi.org/project/mysqlclient/) how to install it.
-   - The config file, C(~/.my.cnf), if it exists, must contain a C([client]) section as a MySQL connector requirement.
-   - The default config file, C(~/.my.cnf) will be read, if it exists, even if I(config_file) is not specified.
-   - To prevent the default config file from being read, set I(config_file) to be an empty string.
-   - If credentials from the config file (for example, C(/root/.my.cnf)) are not needed to connect to a database server but
-     the file exists and does not contain a C([client]) section, it will be read and will cause the connection to fail.
+   - If credentials from the config file (for example, C(/root/.my.cnf)) are not needed to connect to a database server, but
+     the file exists and does not contain a C([client]) section, before any other valid directives, it will be read and this
+     will cause the connection to fail, to prevent this set it to an empty string, (for example C(config_file: '')).
 '''


### PR DESCRIPTION
Update the notes to reflect the module behaviour regarding `~/.my.cnf` files that don't contain `[client]` section.