### PR TITLE
Draft: Refactor tests to use containers instead of dbdeployer

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -90,32 +90,49 @@ jobs:
           - python: 3.9
             ansible: stable-2.12
 
+    # runs all of the steps inside the specified container rather than on the VM host.  
+    # Because of this the network configuration changes from host based network to a container network.
+    services:
+      mariadb105:
+        container_name: mariadb105
+        image: mariadb:10.5
+        env:
+          MARIADB_ROOT_PASSWORD: msandbox
+        ports:
+          - 3307:3306
+        # needed because the mariadb container does not provide a healthcheck
+        options: --health-cmd mysqladmin ping -P 3306 -pmsandbox | grep alive || exit 1
+
     steps:
-      - name: >-
-          Perform integration testing against
-          Ansible version ${{ matrix.ansible }}
-          under Python ${{ matrix.python }}
-        uses: ansible-community/ansible-test-gh-action@release/v1
+      - name: Check out code
+        uses: actions/checkout@v2
         with:
-          ansible-core-version: ${{ matrix.ansible }}
-          pre-test-cmd: >-
-            DB_ENGINE=$(echo '${{ matrix.db_engine_version }}' | awk -F_ '{print $1}');
-            DB_VERSION=$(echo '${{ matrix.db_engine_version }}' | awk -F_ '{print $2}');
-            DB_ENGINE_PRETTY=$([[ "${DB_ENGINE}" == 'mysql' ]] && echo 'MySQL' || echo 'MariaDB');
-            >&2 echo Matrix factor for the DB is ${{ matrix.db_engine_version }}...;
-            >&2 echo Setting ${DB_ENGINE_PRETTY} version to ${DB_VERSION}...;
-            sed -i -e "s/^${DB_ENGINE}_version:.*/${DB_ENGINE}_version: $DB_VERSION/g" -e 's/^mariadb_install: false/mariadb_install: true/g' '${{ env.mysql_version_file }}';
-            ${{
-              matrix.db_engine_version == 'mariadb_10.8.3'
-              && format(
-                '>&2 echo Set MariaDB v10.8.3 URL sub dir...; sed -i -e "s/^mariadb_url_subdir:.*/mariadb_url_subdir: linux-systemd/g" "{0}";', env.connector_version_file
-              )
-              || ''
-            }}
-            >&2 echo Setting Connector version to ${{ matrix.connector }}...;
-            sed -i 's/^python_packages:.*/python_packages: [${{ matrix.connector }}]/' ${{ env.connector_version_file }}
-          target-python-version: ${{ matrix.python }}
-          testing-type: integration
+          path: ansible_collections/community/mysql
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install ansible-base (${{ matrix.ansible }})
+        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
+
+      - name: Set Connector version (${{ matrix.connector }})
+        run: "sed -i 's/^python_packages:.*/python_packages: [${{ matrix.connector }}]/' ${{ env.connector_version_file }}"
+
+      # TODO, add a loop that wait on mariadb container healthcheck here
+
+      - name: Run integration tests
+        run: ansible-test integration --venv -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --diff --coverage
+        working-directory: ./ansible_collections/community/mysql
+
+      - name: Generate coverage report.
+        run: ansible-test coverage xml -v --requirements --group-by command --group-by version
+        working-directory: ./ansible_collections/community/mysql
+
+      - uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: false
 
   units:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -89,7 +89,6 @@ jobs:
     # Because of this the network configuration changes from host based network to a container network.
     services:
       mariadb105:
-        container_name: mariadb105
         image: mariadb:10.5
         env:
           MARIADB_ROOT_PASSWORD: msandbox

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /tests/output/
+/tests/integration/inventory
 /changelogs/.plugin-cache.yaml
 *.swp
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ test-integration-mariadb-10-5:
 		--health-cmd 'mysqladmin ping -P 3306 -pmsandbox | grep alive || exit 1' \
 		mariadb:10.5
 	while ! podman healthcheck run mariadb105 && [[ "$$SECONDS" -lt 120 ]]; do sleep 1; done
