### PR TITLE
add service name to plugin pam/auth_pam usage

### DIFF
--- a/changelogs/fragments/445_add_service_name_to_plugin_pam_auth_pam_usage.yml
+++ b/changelogs/fragments/445_add_service_name_to_plugin_pam_auth_pam_usage.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - mysql_user - add plugin_auth_string as optional parameter to use a specific pam service if pam/auth_pam plugin is used.
+  - mysql_user - add plugin_auth_string as optional parameter to use a specific pam service if pam/auth_pam plugin is used (https://github.com/ansible-collections/community.mysql/pull/445).

--- a/changelogs/fragments/445_add_service_name_to_plugin_pam_auth_pam_usage.yml
+++ b/changelogs/fragments/445_add_service_name_to_plugin_pam_auth_pam_usage.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - mysql_user - add plugin_auth_string as optional parameter to use a specific pam service if pam/auth_pam plugin is used.

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -171,7 +171,7 @@ def user_add(cursor, user, host, host_all, password, encrypted,
         query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
     elif plugin and plugin_auth_string:
         # Mysql and MariaDB differ in naming pam plugin and Syntax to set it
-        if plugin == 'pam':
+        if plugin == 'pam':  # Used by MariaDB which requires the USING keyword, not BY
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
         else:
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s BY %s", (user, host, plugin, plugin_auth_string)

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -171,7 +171,7 @@ def user_add(cursor, user, host, host_all, password, encrypted,
         query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
     elif plugin and plugin_auth_string:
         # Mysql and MariaDB differ in naming pam plugin
-        if plugin = 'pam' or plugin = 'auth_pam':  
+        if plugin == 'pam' or plugin == 'auth_pam':  
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
         else:
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s BY %s", (user, host, plugin, plugin_auth_string)
@@ -310,7 +310,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
                 elif plugin_auth_string:
                     # Mysql and MariaDB differ in naming pam plugin
-                    if plugin = 'pam' or plugin = 'auth_pam':  
+                    if plugin == 'pam' or plugin == 'auth_pam':  
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
                     else:
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s BY %s", (user, host, plugin, plugin_auth_string)

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -170,8 +170,8 @@ def user_add(cursor, user, host, host_all, password, encrypted,
     elif plugin and plugin_hash_string:
         query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
     elif plugin and plugin_auth_string:
-        # Mysql and MariaDB differ in naming pam plugin
-        if plugin == 'pam' or plugin == 'auth_pam':  
+        # Mysql and MariaDB differ in naming pam plugin and Syntax to set it
+        if plugin == 'pam':
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
         else:
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s BY %s", (user, host, plugin, plugin_auth_string)
@@ -309,8 +309,8 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                 if plugin_hash_string:
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
                 elif plugin_auth_string:
-                    # Mysql and MariaDB differ in naming pam plugin
-                    if plugin == 'pam' or plugin == 'auth_pam':  
+                    # Mysql and MariaDB differ in naming pam plugin and syntax to set it
+                    if plugin == 'pam':
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
                     else:
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s BY %s", (user, host, plugin, plugin_auth_string)

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -170,7 +170,11 @@ def user_add(cursor, user, host, host_all, password, encrypted,
     elif plugin and plugin_hash_string:
         query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
     elif plugin and plugin_auth_string:
-        query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s BY %s", (user, host, plugin, plugin_auth_string)
+        # Mysql and MariaDB differ in naming pam plugin
+        if plugin = 'pam' or plugin = 'auth_pam':  
+            query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
+        else:
+            query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s BY %s", (user, host, plugin, plugin_auth_string)
     elif plugin:
         query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s", (user, host, plugin)
     else:
@@ -305,7 +309,11 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                 if plugin_hash_string:
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
                 elif plugin_auth_string:
-                    query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s BY %s", (user, host, plugin, plugin_auth_string)
+                    # Mysql and MariaDB differ in naming pam plugin
+                    if plugin = 'pam' or plugin = 'auth_pam':  
+                        query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
+                    else:
+                        query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s BY %s", (user, host, plugin, plugin_auth_string)
                 else:
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s", (user, host, plugin)
 

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -117,7 +117,7 @@ options:
   update_password:
     description:
       - C(always) will update passwords if they differ. This affects I(password) and the combination of I(plugin), I(plugin_hash_string), I(plugin_auth_string).
-      - C(on_create) will only set the password or the combination of plugin, plugin_hash_string, plugin_auth_string for newly created users.
+      - C(on_create) will only set the password or the combination of I(plugin), I(plugin_hash_string), I(plugin_auth_string) for newly created users.
       - "C(on_new_username) works like C(on_create), but it tries to reuse an existing password: If one different user
         with the same username exists, or multiple different users with the same username and equal C(plugin) and
         C(authentication_string) attribute, the existing C(plugin) and C(authentication_string) are used for the
@@ -138,6 +138,8 @@ options:
   plugin_auth_string:
     description:
       - User's plugin auth_string (``CREATE USER user IDENTIFIED WITH plugin BY plugin_auth_string``).
+      - If I(plugin) is ``pam`` or ``auth_pam`` I(plugin_auth_string) can be used to determine the pam service  (``CREATE USER user IDENTIFIED WITH plugin USING plugin_auth_string``).
+        This was chosen because MySQL and MariaDB store the ``USING plugin_auth_string`` part in the ``authentication_string`` column in ``mysql.user``.
     type: str
     version_added: '0.1.0'
   resource_limits:

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -138,7 +138,7 @@ options:
   plugin_auth_string:
     description:
       - User's plugin auth_string (``CREATE USER user IDENTIFIED WITH plugin BY plugin_auth_string``).
-      - If I(plugin) is ``pam`` or ``auth_pam`` I(plugin_auth_string) can be used to determine the pam service  (``CREATE USER user IDENTIFIED WITH plugin USING plugin_auth_string``).
+      - MariaDB: If I(plugin) is ``pam`` an optional I(plugin_auth_string) ults in (``CREATE USER user IDENTIFIED WITH plugin USING plugin_auth_string``).
         This was chosen because MySQL and MariaDB store the ``USING plugin_auth_string`` part in the ``authentication_string`` column in ``mysql.user``.
     type: str
     version_added: '0.1.0'

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -138,8 +138,7 @@ options:
   plugin_auth_string:
     description:
       - User's plugin auth_string (``CREATE USER user IDENTIFIED WITH plugin BY plugin_auth_string``).
-      - MariaDB If I(plugin) is ``pam`` an optional I(plugin_auth_string) ults in (``CREATE USER user IDENTIFIED WITH plugin USING plugin_auth_string``).
-        This was chosen because MySQL and MariaDB store the ``USING plugin_auth_string`` part in the ``authentication_string`` column in ``mysql.user``.
+      - If I(plugin) is ``pam`` (MariaDB) or ``auth_pam`` (MySQL) an optional I(plugin_auth_string) can be used to choose a specific PAM service.
     type: str
     version_added: '0.1.0'
   resource_limits:

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -138,7 +138,7 @@ options:
   plugin_auth_string:
     description:
       - User's plugin auth_string (``CREATE USER user IDENTIFIED WITH plugin BY plugin_auth_string``).
-      - MariaDB: If I(plugin) is ``pam`` an optional I(plugin_auth_string) ults in (``CREATE USER user IDENTIFIED WITH plugin USING plugin_auth_string``).
+      - MariaDB If I(plugin) is ``pam`` an optional I(plugin_auth_string) ults in (``CREATE USER user IDENTIFIED WITH plugin USING plugin_auth_string``).
         This was chosen because MySQL and MariaDB store the ``USING plugin_auth_string`` part in the ``authentication_string`` column in ``mysql.user``.
     type: str
     version_added: '0.1.0'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
for plugin  = pam (MariaDB)
or plugin = auth_pam (MySQL) 
use an optional plugin_auth_string to set the pam service to use

`CREATE USER user IDENTIFIED WITH plugin USING plugin_auth_string`

As MySQL and MariaDB store this option in authentication_string column this reuse of plugin_auth_string seems vaild.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_user

##### ADDITIONAL INFORMATION
would need help if this should have a unit/integration test