### PR TITLE
[PR #423/61586ae4 backport][stable-2] Port stable 1 ci changes

### DIFF
--- a/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
@@ -14,7 +14,12 @@
 - name: Add blank line
   shell: 'echo "" >> {{ config_file }}'
   when:
-  - (connector.name.0 is search('pymysql') and connector_ver is version('0.9.3', '>=')) or connector.name.0 is not search('pymysql')
+    - >
+      connector_name is not search('pymysql')
+      or (
+        connector_name is search('pymysql')
+        and connector_ver is version('0.9.3', '>=')
+      )
 
 - name: Create include_dir
   file:
@@ -22,7 +27,12 @@
     state: directory
     mode: '0777'
   when:
-  - (connector.name.0 is search('pymysql') and connector_ver is version('0.9.3', '>=')) or connector.name.0 is not search('pymysql')
+    - >
+      connector_name is not search('pymysql')
+      or (
+        connector_name is search('pymysql')
+        and connector_ver is version('0.9.3', '>=')
+      )
 
 - name: Add include_dir
   lineinfile:
@@ -30,7 +40,12 @@
     line: '!includedir {{ include_dir }}'
     insertafter: EOF
   when:
-  - (connector.name.0 is search('pymysql') and connector_ver is version('0.9.3', '>=')) or connector.name.0 is not search('pymysql')
+    - >
+      connector_name is not search('pymysql')
+      or (
+        connector_name is search('pymysql')
+        and connector_ver is version('0.9.3', '>=')
+      )
 
 - name: Create database using fake port to connect to, must fail
   mysql_db:

--- a/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
@@ -46,12 +46,12 @@
     - assert:
         that:
           - result is failed
-      when: connector.name.0 is search('pymysql')
+      when: connector_name is search('pymysql')
 
     - assert:
         that:
           - result is succeeded
-      when: connector.name.0 is not search('pymysql')
+      when: connector_name is not search('pymysql')
 
     - name: attempt connection with newly created user ignoring hostname
       mysql_db:

--- a/tests/integration/targets/test_mysql_info/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/issue-28.yml
@@ -44,12 +44,12 @@
     - assert:
         that:
           - result is failed
-      when: connector.name.0 is search('pymysql')
+      when: connector_name is search('pymysql')
 
     - assert:
         that:
           - result is succeeded
-      when: connector.name.0 is not search('pymysql')
+      when: connector_name is not search('pymysql')
 
     - name: attempt connection with newly created user ignoring hostname
       mysql_info:

--- a/tests/integration/targets/test_mysql_query/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/issue-28.yml
@@ -44,12 +44,12 @@
     - assert:
         that:
           - result is failed
-      when: connector.name.0 is search('pymysql')
+      when: connector_name is search('pymysql')
 
     - assert:
         that:
           - result is succeeded
-      when: connector.name.0 is not search('pymysql')
+      when: connector_name is not search('pymysql')
 
     - name: attempt connection with newly created user ignoring hostname
       mysql_query:

--- a/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
@@ -343,7 +343,7 @@
       that:
       # PyMySQL driver throws a warning, so the following is correct
       - result is not changed
-    when: connector.name.0 is search('pymysql')
+    when: connector_name is search('pymysql')
 
   # Issue https://github.com/ansible-collections/community.mysql/issues/268
   - assert:
@@ -352,7 +352,7 @@
       # if the state was changed or not.
       # We assume that it was for DDL queryes by default in the code
       - result is changed
-    when: connector.name.0 is search('mysqlclient')
+    when: connector_name is search('mysqlclient')
 
   - name: Drop db {{ test_db }}
     mysql_query:

--- a/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
@@ -45,12 +45,12 @@
     - assert:
         that:
           - result is failed
-      when: connector.name.0 is search('pymysql')
+      when: connector_name is search('pymysql')
 
     - assert:
         that:
           - result is succeeded
-      when: connector.name.0 is not search('pymysql')
+      when: connector_name is not search('pymysql')
 
     - name: attempt connection with newly created user ignoring hostname
       mysql_replication:

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -176,8 +176,8 @@
       shell: "echo \"INSERT INTO {{ test_table }} (id) VALUES (1), (2), (3); FLUSH LOGS;\" | {{ mysql_command }} -P{{ mysql_primary_port }} {{ test_db }}"
 
     - name: Small pause to be sure the bin log, which was flushed previously, reached the replica
-      pause:
-        seconds: 2
+      ansible.builtin.wait_for:
+        timeout: 2
 
     # Test primary log pos has been changed:
     - name: Get replica status
@@ -210,10 +210,12 @@
         fail_on_error: true
       register: result
 
+    # mysqlclient 2.0.1 always return "changed"
     - assert:
         that:
-        - result is not changed
-      when: (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '<=')
+          - result is not changed
+      when:
+        - connector_name == 'pymysql'
 
     # Test stopreplica mode:
     - name: Stop replica using deprecated stopslave choice
@@ -228,7 +230,12 @@
         - result is changed
         - result.queries == ["STOP SLAVE"] or result.queries == ["STOP REPLICA"]
 
+    - name: Pause for 2 seconds to let the replication stop
+      ansible.builtin.wait_for:
+        timeout: 2
+
     # Test stopreplica mode:
+    # mysqlclient 2.0.1 always return "changed"
     - name: Stop replica that is no longer running
       mysql_replication:
         <<: *mysql_params
@@ -239,5 +246,6 @@
 
     - assert:
         that:
-        - result is not changed
-      when: (pymysql_version.stdout | default('1000', true)) is version('0.9.3', '<=')
+          - result is not changed
+      when:
+        - connector_name == 'pymysql'

--- a/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
@@ -9,8 +9,6 @@
   block:
 
     # ============================================================
-    - shell: pip show pymysql | awk '/Version/ {print $2}'
-      register: pymysql_version
 
     - name: get server certificate
       copy:

--- a/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
@@ -47,12 +47,12 @@
     - assert:
         that:
           - result is failed
-      when: connector.name.0 is search('pymysql')
+      when: connector_name is search('pymysql')
 
     - assert:
         that:
           - result is succeeded
-      when: connector.name.0 is not search('pymysql')
+      when: connector_name is not search('pymysql')
 
     - name: attempt connection with newly created user ignoring hostname
       mysql_user:

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -334,12 +334,14 @@
     # plugins that are loaded by default are sha2*, but these aren't compatible with pymysql < 0.9, so skip these tests
     # for those versions.
     #
-    - name: Get pymysql version
-      shell: pip show pymysql | awk '/Version/ {print $2}'
-      register: pymysql_version
-
     - name: Test plugin auth switching which doesn't work on pymysql < 0.9
-      when: pymysql_version.stdout == "" or (pymysql_version.stdout != "" and pymysql_version.stdout is version('0.9', '>='))
+      when:
+        - >
+          connector_name is not search('pymysql')
+          or (
+            connector_name is search('pymysql')
+            and connector_ver is version('0.9', '>=')
+          )
       block:
 
       - name: Create user with plugin auth (empty auth string)

--- a/tests/integration/targets/test_mysql_variables/tasks/assert_fail_msg.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/assert_fail_msg.yml
@@ -22,4 +22,4 @@
 - name: assert message failure (expect failed=true)
   assert:
     that:
-      - "output.failed == true"
+      - "output.failed | bool == true"

--- a/tests/integration/targets/test_mysql_variables/tasks/assert_var.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/assert_var.yml
@@ -22,7 +22,7 @@
 - name: assert output message changed value
   assert:
     that:
-      - "output.changed == {{ changed }}"
+      - "output.changed | bool == changed | bool"
 
 - name: run mysql command to show variable
   command: "{{ mysql_command }} \"-e show variables like '{{ var_name }}'\""
@@ -31,6 +31,6 @@
 - name: assert output mysql variable name and value
   assert:
     that:
-      - "result.changed == true"
+      - "result.changed | bool == true"
       - "'{{ var_name }}' in result.stdout"
       - "'{{ var_value }}' in result.stdout"

--- a/tests/integration/targets/test_mysql_variables/tasks/assert_var_output.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/assert_var_output.yml
@@ -22,7 +22,7 @@
 - name: assert output message changed value
   assert:
     that:
-      - "output.changed == {{ changed }}"
+      - "output.changed | bool == changed | bool"
 
 - set_fact:
     key_name: "{{ var_name }}"
@@ -35,6 +35,6 @@
 - name: assert output variable info match mysql variable info
   assert:
     that:
-      - "result.changed == true"
+      - "result.changed | bool == true"
       - "key_name in result.stdout"
       - "key_value in result.stdout"

--- a/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
@@ -45,12 +45,12 @@
     - assert:
         that:
           - result is failed
-      when: connector.name.0 is search('pymysql')
+      when: connector_name is search('pymysql')
 
     - assert:
         that:
           - result is succeeded
-      when: connector.name.0 is not search('pymysql')
+      when: connector_name is not search('pymysql')
 
     - name: attempt connection with newly created user ignoring hostname
       mysql_variables:

--- a/tests/integration/targets/test_mysql_variables/tasks/mysql_variables.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/mysql_variables.yml
@@ -155,15 +155,15 @@
       mysql_variables:
         <<: *mysql_params
         variable: max_connect_errors
-        value: -1
+        value: '-1'
       register: oor_result
       ignore_errors: true
 
     - include: assert_var.yml changed=true output={{ oor_result }} var_name=max_connect_errors var_value=1
-      when: connector.name.0 is not search('pymysql')
+      when: connector_name is not search('pymysql')
 
     - include: assert_fail_msg.yml output={{ oor_result }}  msg='Truncated incorrect'
-      when: connector.name.0 is search('pymysql')
+      when: connector_name is search('pymysql')
 
     # ============================================================
     # Verify mysql_variable fails when setting an incorrect value (incorrect type)


### PR DESCRIPTION
* Add changes from stable-1 integrations tests (PR 418)

* Refactor to use connectors' info declared in setup_mysql

* Fix 2nd replication stop marked changed by mysqlclient

(cherry picked from commit 61586ae4cc169119cb3fa9824fdfe9f5aeb46308)