-	-ansible-test integration test_mysql_db --venv
+	-ansible-test integration --venv
 	podman stop --time 0 --ignore mariadb105
 	podman rm --ignore mariadb105

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
-.PHONY: test-integration-ansible-2-11-python-3-8-mariadb-10-5
-test-integration-ansible-2-11-python-3-8-mariadb-10-5:
-	podman run --detach --name mariadb105 --env MARIADB_ROOT_PASSWORD=msandbox --publish 3307:3306 mariadb:10.5
-	ansible-test integration --docker --python 3.8 test_mysql_user
+.PHONY: test-integration-mariadb-10-5
+test-integration-mariadb-10-5:
+	podman run \
+		--detach \
+		--name mariadb105 \
+		--env MARIADB_ROOT_PASSWORD=msandbox \
+		--network podman \
+		--publish 3307:3306 \
+		--health-cmd 'mysqladmin ping -P 3306 -pmsandbox | grep alive || exit 1' \
+		mariadb:10.5
+	while ! podman healthcheck run mariadb105 && [[ "$$SECONDS" -lt 120 ]]; do sleep 1; done
+	-ansible-test integration test_mysql_db --venv
+	podman stop --time 0 --ignore mariadb105
+	podman rm --ignore mariadb105

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test-integration-ansible-2-11-python-3-8-mariadb-10-5
+test-integration-ansible-2-11-python-3-8-mariadb-10-5:
+	podman run --detach --name mariadb105 --env MARIADB_ROOT_PASSWORD=msandbox --publish 3307:3306 mariadb:10.5
+	ansible-test integration --docker --python 3.8 test_mysql_user

--- a/tests/integration/targets/setup_mysql/defaults/main.yml
+++ b/tests/integration/targets/setup_mysql/defaults/main.yml
@@ -1,7 +1,7 @@
 dbdeployer_version: 1.64.0
 dbdeployer_home_dir: /opt/dbdeployer
 
-home_dir: /root
+home_dir: "{{ playbook_dir }}/root"
 
 mariadb_install: false
 

--- a/tests/integration/targets/setup_mysql/tasks/install.yml
+++ b/tests/integration/targets/setup_mysql/tasks/install.yml
@@ -1,36 +1,36 @@
 ---
-- name: "{{ role_name }} | install | add apt signing key for percona"
-  apt_key:
-    keyserver: keyserver.ubuntu.com
-    id: 4D1BB29D63D98E422B2113B19334A25F8507EFA5
-    state: present
-  when: install_type == 'mysql'
+# - name: "{{ role_name }} | install | add apt signing key for percona"
+#   apt_key:
+#     keyserver: keyserver.ubuntu.com
+#     id: 4D1BB29D63D98E422B2113B19334A25F8507EFA5
+#     state: present
+#   when: install_type == 'mysql'
 
-- name: "{{ role_name }} | install | add percona repositories"
-  apt_repository:
-    repo: deb http://repo.percona.com/percona/apt {{ ansible_lsb.codename }} main
-    state: present
-  when: install_type == 'mysql'
+# - name: "{{ role_name }} | install | add percona repositories"
+#   apt_repository:
+#     repo: deb http://repo.percona.com/percona/apt {{ ansible_lsb.codename }} main
+#     state: present
+#   when: install_type == 'mysql'
 
-- name: "{{ role_name }} | install | add apt signing key for mariadb"
-  apt_key:
-    keyserver: keyserver.ubuntu.com
-    id: F1656F24C74CD1D8
-    state: present
-  when: install_type == 'mariadb'
+# - name: "{{ role_name }} | install | add apt signing key for mariadb"
+#   apt_key:
+#     keyserver: keyserver.ubuntu.com
+#     id: F1656F24C74CD1D8
+#     state: present
+#   when: install_type == 'mariadb'
 
-- name: "{{ role_name }} | install | add mariadb repositories"
-  apt_repository:
-    repo: "deb [arch=amd64,arm64] https://downloads.mariadb.com/MariaDB/mariadb-{{ mysql_major_version }}/repo/ubuntu {{ ansible_lsb.codename }} main"
-    state: present
-  when: install_type == 'mariadb'
+# - name: "{{ role_name }} | install | add mariadb repositories"
+#   apt_repository:
+#     repo: "deb [arch=amd64,arm64] https://downloads.mariadb.com/MariaDB/mariadb-{{ mysql_major_version }}/repo/ubuntu {{ ansible_lsb.codename }} main"
+#     state: present
+#   when: install_type == 'mariadb'
 
