### PR TITLE
Display a more informative error when InvalidPrivsError is raised (#465)

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   sanity:
     name: "Sanity (Ansible: ${{ matrix.ansible }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         ansible:
@@ -39,7 +39,7 @@ jobs:
 
   integration:
     name: "Integration (Python: ${{ matrix.python }}, Ansible: ${{ matrix.ansible }}, MySQL: ${{ matrix.db_engine_version }}, Connector: ${{ matrix.connector }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
           testing-type: integration
 
   units:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Units (Ⓐ${{ matrix.ansible }})
     strategy:
       # As soon as the first unit test fails,

--- a/.github/workflows/ansible-test-roles.yml
+++ b/.github/workflows/ansible-test-roles.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   molecule:
     name: "Molecule (Python: ${{ matrix.python }}, Ansible: ${{ matrix.ansible }}, MySQL: ${{ matrix.mysql }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1

--- a/changelogs/fragments/465-display_more_informative_invalid_priv_exceptiion.yml
+++ b/changelogs/fragments/465-display_more_informative_invalid_priv_exceptiion.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - mysql_user - display a more informative invalid privilege exception.
+    Changes the exception handling of the granting permission logic to show the query executed 
+    and the exception message granting privileges fails` (https://github.com//pull/435).

--- a/changelogs/fragments/465-display_more_informative_invalid_priv_exceptiion.yml
+++ b/changelogs/fragments/465-display_more_informative_invalid_priv_exceptiion.yml
@@ -1,5 +1,5 @@
 ---
 minor_changes:
   - mysql_user - display a more informative invalid privilege exception.
-    Changes the exception handling of the granting permission logic to show the query executed 
-    and the exception message granting privileges fails` (https://github.com//pull/435).
+    Changes the exception handling of the granting permission logic to show the query executed , params
+    and the exception message granting privileges fails` (https://github.com/ansible-collections/community.mysql/issues/465).

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -725,7 +725,7 @@ def privileges_grant(cursor, user, host, db_table, priv, tls_requires, maria_rol
     try:
         cursor.execute(query, params)
     except (mysql_driver.ProgrammingError, mysql_driver.OperationalError, mysql_driver.InternalError) as e:
-        raise InvalidPrivsError("Error granting privileges, invalid priv string: %s , query: %s , exception: %s." % (priv_string, query, str(e)) )
+        raise InvalidPrivsError("Error granting privileges, invalid priv string: %s , query: %s , exception: %s." % (priv_string, query, str(e)))
 
 
 def convert_priv_dict_to_str(priv):

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -725,7 +725,7 @@ def privileges_grant(cursor, user, host, db_table, priv, tls_requires, maria_rol
     try:
         cursor.execute(query, params)
     except (mysql_driver.ProgrammingError, mysql_driver.OperationalError, mysql_driver.InternalError) as e:
-        raise InvalidPrivsError("Error granting privileges, invalid priv string: %s" % priv_string)
+        raise InvalidPrivsError("Error granting privileges, invalid priv string: %s , query: %s , exception: %s." % (priv_string, query, str(e)) )
 
 
 def convert_priv_dict_to_str(priv):

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -725,7 +725,8 @@ def privileges_grant(cursor, user, host, db_table, priv, tls_requires, maria_rol
     try:
         cursor.execute(query, params)
     except (mysql_driver.ProgrammingError, mysql_driver.OperationalError, mysql_driver.InternalError) as e:
-        raise InvalidPrivsError("Error granting privileges, invalid priv string: %s , query: %s , exception: %s." % (priv_string, query, str(e)))
+        raise InvalidPrivsError("Error granting privileges, invalid priv string: %s , params: %s, query: %s ,"
+                                " exception: %s." % (priv_string, str(params), query, str(e)))
 
 
 def convert_priv_dict_to_str(priv):

--- a/tests/integration/targets/setup_mysql/handlers/main.yml
+++ b/tests/integration/targets/setup_mysql/handlers/main.yml
@@ -4,3 +4,5 @@
     src: installed_file.j2
     dest: "{{ dbdeployer_installed_file }}"
   listen: create zookeeper installed file
+  tags:
+    - setup_mysql

--- a/tests/integration/targets/setup_mysql/tasks/main.yml
+++ b/tests/integration/targets/setup_mysql/tasks/main.yml
@@ -5,7 +5,17 @@
 ####################################################################
 
 - import_tasks: setvars.yml
+  tags:
+    - setup_mysql
 - import_tasks: dir.yml
+  tags:
+    - setup_mysql
 - import_tasks: install.yml
+  tags:
+    - setup_mysql
 - import_tasks: config.yml
+  tags:
+    - setup_mysql
 - import_tasks: verify.yml
+  tags:
+    - setup_mysql

--- a/tests/integration/targets/setup_remote_tmp_dir/handlers/main.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/handlers/main.yml
@@ -1,5 +1,9 @@
 - name: delete temporary directory
   include_tasks: default-cleanup.yml
+  tags:
+    - setup_remote_tmp_dir
 
 - name: delete temporary directory (windows)
   include_tasks: windows-cleanup.yml
+  tags:
+    - setup_remote_tmp_dir

--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
@@ -7,9 +7,13 @@
   setup:
     gather_subset: distribution
   when: ansible_facts == {}
+  tags:
+    - setup_remote_tmp_dir
 
 - include_tasks: "{{ lookup('first_found', files)}}"
   vars:
     files:
       - "{{ ansible_os_family | lower }}.yml"
       - "default.yml"
+  tags:
+    - setup_remote_tmp_dir

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -281,7 +281,7 @@
     - include: test_priv_subtract.yml enable_check_mode=no
     - include: test_priv_subtract.yml enable_check_mode=yes
 
-    - include: test_privs_issue_465.yml
+    - import_tasks: test_privs_issue_465.yml
       tags:
         - issue_465
 

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -281,6 +281,10 @@
     - include: test_priv_subtract.yml enable_check_mode=no
     - include: test_priv_subtract.yml enable_check_mode=yes
 
+    - include: test_privs_issue_465.yml
+      tags:
+        - issue_465
+
     # Tests for the TLS requires dictionary
     - include: tls_requirements.yml
 

--- a/tests/integration/targets/test_mysql_user/tasks/test_privs_issue_465.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_privs_issue_465.yml
@@ -40,5 +40,7 @@
       assert:
         that:
           - result is failed
-          - result.msg.find('exception') != -1
-        fail_msg: "Error granting privileges, invalid priv string: SELECT , query: GRANT SELECT ON *.`data` TO %s@%s , exception: (1064, \"You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '`data` TO 'db_user2'@'localhost'' at line 1\")."
+          - result.msg is search('invalid priv string')
+          - result.msg is search('params')
+          - result.msg is search('query')
+          - result.msg is search('exception')

--- a/tests/integration/targets/test_mysql_user/tasks/test_privs_issue_465.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_privs_issue_465.yml
@@ -26,28 +26,19 @@
   block:
 
     # ============================================================
-    - name: create admin user with ALL privs, without GRANT OPTIONS
-      mysql_user:
-        <<: *mysql_params
-        name: '{{ user_name_1 }}'
-        password: '{{ user_password_1 }}'
-        priv: '*.{{ db_name }}:ALL'
-        state: present
-
-    - include: assert_user.yml user_name={{user_name_2}} priv='ALL'
-
-    - name: create consumer user with all privileges using admin user
+    - name: create a user with parameters that will always cause an exception
       mysql_user:
         <<: *mysql_params
         name: '{{ user_name_2 }}'
         password: '{{ user_password_2 }}'
-        login_user: '{{ user_name_1 }}'
-        login_password: '{{ user_password_1 }}'
-        priv: '*.{{ db_name }}:ALL'
+        priv: '*.{{ db_name }}:SELECT'
         state: present
+      ignore_errors: yes
       register: result
 
     - name: assert output message for current privileges
       assert:
         that:
-          - result is changed
+          - result is failed
+          - result.msg.find('exception') != -1
+        fail_msg: "Error granting privileges, invalid priv string: SELECT , query: GRANT SELECT ON *.`data` TO %s@%s , exception: (1064, \"You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '`data` TO 'db_user2'@'localhost'' at line 1\")."

--- a/tests/integration/targets/test_mysql_user/tasks/test_privs_issue_465.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_privs_issue_465.yml
@@ -1,20 +1,5 @@
+---
 # test code for privileges for mysql_user module - issue 465
-# (c) 2014,  Wayne Rosario <wrosario@ansible.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - vars:
     mysql_parameters: &mysql_params
@@ -29,11 +14,11 @@
     - name: create a user with parameters that will always cause an exception
       mysql_user:
         <<: *mysql_params
-        name: '{{ user_name_2 }}'
-        password: '{{ user_password_2 }}'
+        name: user_issue_465
+        password: a_test_password_465
         priv: '*.{{ db_name }}:SELECT'
         state: present
-      ignore_errors: yes
+      ignore_errors: true
       register: result
 
     - name: assert output message for current privileges

--- a/tests/integration/targets/test_mysql_user/tasks/test_privs_issue_465.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_privs_issue_465.yml
@@ -1,0 +1,53 @@
+# test code for privileges for mysql_user module - issue 465
+# (c) 2014,  Wayne Rosario <wrosario@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    - name: create admin user with ALL privs, without GRANT OPTIONS
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        password: '{{ user_password_1 }}'
+        priv: '*.{{ db_name }}:ALL'
+        state: present
+
+    - include: assert_user.yml user_name={{user_name_2}} priv='ALL'
+
+    - name: create consumer user with all privileges using admin user
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_2 }}'
+        password: '{{ user_password_2 }}'
+        login_user: '{{ user_name_1 }}'
+        login_password: '{{ user_password_1 }}'
+        priv: '*.{{ db_name }}:ALL'
+        state: present
+      register: result
+
+    - name: assert output message for current privileges
+      assert:
+        that:
+          - result is changed


### PR DESCRIPTION

##### SUMMARY
When a mysql_user module is used and fails the error usually is abstracted/reduced to `msg": "Error granting privileges, invalid priv string: ALL"`
This often has nothing to do with the actual error but the user will never know

##### ISSUE TYPE
- Bug Report

##### COMPONENT NAME
mysql_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible [core 2.13.6rc1]
  config file = /home/bizmate/Documents/siti-web/myapp-infra/rancher1/ansible/ansible.cfg
  configured module search path = ['/home/bizmate/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /home/bizmate/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.10.6 (main, Nov  2 2022, 18:53:38) [GCC 11.3.0]
  jinja version = 3.0.3
  libyaml = True

```

##### COLLECTION VERSION
<!--- Paste verbatim output from "ansible-galaxy collection list <namespace>.<collection>"  between the quotes
for example: ansible-galaxy collection list community.general
-->
```
# /usr/lib/python3/dist-packages/ansible_collections
Collection      Version
--------------- -------
community.mysql 3.5.1  

# /home/bizmate/.ansible/collections/ansible_collections
Collection      Version
--------------- -------
community.mysql 3.5.1  

```

##### CONFIGURATION
<!--- Paste verbatim output from "ansible-config dump --only-changed" between quotes -->
```
DEFAULT_HOST_LIST(/home/bizmate/Documents/siti-web/myapp-infra/rancher1/ansible/ansible.cfg) = ['/home/bizmate/Documents/siti-web/myapp-infra/rancher1/ansible/inventory']
DEFAULT_PRIVATE_KEY_FILE(/home/bizmate/Documents/siti-web/myapp-infra/rancher1/ansible/ansible.cfg) = /home/bizmate/.ssh/id_rsa_MyApp_Infra
DEFAULT_REMOTE_USER(/home/bizmate/Documents/siti-web/myapp-infra/rancher1/ansible/ansible.cfg) = root
HOST_KEY_CHECKING(/home/bizmate/Documents/siti-web/myapp-infra/rancher1/ansible/ansible.cfg) = False
```

##### OS / ENVIRONMENT
ubuntu 18, mysql 5.7

##### STEPS TO REPRODUCE
1 - add a user without grant options, ie not root
2 - use this user to create another user with access to a specific DB
3 - the command `mysql_user` will fail and display error `"Error granting privileges, invalid priv string: ALL"` even if there is not problem with the actual permission requested and instead the problem is the user used as the admin user when adding another user.

<!--- Paste example playbooks or commands between quotes below -->
```yaml

# This creates a user for administration purposes. Notice that it is created without WITH GRANT OPTION
- name: create mysql admin user
  block:
    - name: run query as admin with password
      community.mysql.mysql_query:
        login_db: mysql
        query: SHOW DATABASES;
        login_user: "{{ lookup('env', 'MYSQL_RANCHER1_ADMIN_USER') }}"
        login_password: "{{ lookup('env', 'MYSQL_RANCHER1_ADMIN_PASS') }}"
  rescue:
    - name: set up admin user
      become: true
      become_user: root
      shell:
        cmd: sudo mysql -u root -e "USE mysql;CREATE USER '{{ lookup('env', 'MYSQL_RANCHER1_ADMIN_USER') }}'@'{{ item }}' IDENTIFIED BY '{{ lookup('env', 'MYSQL_RANCHER1_ADMIN_PASS') }}';GRANT ALL PRIVILEGES ON *.* TO '{{ lookup('env', 'MYSQL_RANCHER1_ADMIN_USER') }}'@'{{ item }}' ;FLUSH PRIVILEGES;"
      with_items:
        - localhost
        - "{{ ansible_default_ipv4.address }}"
  tags:
    - mysqldebug

# This Database is created and will be consumed by the user we create below
- name: create a new database
  mysql_db: name=cattle state=present login_user={{ lookup('env', 'MYSQL_RANCHER1_ADMIN_USER') }} login_password="{{ lookup('env', 'MYSQL_RANCHER1_ADMIN_PASS') }}"

- name: add rancher user to consume cattle db
  become: true
  become_user: root
  mysql_user:
    name: rancher
    host: "{{ item }}"
    password: "{{ lookup('env', 'MYSQL_RANCHER1_RANCHER_PASS') }}"
    login_user: "{{ lookup('env', 'MYSQL_RANCHER1_ADMIN_USER') }}"
    login_password: "{{ lookup('env', 'MYSQL_RANCHER1_ADMIN_PASS') }}"
    check_implicit_admin: yes
    priv:
      'cattle.*' : 'ALL,GRANT'
    state: present
    check_implicit_admin: no
  with_items:
    - "{{ ansible_default_ipv4.address }}"
    - localhost
  tags:
    - mysqldebug

```


##### EXPECTED RESULTS
When mysql_user throws an exception also print the actual exception message so the user knows what really happened ie

`Error granting privileges, invalid priv string: ALL and exception: XYZ"`
 
##### ACTUAL RESULTS
As per steps to reproduce the user does not really know what is happening.

Fixes https://github.com/ansible-collections/community.mysql/issues/465

As similar problem is most likely happening with https://github.com/ansible-collections/community.mysql/issues/462



