### PR TITLE
Fix mysqldump ignoring errors

### DIFF
--- a/changelogs/fragments/fix-256-mysql_dump-errors.yml
+++ b/changelogs/fragments/fix-256-mysql_dump-errors.yml
@@ -4,4 +4,4 @@ bugfixes:
   - mysql_dump - Fixes issue 256. Using compression masks errors messages from
     mysql_dump. By default the fix is inactiv to ensure retro-compatibility
     with system without bash. To activate the fix, use the module option
-    `pipefail=true`.
+    ``pipefail=true`` (https://github.com/ansible-collections/community.mysql/issues/256).

--- a/changelogs/fragments/fix-256-mysql_dump-errors.yml
+++ b/changelogs/fragments/fix-256-mysql_dump-errors.yml
@@ -1,0 +1,7 @@
+---
+
+bugfixes:
+  - mysql_dump - Fixes issue 256. Using compression masks errors messages from
+    mysql_dump. By default the fix is inactiv to ensure retro-compatibility
+    with system without bash. To activate the fix, use the module option
+    `pipefail=true`.

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -156,6 +156,14 @@ options:
     - Can be useful, for example, when I(state=import) and a dump file contains relative paths.
     type: path
     version_added: '3.4.0'
+  pipefail:
+    description:
+    - Use bash instead of sh and add -o pipefail to catch errors from the
+      mysql_dump command when compression is used. The default is false to
+      prevent issue on system without bash. The default may change in a future release
+    type: bool
+    default: no
+    version_added: '3.3.1'
 
 seealso:
 - module: community.mysql.mysql_info
@@ -355,7 +363,7 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
             single_transaction=None, quick=None, ignore_tables=None, hex_blob=None,
             encoding=None, force=False, master_data=0, skip_lock_tables=False,
             dump_extra_args=None, unsafe_password=False, restrict_config_file=False,
-            check_implicit_admin=False):
+            check_implicit_admin=False, pipefail=False):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option
     if config_file:
@@ -422,13 +430,20 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
     elif os.path.splitext(target)[-1] == '.xz':
         path = module.get_bin_path('xz', True)
 
-    if path:
+    if pipefail:
         cmd = 'set -o pipefail && %s | %s > %s' % (cmd, path, shlex_quote(target))
+    elif path:
+        cmd = '%s | %s > %s' % (cmd, path, shlex_quote(target))
     else:
         cmd += " > %s" % shlex_quote(target)
 
     executed_commands.append(cmd)
-    rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True, executable='bash')
+
+    if pipefail:
+      rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True, executable='bash')
+    else:
+      rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
+
     return rc, stdout, stderr
 
 
@@ -569,6 +584,7 @@ def main():
         check_implicit_admin=dict(type='bool', default=False),
         config_overrides_defaults=dict(type='bool', default=False),
         chdir=dict(type='path'),
+        pipefail=dict(type='bool', default=False),
     )
 
     module = AnsibleModule(
@@ -618,6 +634,7 @@ def main():
     check_implicit_admin = module.params['check_implicit_admin']
     config_overrides_defaults = module.params['config_overrides_defaults']
     chdir = module.params['chdir']
+    pipefail = module.params['pipefail']
 
     if chdir:
         try:
@@ -704,7 +721,7 @@ def main():
                                      ssl_ca, single_transaction, quick, ignore_tables,
                                      hex_blob, encoding, force, master_data, skip_lock_tables,
                                      dump_extra_args, unsafe_login_password, restrict_config_file,
-                                     check_implicit_admin)
+                                     check_implicit_admin, pipefail)
         if rc != 0:
             module.fail_json(msg="%s" % stderr)
         module.exit_json(changed=True, db=db_name, db_list=db, msg=stdout,

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -430,7 +430,7 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
     elif os.path.splitext(target)[-1] == '.xz':
         path = module.get_bin_path('xz', True)
 
-    if pipefail:
+    if pipefail and path:
         cmd = 'set -o pipefail && %s | %s > %s' % (cmd, path, shlex_quote(target))
     elif path:
         cmd = '%s | %s > %s' % (cmd, path, shlex_quote(target))

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -423,12 +423,12 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
         path = module.get_bin_path('xz', True)
 
     if path:
-        cmd = '%s | %s > %s' % (cmd, path, shlex_quote(target))
+        cmd = 'set -o pipefail && %s | %s > %s' % (cmd, path, shlex_quote(target))
     else:
         cmd += " > %s" % shlex_quote(target)
 
     executed_commands.append(cmd)
-    rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
+    rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True, executable='bash')
     return rc, stdout, stderr
 
 

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -437,10 +437,10 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
     elif os.path.splitext(target)[-1] == '.xz':
         path = module.get_bin_path('xz', True)
 