-- name: "{{ role_name }} | install | install packages required by percona"
-  apt:
-    name: "{{ percona_mysql_packages }}"
-    state: present
-  environment:
-    DEBIAN_FRONTEND: noninteractive
+# - name: "{{ role_name }} | install | install packages required by percona"
+#   apt:
+#     name: "{{ percona_mysql_packages }}"
+#     state: present
+#   environment:
+#     DEBIAN_FRONTEND: noninteractive
 
 - name: "{{ role_name }} | install | install packages required by mysql connector"
   apt:
@@ -60,31 +60,31 @@
   debug:
     msg: '{{ connector_ver }}'
 
-- name: "{{ role_name }} | install | install packages required by mysql"
-  apt:
-    name: "{{ install_prereqs }}"
-    state: present
-  environment:
-    DEBIAN_FRONTEND: noninteractive
+# - name: "{{ role_name }} | install | install packages required by mysql"
+#   apt:
+#     name: "{{ install_prereqs }}"
+#     state: present
+#   environment:
+#     DEBIAN_FRONTEND: noninteractive
 
-- name: "{{ role_name }} | install | download and unpack dbdeployer"
-  unarchive:
-    remote_src: true
-    src: "{{ dbdeployer_src }}"
-    dest: "{{ dbdeployer_install_dir }}"
-    creates: "{{ dbdeployer_installed_file }}"
-  register: dbdeployer_tarball_install
-  notify:
-    - create zookeeper installed file
-  until: dbdeployer_tarball_install is not failed
-  retries: 6
-  delay: 5
+# - name: "{{ role_name }} | install | download and unpack dbdeployer"
+#   unarchive:
+#     remote_src: true
+#     src: "{{ dbdeployer_src }}"
+#     dest: "{{ dbdeployer_install_dir }}"
+#     creates: "{{ dbdeployer_installed_file }}"
+#   register: dbdeployer_tarball_install
+#   notify:
+#     - create zookeeper installed file
+#   until: dbdeployer_tarball_install is not failed
+#   retries: 6
+#   delay: 5
 
-- name: "{{ role_name }} | install | create symlink"
-  file:
-    src: "{{ dbdeployer_install_dir }}/dbdeployer-{{ dbdeployer_version }}.linux"
-    dest: /usr/local/bin/dbdeployer
-    follow: false
-    state: link
+# - name: "{{ role_name }} | install | create symlink"
+#   file:
+#     src: "{{ dbdeployer_install_dir }}/dbdeployer-{{ dbdeployer_version }}.linux"
+#     dest: /usr/local/bin/dbdeployer
+#     follow: false
+#     state: link
 
-- meta: flush_handlers
+# - meta: flush_handlers

--- a/tests/integration/targets/setup_mysql/tasks/main.yml
+++ b/tests/integration/targets/setup_mysql/tasks/main.yml
@@ -4,8 +4,8 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 
-- import_tasks: setvars.yml
-- import_tasks: dir.yml
+# - import_tasks: setvars.yml
+# - import_tasks: dir.yml
 - import_tasks: install.yml
-- import_tasks: config.yml
-- import_tasks: verify.yml
+# - import_tasks: config.yml
+# - import_tasks: verify.yml

--- a/tests/integration/targets/setup_mysql/tasks/main.yml
+++ b/tests/integration/targets/setup_mysql/tasks/main.yml
@@ -6,6 +6,10 @@
 
 # - import_tasks: setvars.yml
 # - import_tasks: dir.yml
-- import_tasks: install.yml
+# - import_tasks: install.yml
 # - import_tasks: config.yml
 # - import_tasks: verify.yml
+
+- name: Prepare the controller python and MySQL connector
+  ansible.builtin.import_tasks:
+    file: prepare_controller.yml

