### PR TITLE
CI: add stable-2.14 to test matrix

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -28,6 +28,7 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
+          - stable-2.14
           - devel
         python:
           - 3.8
@@ -35,6 +36,8 @@ jobs:
         exclude:
           - python: 3.8
             ansible: stable-2.13
+          - python: 3.8
+            ansible: stable-2.14
           - python: 3.8
             ansible: devel
           - python: 3.9
@@ -77,6 +80,7 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
+          - stable-2.14
           - devel
         python:
           - 3.6
@@ -96,11 +100,15 @@ jobs:
           - python: 3.6
             ansible: stable-2.13
           - python: 3.6
+            ansible: stable-2.14
+          - python: 3.6
             ansible: devel
           - python: 3.8
             ansible: stable-2.11
           - python: 3.8
             ansible: stable-2.13
+          - python: 3.8
+            ansible: stable-2.14
           - python: 3.8
             ansible: devel
           - python: 3.9
@@ -167,6 +175,7 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
+          - stable-2.14
           - devel
         python:
           - 3.8
@@ -174,6 +183,8 @@ jobs:
         exclude:
           - python: 3.8
             ansible: stable-2.13
+          - python: 3.8
+            ansible: stable-2.14
           - python: 3.8
             ansible: devel
           - python: 3.9

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,0 +1,8 @@
+plugins/modules/mysql_db.py validate-modules:doc-elements-mismatch
+plugins/modules/mysql_db.py validate-modules:parameter-list-no-elements
+plugins/modules/mysql_db.py validate-modules:use-run-command-not-popen
+plugins/modules/mysql_info.py validate-modules:doc-elements-mismatch
+plugins/modules/mysql_info.py validate-modules:parameter-list-no-elements
+plugins/modules/mysql_query.py validate-modules:parameter-list-no-elements
+plugins/modules/mysql_user.py validate-modules:undocumented-parameter
+plugins/modules/mysql_variables.py validate-modules:doc-required-mismatch


### PR DESCRIPTION
##### SUMMARY
CI: add stable-2.14 to test matrix

Relates to https://github.com/ansible-collections/news-for-maintainers/issues/24