-    if pipefail and path:
-        cmd = 'set -o pipefail && %s | %s > %s' % (cmd, path, shlex_quote(target))
-    elif path:
+    if path:
         cmd = '%s | %s > %s' % (cmd, path, shlex_quote(target))
+        if pipefail:
+            cmd = 'set -o pipefail && ' + cmd
     else:
         cmd += " > %s" % shlex_quote(target)
 

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -440,9 +440,9 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
     executed_commands.append(cmd)
 
     if pipefail:
-      rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True, executable='bash')
+        rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True, executable='bash')
     else:
-      rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
+        rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
 
     return rc, stdout, stderr
 

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -159,11 +159,11 @@ options:
   pipefail:
     description:
     - Use C(bash) instead of C(sh) and add C(-o pipefail) to catch errors from the
-      mysql_dump command when compression is used. The default is false to
-      prevent issue on system without bash. The default may change in a future release
+      mysql_dump command when I(state=import) and compression is used. The default is I(false) to
+      prevent issue on system without bash. The default may change in a future release.
     type: bool
     default: no
-    version_added: '3.3.1'
+    version_added: '3.4.0'
 
 seealso:
 - module: community.mysql.mysql_info

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -303,6 +303,13 @@ EXAMPLES = r'''
     login_password: 123456
     name: bobdata
     state: present
+
+- name: Dump a database with compression and catch errors from mysqldump with bash pipefail
+  community.mysql.mysql_db:
+    state: dump
+    name: foo
+    target: /tmp/dump.sql.gz
+    pipefail: true
 '''
 
 RETURN = r'''

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -158,7 +158,7 @@ options:
     version_added: '3.4.0'
   pipefail:
     description:
-    - Use bash instead of sh and add -o pipefail to catch errors from the
+    - Use C(bash) instead of C(sh) and add C(-o pipefail) to catch errors from the
       mysql_dump command when compression is used. The default is false to
       prevent issue on system without bash. The default may change in a future release
     type: bool

--- a/tests/integration/targets/setup_mysql/vars/main.yml
+++ b/tests/integration/targets/setup_mysql/vars/main.yml
@@ -19,6 +19,7 @@ install_prereqs:
 
 install_python_prereqs:
   - python3-dev
+  - python3-cryptography
   - default-libmysqlclient-dev
   - build-essential
 

--- a/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
@@ -1,0 +1,28 @@
+---
+
+# When mysqldump encountered an issue, mysql_db was still happy. But the
+# dump produced was empty or worse, only contained `DROP TABLE IF EXISTS...`
+
+- module_defaults:
+    ansible.builtin.mysql_db: &mysql_defaults
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+    ansible.builtin.mysql_query: *mysql_defaults
+
+  block:
+
+    - name: Setup test - Create 2 schemas
+      community.mysql.mysql_db:
+        name:
+          - "db1"
+          - "db2"
+        state: present
+
+    - name: Setup test - Create 2 tables
+      community.mysql.mysql_query:
+        query:
+          - "CREATE TABLE db1.t1 (id int)"
+          - "CREATE TABLE db1.t2 (id int)"
+          - "CREATE VIEW db2.v1 AS SELECT id from db1.t1"

--- a/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
@@ -97,11 +97,11 @@
         that:
           - full_dump_without_t1 is failed
           - full_dump_without_t1.msg is search(
-              "View 'db2.v1' references invalid table(s)")
+              'references invalid table')
           - full_dump_without_t1_gz_without_fix is changed
           - full_dump_without_t1_gz_with_fix is failed
           - full_dump_without_t1_gz_with_fix.msg is search(
-              "View 'db2.v1' references invalid table(s)")
+              'references invalid table')
 
     - name: Dumps errors | Distinct dump after drop t1 without compression
       community.mysql.mysql_db:
@@ -128,17 +128,16 @@
       register: dump_db2_without_t1_gz_with_fix
       ignore_errors: true
 
-    - name: Dumps errors | Check full dump
+    - name: Dumps errors | Check distinct dump
       ansible.builtin.assert:
         that:
           - dump_db2_without_t1 is failed
           - dump_db2_without_t1.msg is search(
-              "View 'db2.v1' references invalid table(s)")
+              'references invalid table')
           - dump_db2_without_t1_gz_without_fix is changed
           - dump_db2_without_t1_gz_with_fix is failed
           - dump_db2_without_t1_gz_with_fix.msg is search(
-              "View 'db2.v1' references invalid table(s)")
-
+              'references invalid table')
     - name: Dumps errors | Cleanup
       community.mysql.mysql_db:
         name:

--- a/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
@@ -41,11 +41,25 @@
         target: /tmp/full-dump.sql.gz
       register: full_dump_gz
 
-    - name: Check dumps errors | Check full dumps are changed
+    - name: Check dumps errors | Distinct dump without compression
+      community.mysql.mysql_db:
+        state: dump
+        name: db2
+        target: /tmp/dump-db2.sql
+      register: dump_db2
+
+    - name: Check dumps errors | Distinct dump with gunzip
+      community.mysql.mysql_db:
+        state: dump
+        name: db2
+        target: /tmp/dump-db2.sql.gz
+      register: dump_db2_gz
+
+    - name: Check dumps errors | Check distinct dumps are changed
       ansible.builtin.assert:
         that:
-          - full_dump is changed
-          - full_dump_gz is changed
+          - dump_db2 is changed
+          - dump_db2_gz is changed
 
     # Now db2.v1 targets an inexistant table so mysqldump will fail
     - name: Check dumps errors | Drop t1
@@ -74,3 +88,25 @@
         that:
           - full_dump_without_t1 is failed
           - full_dump_without_t1_gz is failed
+
+    - name: Check dumps errors | Distinct dump after drop t1 without compression
+      community.mysql.mysql_db:
+        state: dump
+        name: db2
+        target: /tmp/dump-db2-without_t1.sql
+      register: dump_db2_without_t1
+      ignore_errors: true
+
+    - name: Check dumps errors | Distinct dump after drop t1 with gzip
+      community.mysql.mysql_db:
+        state: dump
+        name: db2
+        target: /tmp/dump-db2-without_t1.sql.gz
+      register: dump_db2_without_t1_gz
+      ignore_errors: true
+
+    - name: Check dumps errors | Check full dump
+      ansible.builtin.assert:
+        that:
+          - dump_db2_without_t1 is failed
+          - dump_db2_without_t1_gz is failed

--- a/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
@@ -110,3 +110,10 @@
         that:
           - dump_db2_without_t1 is failed
           - dump_db2_without_t1_gz is failed
+
+    - name: Check dumps errors | Cleanup
+      community.mysql.mysql_db:
+        name:
+          - "db1"
+          - "db2"
+        state: absent

--- a/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
@@ -13,61 +13,61 @@
 
   block:
 
-    - name: Check dumps errors | Setup test | Create 2 schemas
+    - name: Dumps errors | Setup test | Create 2 schemas
       community.mysql.mysql_db:
         name:
           - "db1"
           - "db2"
         state: present
 
-    - name: Check dumps errors | Setup test | Create 2 tables
+    - name: Dumps errors | Setup test | Create 2 tables
       community.mysql.mysql_query:
         query:
           - "CREATE TABLE db1.t1 (id int)"
           - "CREATE TABLE db1.t2 (id int)"
           - "CREATE VIEW db2.v1 AS SELECT id from db1.t1"
 
-    - name: Check dumps errors | Full dump without compression
+    - name: Dumps errors | Full dump without compression
       community.mysql.mysql_db:
         state: dump
         name: all
         target: /tmp/full-dump.sql
       register: full_dump
 
-    - name: Check dumps errors | Full dump with gunzip
+    - name: Dumps errors | Full dump with gunzip
       community.mysql.mysql_db:
         state: dump
         name: all
         target: /tmp/full-dump.sql.gz
       register: full_dump_gz
 
-    - name: Check dumps errors | Distinct dump without compression
+    - name: Dumps errors | Distinct dump without compression
       community.mysql.mysql_db:
         state: dump
         name: db2
         target: /tmp/dump-db2.sql
       register: dump_db2
 
-    - name: Check dumps errors | Distinct dump with gunzip
+    - name: Dumps errors | Distinct dump with gunzip
       community.mysql.mysql_db:
         state: dump
         name: db2
         target: /tmp/dump-db2.sql.gz
       register: dump_db2_gz
 
-    - name: Check dumps errors | Check distinct dumps are changed
+    - name: Dumps errors | Check distinct dumps are changed
       ansible.builtin.assert:
         that:
           - dump_db2 is changed
           - dump_db2_gz is changed
 
     # Now db2.v1 targets an inexistant table so mysqldump will fail
-    - name: Check dumps errors | Drop t1
+    - name: Dumps errors | Drop t1
       community.mysql.mysql_query:
         query:
           - "DROP TABLE db1.t1"
 
-    - name: Check dumps errors | Full dump after drop t1 without compression
+    - name: Dumps errors | Full dump after drop t1 without compression
       community.mysql.mysql_db:
         state: dump
         name: all
@@ -75,21 +75,35 @@
       register: full_dump_without_t1
       ignore_errors: true
 
-    - name: Check dumps errors | Full dump after drop t1 with gzip
+    - name: Dumps errors | Full dump after drop t1 with gzip without the fix
       community.mysql.mysql_db:
         state: dump
         name: all
         target: /tmp/full-dump-without-t1.sql.gz
-      register: full_dump_without_t1_gz
+      register: full_dump_without_t1_gz_without_fix
       ignore_errors: true
 
-    - name: Check dumps errors | Check full dump
+    - name: Dumps errors | Full dump after drop t1 with gzip with the fix
+      community.mysql.mysql_db:
+        state: dump
+        name: all
+        target: /tmp/full-dump-without-t1.sql.gz
+        pipefail: true
+      register: full_dump_without_t1_gz_with_fix
+      ignore_errors: true
+
+    - name: Dumps errors | Check full dump
       ansible.builtin.assert:
         that:
           - full_dump_without_t1 is failed
-          - full_dump_without_t1_gz is failed
+          - full_dump_without_t1.msg is search(
+              "View 'db2.v1' references invalid table(s)")
+          - full_dump_without_t1_gz_without_fix is changed
+          - full_dump_without_t1_gz_with_fix is failed
+          - full_dump_without_t1_gz_with_fix.msg is search(
+              "View 'db2.v1' references invalid table(s)")
 
-    - name: Check dumps errors | Distinct dump after drop t1 without compression
+    - name: Dumps errors | Distinct dump after drop t1 without compression
       community.mysql.mysql_db:
         state: dump
         name: db2
@@ -97,21 +111,35 @@
       register: dump_db2_without_t1
       ignore_errors: true
 
-    - name: Check dumps errors | Distinct dump after drop t1 with gzip
+    - name: Dumps errors | Distinct dump after drop t1 with gzip without the fix
       community.mysql.mysql_db:
         state: dump
         name: db2
         target: /tmp/dump-db2-without_t1.sql.gz
-      register: dump_db2_without_t1_gz
+      register: dump_db2_without_t1_gz_without_fix
       ignore_errors: true
 
-    - name: Check dumps errors | Check full dump
+    - name: Dumps errors | Distinct dump after drop t1 with gzip with the fix
+      community.mysql.mysql_db:
+        state: dump
+        name: db2
+        target: /tmp/dump-db2-without_t1.sql.gz
+        pipefail: true
+      register: dump_db2_without_t1_gz_with_fix
+      ignore_errors: true
+
+    - name: Dumps errors | Check full dump
       ansible.builtin.assert:
         that:
           - dump_db2_without_t1 is failed
-          - dump_db2_without_t1_gz is failed
+          - dump_db2_without_t1.msg is search(
+              "View 'db2.v1' references invalid table(s)")
+          - dump_db2_without_t1_gz_without_fix is changed
+          - dump_db2_without_t1_gz_with_fix is failed
+          - dump_db2_without_t1_gz_with_fix.msg is search(
+              "View 'db2.v1' references invalid table(s)")
 
-    - name: Check dumps errors | Cleanup
+    - name: Dumps errors | Cleanup
       community.mysql.mysql_db:
         name:
           - "db1"

--- a/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
@@ -4,12 +4,12 @@
 # dump produced was empty or worse, only contained `DROP TABLE IF EXISTS...`
 
 - module_defaults:
-    ansible.builtin.mysql_db: &mysql_defaults
+    community.mysql.mysql_db: &mysql_defaults
       login_user: '{{ mysql_user }}'
       login_password: '{{ mysql_password }}'
       login_host: 127.0.0.1
       login_port: '{{ mysql_primary_port }}'
-    ansible.builtin.mysql_query: *mysql_defaults
+    community.mysql.mysql_query: *mysql_defaults
 
   block:
 

--- a/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
@@ -13,16 +13,64 @@
 
   block:
 
-    - name: Setup test - Create 2 schemas
+    - name: Check dumps errors | Setup test | Create 2 schemas
       community.mysql.mysql_db:
         name:
           - "db1"
           - "db2"
         state: present
 
-    - name: Setup test - Create 2 tables
+    - name: Check dumps errors | Setup test | Create 2 tables
       community.mysql.mysql_query:
         query:
           - "CREATE TABLE db1.t1 (id int)"
           - "CREATE TABLE db1.t2 (id int)"
           - "CREATE VIEW db2.v1 AS SELECT id from db1.t1"
+
+    - name: Check dumps errors | Full dump without compression
+      community.mysql.mysql_db:
+        state: dump
+        name: all
+        target: /tmp/full-dump.sql
+      register: full_dump
+
+    - name: Check dumps errors | Full dump with gunzip
+      community.mysql.mysql_db:
+        state: dump
+        name: all
+        target: /tmp/full-dump.sql.gz
+      register: full_dump_gz
+
+    - name: Check dumps errors | Check full dumps are changed
+      ansible.builtin.assert:
+        that:
+          - full_dump is changed
+          - full_dump_gz is changed
+
+    # Now db2.v1 targets an inexistant table so mysqldump will fail
+    - name: Check dumps errors | Drop t1
+      community.mysql.mysql_query:
+        query:
+          - "DROP TABLE db1.t1"
+
+    - name: Check dumps errors | Full dump after drop t1 without compression
+      community.mysql.mysql_db:
+        state: dump
+        name: all
+        target: /tmp/full-dump-without-t1.sql
+      register: full_dump_without_t1
+      ignore_errors: true
+
+    - name: Check dumps errors | Full dump after drop t1 with gzip
+      community.mysql.mysql_db:
+        state: dump
+        name: all
+        target: /tmp/full-dump-without-t1.sql.gz
+      register: full_dump_without_t1_gz
+      ignore_errors: true
+
+    - name: Check dumps errors | Check full dump
+      ansible.builtin.assert:
+        that:
+          - full_dump_without_t1 is failed
+          - full_dump_without_t1_gz is failed

--- a/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue_256_mysqldump_errors.yml
@@ -72,6 +72,7 @@
         state: dump
         name: all
         target: /tmp/full-dump-without-t1.sql
+        pipefail: true  # This should do nothing
       register: full_dump_without_t1
       ignore_errors: true
 
@@ -108,6 +109,7 @@
         state: dump
         name: db2
         target: /tmp/dump-db2-without_t1.sql
+        pipefail: true  # This should do nothing
       register: dump_db2_without_t1
       ignore_errors: true
 

--- a/tests/integration/targets/test_mysql_db/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/main.yml
@@ -63,3 +63,6 @@
   vars:
     db_name: "{{ item }}"
   loop: "{{ db_names }}"
+
+- name: Check errors from mysqldump are seen issue 256
+  ansible.builtin.include_tasks: issue_256_mysqldump_errors.yml

--- a/tests/integration/targets/test_mysql_db/tasks/state_present_absent.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/state_present_absent.yml
@@ -18,8 +18,8 @@
 # ============================================================
 - name: remove database if it exists
   command: >
-    "{{ mysql_command }} -sse 'drop database {{ db_name }}'"
-  ignore_errors: True
+    "{{ mysql_command }} -sse 'DROP DATABASE IF EXISTS {{ db_name }}'"
+  ignore_errors: true
 
 - name: make sure the test database is not there
   command: "{{ mysql_command }} {{ db_name }}"


### PR DESCRIPTION
##### SUMMARY
The mysql_db module does not display mysqldump errors when compression is used.

Fixes #256 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

mysql_db

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The issue #256 initially was met the first time because of a too big field and a `max_allowed_packet` to small. As this is difficult to test, the tests were written with a MySQL view pointing to a non-existent table.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# Before
changed: [testhost]

# After
fatal: [testhost]: FAILED! => {"changed": false, "msg": "mysqldump: [Warning] Using a password on the command line interface can be insecure.\nmysqldump: Got error: 1356: View 'db2.v1' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them when using LOCK TABLES\n"}
```