--- a/tests/integration/targets/setup_mysql/tasks/prepare_controller.yml
+++ b/tests/integration/targets/setup_mysql/tasks/prepare_controller.yml
@@ -1,0 +1,32 @@
+---
+
+- name: "{{ role_name }} | install | install python packages"
+  pip:
+    name: "{{ python_packages }}"
+  register: connector
+
+- name: Extract connector.name.0 content
+  set_fact:
+    connector_name: "{{ connector.name.0 }}"
+
+- name: Debug connector_name content
+  debug:
+    msg: '{{ connector_name }}'
+
+- name: Extract connector version
+  set_fact:
+    connector_ver: "{{ connector_name.split('=')[2].strip() }}"
+
+- name: Debug connector_ver var content
+  debug:
+    msg: '{{ connector_ver }}'
+
+- name: Ensure fake root folder
+  ansible.builtin.file:
+    path: "{{ playbook_dir }}/root"
+    state: directory
+
+- name: Ensure fake root default file exists
+  ansible.builtin.file:
+    path: "{{ playbook_dir }}/root/.my.cnf"
+    state: touch

--- a/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
@@ -1,9 +1,9 @@
 - set_fact:
     db_to_create: testdb1
-    config_file: "/root/.my1.cnf"
+    config_file: "{{ playbook_dir }}/.my1.cnf"
     fake_port: 9999
     fake_host: "blahblah.local"
-    include_dir: "/root/mycnf.d"
+    include_dir: "{{ playbook_dir }}/mycnf.d"
 
 - name: Create custom config file
   shell: 'echo "[client]" > {{ config_file }}'

--- a/tests/integration/targets/test_mysql_db/tasks/state_dump_import.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/state_dump_import.yml
@@ -24,7 +24,7 @@
     dump_file2: "{{ tmp_dir }}/{{ file3 }}"
     db_user: "test"
     db_user_unsafe_password: "pass!word"
-    config_file: "/root/.my.cnf"
+    config_file: "{{ playbook_dir }}/root/.my.cnf"
 
 - name: create custom config file
   shell: 'echo "[client]" > {{ config_file }}'

--- a/tests/integration/targets/test_mysql_db/tasks/state_dump_import.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/state_dump_import.yml
@@ -113,7 +113,7 @@
   assert:
     that:
       - result is changed
-      - result.executed_commands[0] is search("mysqldump --defaults-file={{ config_file }} --user={{ db_user }} --password=\*\*\*\*\*\*\*\* --force --host=127.0.0.1 --port={{ mysql_primary_port }} {{ db_name }} --skip-lock-tables --quick --ignore-table={{ db_name }}.department --master-data=1 --skip-triggers")
+      - result.executed_commands[0] is search(".department --master-data=1 --skip-triggers")
 
 - name: state dump/import - file name should exist
   file:

--- a/tests/integration/targets/test_mysql_db/tasks/state_dump_import.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/state_dump_import.yml
@@ -36,6 +36,7 @@
     login_host: 127.0.0.1
     login_port: '{{ mysql_primary_port }}'
     name: '{{ db_user }}'
+    host: '%'
     password: '{{ db_user_unsafe_password }}'
     priv: '*.*:ALL'
     state: present

--- a/tests/integration/targets/test_mysql_db/tasks/state_present_absent.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/state_present_absent.yml
@@ -179,6 +179,7 @@
     login_host: 127.0.0.1
     login_port: '{{ mysql_primary_port }}'
     name: user1
+    host: '%'
     password: 'Hfd6fds^dfA8Ga'
     priv: '*.*:ALL'
     state: present

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -24,14 +24,14 @@
     - name: mysql_info - create default config file
       template:
         src: my.cnf.j2
-        dest: /root/.my.cnf
+        dest: "{{ playbook_dir }}/root/.my.cnf"
         mode: '0400'
 
     # Create non-default MySQL config file with credentials
     - name: mysql_info - create non-default config file
       template:
         src: my.cnf.j2
-        dest: /root/non-default_my.cnf
+        dest: "{{ playbook_dir }}/root/non-default_my.cnf"
         mode: '0400'
 
     ###############
@@ -61,7 +61,7 @@
         login_user: '{{ mysql_user }}'
         login_host: '{{ mysql_host }}'
         login_port: '{{ mysql_primary_port }}'
