### PR TITLE
Fix: devel requires python 3.9 in roles CI

### DIFF
--- a/.github/workflows/ansible-test-roles.yml
+++ b/.github/workflows/ansible-test-roles.yml
@@ -32,8 +32,6 @@ jobs:
           - 3.8
           - 3.9
         exclude:
-          - python: 3.8
-            ansible: stable-2.11
           - python: 3.6
             ansible: stable-2.12
           - python: 3.6
@@ -41,7 +39,15 @@ jobs:
           - python: 3.6
             ansible: devel
           - python: 3.8
+            ansible: stable-2.11
+          - python: 3.8
+            ansible: stable-2.13
+          - python: 3.8
             ansible: devel
+          - python: 3.9
+            ansible: stable-2.11
+          - python: 3.9
+            ansible: stable-2.12
 
     steps:
 

--- a/.github/workflows/ansible-test-roles.yml
+++ b/.github/workflows/ansible-test-roles.yml
@@ -30,6 +30,7 @@ jobs:
         python:
           - 3.6
           - 3.8
+          - 3.9
         exclude:
           - python: 3.8
             ansible: stable-2.11
@@ -38,6 +39,8 @@ jobs:
           - python: 3.6
             ansible: stable-2.13
           - python: 3.6
+            ansible: devel
+          - python: 3.8
             ansible: devel
 
     steps:


### PR DESCRIPTION
Fix [CI for roles](https://github.com/ansible-collections/community.mysql/actions/runs/3022728901/jobs/4862148734).

Package 'ansible-core' requires a different Python: 3.8.13 not in '>=3.9'