### PR TITLE
Add fixed version of Ubuntu instead of latest

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   sanity:
     name: "Sanity (Ansible: ${{ matrix.ansible }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         ansible:
@@ -39,7 +39,7 @@ jobs:
 
   integration:
     name: "Integration (Python: ${{ matrix.python }}, Ansible: ${{ matrix.ansible }}, MySQL: ${{ matrix.db_engine_version }}, Connector: ${{ matrix.connector }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
           testing-type: integration
 
   units:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Units (Ⓐ${{ matrix.ansible }})
     strategy:
       # As soon as the first unit test fails,

--- a/.github/workflows/ansible-test-roles.yml
+++ b/.github/workflows/ansible-test-roles.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   molecule:
     name: "Molecule (Python: ${{ matrix.python }}, Ansible: ${{ matrix.ansible }}, MySQL: ${{ matrix.mysql }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1


### PR DESCRIPTION
This is because "ubuntu-latest" link to ubuntu-22.04 which includes cgroup-v2. I think our tests fails because of that. See https://github.com/ansible-collections/news-for-maintainers/issues/28 for more information.