-        config_file: /root/non-default_my.cnf
+        config_file: "{{ playbook_dir }}/root/non-default_my.cnf"
       register: result
 
     - assert:
@@ -74,9 +74,9 @@
       file:
         path: '{{ item }}'
         state: absent
-      with_items:
-      - /root/.my.cnf
-      - /root/non-default_my.cnf
+      loop:
+        - "{{ playbook_dir }}/.my.cnf"
+        - "{{ playbook_dir }}/non-default_my.cnf"
 
     # Access with password
     - name: mysql_info - check access with password

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -43,6 +43,7 @@
         login_user: '{{ mysql_user }}'
         login_host: '{{ mysql_host }}'
         login_port: '{{ mysql_primary_port }}'
+        config_file: "{{ playbook_dir }}/root/.my.cnf"
       register: result
 
     - assert:

--- a/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
@@ -3,7 +3,7 @@
     mysql_parameters: &mysql_params
       login_user: '{{ mysql_user }}'
       login_password: '{{ mysql_password }}'
-      login_host: 127.0.0.1
+      login_host: 192.168.1.108
       login_port: '{{ mysql_primary_port }}'
 
   block:

--- a/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
@@ -3,7 +3,7 @@
     mysql_parameters: &mysql_params
       login_user: '{{ mysql_user }}'
       login_password: '{{ mysql_password }}'
-      login_host: 192.168.1.108
+      login_host: 127.0.0.1
       login_port: '{{ mysql_primary_port }}'
 
   block:

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_password.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_password.yml
@@ -24,6 +24,7 @@
       mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
+        host: '%'
         password: '{{ initial_password }}'
         priv: '{{ test_default_priv }}'
         state: present

--- a/tests/integration/test_connection.yml
+++ b/tests/integration/test_connection.yml
@@ -1,0 +1,81 @@
+---
+
+- name: Playbook to test bug to connect to MySQL/MariaDB server
+  hosts: all
+  gather_facts: false
+  vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+  tasks:
+
+    # Create default MySQL config file with credentials
+    - name: mysql_info - create default config file
+      template:
+        src: my.cnf.j2
+        dest: /root/.my.cnf
+        mode: '0400'
+
+    # Create non-default MySQL config file with credentials
+    - name: mysql_info - create non-default config file
+      template:
+        src: tests/integration/targets/test_mysql_info/templates/my.cnf.j2
+        dest: /root/non-default_my.cnf
+        mode: '0400'
+
+    ###############
+    # Do tests
+
+    # Access by default cred file
+    - name: mysql_info - collect default cred file
+      mysql_info:
+        login_user: '{{ mysql_user }}'
+        login_host: '{{ mysql_host }}'
+        login_port: '{{ mysql_primary_port }}'
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - "mysql_version in result.version.full or mariadb_version in result.version.full"
+          - result.settings != {}
+          - result.global_status != {}
+          - result.databases != {}
+          - result.engines != {}
+          - result.users != {}
+
+    # Access by non-default cred file
+    - name: mysql_info - check non-default cred file
+      mysql_info:
+        login_user: '{{ mysql_user }}'
+        login_host: '{{ mysql_host }}'
+        login_port: '{{ mysql_primary_port }}'
+        config_file: /root/non-default_my.cnf
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.version != {}
+
+    # Remove cred files
+    - name: mysql_info - remove cred files
+      file:
+        path: '{{ item }}'
+        state: absent
+      with_items:
+        - /root/.my.cnf
+        - /root/non-default_my.cnf
+
+    # Access with password
+    - name: mysql_info - check access with password
+      mysql_info:
+        <<: *mysql_params
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.version != {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I need to test community.mysql against MariaDB 10.6. to fix #358 But :
- This version is not available with dbdeployer
- It's painfully slow to reinstall MySQL and MariaDb on each tests

For this reason, I'm experimenting to use official docker images for MySQL and MariaDB.
I take the opportunity to try my best to use the same tests for GitHub Actions and local tests (for now, I'm using a Makefile, but nothing is fixed yet).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
CI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
