### PR TITLE
* add `socket` option suggestion in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 
 # MacOS
 .DS_Store
+
+# IntelliJ IDEA or PyCharm
+.idea/

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -81,6 +81,9 @@ requirements:
 notes:
    - "To avoid the C(Please explicitly state intended protocol) error, use the I(login_unix_socket) argument,
      for example, C(login_unix_socket: /run/mysqld/mysqld.sock)."
+   - Alternatively, to avoid using I(login_unix_socket) argument on each invocation you can specify the socket path 
+     using the `socket` option in your MySQL config file (usually C(~/.my.cnf)) on the destination host, for 
+     example C(socket=/var/lib/mysql/mysql.sock).
    - Requires the PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) package installed on the remote host.
      The Python package may be installed with apt-get install python-pymysql (Ubuntu; see M(ansible.builtin.apt)) or
      yum install python2-PyMySQL (RHEL/CentOS/Fedora; see M(ansible.builtin.yum)). You can also use dnf install python2-PyMySQL

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -79,11 +79,6 @@ requirements:
    - PyMySQL (Python 2.7 and Python 3.x) or
    - MySQLdb (Python 2.x)
 notes:
-   - "To avoid the C(Please explicitly state intended protocol) error, use the I(login_unix_socket) argument,
-     for example, C(login_unix_socket: /run/mysqld/mysqld.sock)."
-   - Alternatively, to avoid using I(login_unix_socket) argument on each invocation you can specify the socket path
-     using the `socket` option in your MySQL config file (usually C(~/.my.cnf)) on the destination host, for
-     example C(socket=/var/lib/mysql/mysql.sock).
    - Requires the PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) package installed on the remote host.
      The Python package may be installed with apt-get install python-pymysql (Ubuntu; see M(ansible.builtin.apt)) or
      yum install python2-PyMySQL (RHEL/CentOS/Fedora; see M(ansible.builtin.yum)). You can also use dnf install python2-PyMySQL
@@ -110,4 +105,9 @@ notes:
    - "If credentials from the config file (for example, C(/root/.my.cnf)) are not needed to connect to a database server, but
      the file exists and does not contain a C([client]) section, before any other valid directives, it will be read and this
      will cause the connection to fail, to prevent this set it to an empty string, (for example C(config_file: ''))."
+   - "To avoid the C(Please explicitly state intended protocol) error, use the I(login_unix_socket) argument,
+     for example, C(login_unix_socket: /run/mysqld/mysqld.sock)."
+   - Alternatively, to avoid using I(login_unix_socket) argument on each invocation you can specify the socket path
+     using the `socket` option in your MySQL config file (usually C(~/.my.cnf)) on the destination host, for
+     example C(socket=/var/lib/mysql/mysql.sock).
 '''

--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -81,8 +81,8 @@ requirements:
 notes:
    - "To avoid the C(Please explicitly state intended protocol) error, use the I(login_unix_socket) argument,
      for example, C(login_unix_socket: /run/mysqld/mysqld.sock)."
-   - Alternatively, to avoid using I(login_unix_socket) argument on each invocation you can specify the socket path 
-     using the `socket` option in your MySQL config file (usually C(~/.my.cnf)) on the destination host, for 
+   - Alternatively, to avoid using I(login_unix_socket) argument on each invocation you can specify the socket path
+     using the `socket` option in your MySQL config file (usually C(~/.my.cnf)) on the destination host, for
      example C(socket=/var/lib/mysql/mysql.sock).
    - Requires the PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) package installed on the remote host.
      The Python package may be installed with apt-get install python-pymysql (Ubuntu; see M(ansible.builtin.apt)) or


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR suggested by @Andersson007  in issue #358.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### ADDITIONAL INFORMATION
If one adds the socket option in `~/my.cnf` on the destination machine you no longer need to specify `login_unix_socket` on each module invocation.
