### PR TITLE
mysql_user: enabled autocommit to support MySQL 8

### DIFF
--- a/changelogs/fragments/479_enable_auto_commit.yml
+++ b/changelogs/fragments/479_enable_auto_commit.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - mysql_user - enable auto_commit to avoid MySQL metadata table lock (https://github.com/ansible-collections/community.mysql/pull/483)
+  - mysql_user - enable auto_commit to avoid MySQL metadata table lock (https://github.com/ansible-collections/community.mysql/issues/479).

--- a/changelogs/fragments/479_enable_auto_commit.yml
+++ b/changelogs/fragments/479_enable_auto_commit.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - mysql_user - enable auto_commit to avoid MySQL metadata table lock (https://github.com/ansible-collections/community.mysql/pull/483)

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -433,13 +433,13 @@ def main():
         if check_implicit_admin:
             try:
                 cursor, db_conn = mysql_connect(module, "root", "", config_file, ssl_cert, ssl_key, ssl_ca, db,
-                                                connect_timeout=connect_timeout, check_hostname=check_hostname)
+                                                connect_timeout=connect_timeout, check_hostname=check_hostname, autocommit=True)
             except Exception:
                 pass
 
         if not cursor:
             cursor, db_conn = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, db,
-                                            connect_timeout=connect_timeout, check_hostname=check_hostname)
+                                            connect_timeout=connect_timeout, check_hostname=check_hostname, autocommit=True)
     except Exception as e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. "
                              "Exception message: %s" % (config_file, to_native(e)))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enable auto-commit for mysql_user module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #479 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_user
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I have:
- not adjusted any tests since I didn't immediately see how I'd model this specific behaviour in tests _and I don't intend to become a regular contributor..._
- run unit tests, they passed
- run integration tests, they failed (trace attached); I've run this on Docker on macOS on an ARM machine, so this may not be representative 😐 ; looks to me like the URL might've changed.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [setup_mysql : setup_mysql | config | download mysql tarball] *************
fatal: [testhost]: FAILED! => {"changed": false, "dest": "/root/downloads/mysql-8.0.22-linux-glibc2.12-x86_64.tar.xz", "elapsed": 0, "msg": "Request failed", "response": "HTTP Error 403: Forbidden", "status_code": 403, "url": "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.22-linux-glibc2.12-x86_64.tar.xz"}

PLAY RECAP *********************************************************************
testhost                   : ok=22   changed=10   unreachable=0    failed=1    skipped=2    rescued=0    ignored=0

NOTICE: To resume at this test target, use the option: --start-at test_mysql_user
ERROR: Command "ansible-playbook test_mysql_user-8vc8g4qc.yml -i inventory -v" returned exit status 2.
Run command: docker exec 7e7a02254cee55d6a92255ad26a94b195f780d376b84cbe950f69b5b75fcffa2 tar czf /root/output.tgz --exclude .tmp -C /root/ansible_collections/community/mysq ...
Run command: docker exec -i 7e7a02254cee55d6a92255ad26a94b195f780d376b84cbe950f69b5b75fcffa2 dd if=/root/output.tgz bs=65536
Run command: tar oxzf /var/folders/25/mtvt8dcd50xgwrgr7d0vkpxm0000gn/T/ansible-result-t9eaptyl.tgz -C /Users/ghostlyrics/ansible_collections/community/mysql/tests
Run command: docker rm -f 7e7a02254cee55d6a92255ad26a94b195f780d376b84cbe950f69b5b75fcffa2
ERROR: Command "docker exec 7e7a02254cee55d6a92255ad26a94b195f780d376b84cbe950f69b5b75fcffa2 /usr/bin/env ANSIBLE_TEST_CONTENT_ROOT=/root/ansible_collections/community/mysql LC_ALL=en_US.UTF-8 /usr/bin/python3.6 /root/ansible/bin/ansible-test integration test_mysql_user -v --metadata tests/output/.tmp/metadata-m3ebh012.json --truncate 178 --redact --color yes --requirements --allow-destructive" returned exit status 1.
```
