### PR TITLE
mysql_info - Add connector_name and connector_version to returned value

### DIFF
--- a/changelogs/fragments/497_mysql_info_returns_connector_name_and_version
+++ b/changelogs/fragments/497_mysql_info_returns_connector_name_and_version
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - mysql_info - add connector_name and connector_version to returned values

--- a/changelogs/fragments/497_mysql_info_returns_connector_name_and_version
+++ b/changelogs/fragments/497_mysql_info_returns_connector_name_and_version
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - mysql_info - add connector_name and connector_version to returned values

--- a/changelogs/fragments/497_mysql_info_returns_connector_name_and_version.yml
+++ b/changelogs/fragments/497_mysql_info_returns_connector_name_and_version.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - mysql_info - add connector_name and connector_version to returned values

--- a/changelogs/fragments/497_mysql_info_returns_connector_name_and_version.yml
+++ b/changelogs/fragments/497_mysql_info_returns_connector_name_and_version.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - mysql_info - add connector_name and connector_version to returned values
+  - mysql_info - add ``connector_name`` and ``connector_version`` to returned values (https://github.com/ansible-collections/community.mysql/pull/497).

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -67,7 +67,7 @@ def get_driver_version(mysql_driver):
     if driver_name == 'pymysql':
         # pymysql has two methods:
         # - __version__ that returns the string: 0.7.11.None
-        # - VERSION that returns the tupple (0, 7, 11, None)
+        # - VERSION that returns the tuple (0, 7, 11, None)
         v = mysql_driver.VERSION[:3]
         return '.'.join(map(str, v))
     elif driver_name == 'MySQLdb':

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -35,6 +35,8 @@ mysql_driver_fail_msg = ('A MySQL module is required: for Python 2.7 either PyMy
                          'Consider setting ansible_python_interpreter to use '
                          'the intended Python version.')
 
+from ansible_collections.community.mysql.plugins.module_utils.database import mysql_quote_identifier
+
 
 def get_driver_name(mysql_driver):
     """ (class) -> str

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -70,11 +70,12 @@ def get_driver_version(mysql_driver):
         # - VERSION that returns the tupple (0, 7, 11, None)
         v = mysql_driver.VERSION[:3]
         return '.'.join(map(str, v))
-
-    if driver_name == 'MySQLdb':
+    elif driver_name == 'MySQLdb':
         # version_info returns the tuple (2, 1, 1, 'final', 0)
         v = mysql_driver.version_info[:3]
         return '.'.join(map(str, v))
+    else:
+        return 'Unknown'
 
 
 def parse_from_mysql_config_file(cnf):

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -64,9 +64,6 @@ def get_driver_version(mysql_driver):
 
     driver_name = get_driver_name(mysql_driver)
 
-    if driver_name == 'Unknown':
-        return 'Unknown'
-
     if driver_name == 'pymysql':
         # pymysql has two methods:
         # - __version__ that returns the string: 0.7.11.None

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -38,41 +38,41 @@ mysql_driver_fail_msg = ('A MySQL module is required: for Python 2.7 either PyMy
 from ansible_collections.community.mysql.plugins.module_utils.database import mysql_quote_identifier
 
 
-def get_driver_name(mysql_driver):
+def get_connector_name(connector):
     """ (class) -> str
-    Return the name of the driver (pymysql or mysqlclient (MySQLdb))
-    or 'Unknown' if the driver name is not pymysql or MySQLdb. When adding a
-    connector here, also modify get_driver_version.
+    Return the name of the connector (pymysql or mysqlclient (MySQLdb))
+    or 'Unknown' if not pymysql or MySQLdb. When adding a
+    connector here, also modify get_connector_version.
     """
-    if mysql_driver is None or not hasattr(mysql_driver, '__name__'):
+    if connector is None or not hasattr(connector, '__name__'):
         return 'Unknown'
 
-    if mysql_driver.__name__ not in ['pymysql', 'MySQLdb']:
+    if connector.__name__ not in ['pymysql', 'MySQLdb']:
         return 'Unknown'
 
-    return mysql_driver.__name__
+    return connector.__name__
 
 
-def get_driver_version(mysql_driver):
+def get_connector_version(connector):
     """ (class) -> str
     Return the version of pymysql or mysqlclient (MySQLdb).
-    If the driver name is unknown, this method also return 'Unknown'.
+    Return 'Unknown' if the connector name is unknown.
     """
 
-    if mysql_driver is None:
+    if connector is None:
         return 'Unknown'
 
-    driver_name = get_driver_name(mysql_driver)
+    connector_name = get_connector_name(connector)
 
-    if driver_name == 'pymysql':
+    if connector_name == 'pymysql':
         # pymysql has two methods:
         # - __version__ that returns the string: 0.7.11.None
         # - VERSION that returns the tuple (0, 7, 11, None)
-        v = mysql_driver.VERSION[:3]
+        v = connector.VERSION[:3]
         return '.'.join(map(str, v))
-    elif driver_name == 'MySQLdb':
+    elif connector_name == 'MySQLdb':
         # version_info returns the tuple (2, 1, 1, 'final', 0)
-        v = mysql_driver.version_info[:3]
+        v = connector.version_info[:3]
         return '.'.join(map(str, v))
     else:
         return 'Unknown'

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -56,7 +56,7 @@ def get_driver_name(mysql_driver):
 def get_driver_version(mysql_driver):
     """ (class) -> str
     Return the version of pymysql or mysqlclient (MySQLdb).
-    If the driver name is unknown, this method also return 'Unknown'
+    If the driver name is unknown, this method also return 'Unknown'.
     """
 
     if mysql_driver is None:

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -47,9 +47,6 @@ def get_connector_name(connector):
     if connector is None or not hasattr(connector, '__name__'):
         return 'Unknown'
 
-    if connector.__name__ not in ['pymysql', 'MySQLdb']:
-        return 'Unknown'
-
     return connector.__name__
 
 

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -23,6 +23,7 @@ try:
     _mysql_cursor_param = 'cursor'
 except ImportError:
     try:
+        # mysqlclient is called MySQLdb
         import MySQLdb as mysql_driver
         import MySQLdb.cursors
         _mysql_cursor_param = 'cursorclass'

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -34,7 +34,47 @@ mysql_driver_fail_msg = ('A MySQL module is required: for Python 2.7 either PyMy
                          'Consider setting ansible_python_interpreter to use '
                          'the intended Python version.')
 
-from ansible_collections.community.mysql.plugins.module_utils.database import mysql_quote_identifier
+
+def get_driver_name(mysql_driver):
+    """ (class) -> str
+    Return the name of the driver (pymysql or mysqlclient (MySQLdb))
+    or 'Unknown' if the driver name is not pymysql or MySQLdb. When adding a
+    connector here, also modify get_driver_version.
+    """
+    if mysql_driver is None or not hasattr(mysql_driver, '__name__'):
+        return 'Unknown'
+
+    if mysql_driver.__name__ not in ['pymysql', 'MySQLdb']:
+        return 'Unknown'
+
+    return mysql_driver.__name__
+
+
+def get_driver_version(mysql_driver):
+    """ (class) -> str
+    Return the version of pymysql or mysqlclient (MySQLdb).
+    If the driver name is unknown, this method also return 'Unknown'
+    """
+
+    if mysql_driver is None:
+        return 'Unknown'
+
+    driver_name = get_driver_name(mysql_driver)
+
+    if driver_name == 'Unknown':
+        return 'Unknown'
+
+    if driver_name == 'pymysql':
+        # pymysql has two methods:
+        # - __version__ that returns the string: 0.7.11.None
+        # - VERSION that returns the tupple (0, 7, 11, None)
+        v = mysql_driver.VERSION[:3]
+        return '.'.join(map(str, v))
+
+    if driver_name == 'MySQLdb':
+        # version_info returns the tuple (2, 1, 1, 'final', 0)
+        v = mysql_driver.version_info[:3]
+        return '.'.join(map(str, v))
 
 
 def parse_from_mysql_config_file(cnf):

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -213,6 +213,7 @@ connector_name:
   sample:
   - "pymysql"
   - "MySQLdb"
+  version_added: '3.6.0'
 connector_version:
   description: Version of the python connector used by the plugin. When the driver is not identified, returns C(Unknown).
   returned: always

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -220,6 +220,7 @@ connector_version:
   type: str
   sample:
   - "1.0.2"
+  version_added: '3.6.0'
 '''
 
 from decimal import Decimal

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -215,7 +215,7 @@ connector_name:
   - "MySQLdb"
   version_added: '3.6.0'
 connector_version:
-  description: Version of the python connector used by the plugin. When the driver is not identified, returns C(Unknown).
+  description: Version of the python connector used by the module. When the connector is not identified, returns C(Unknown).
   returned: always
   type: str
   sample:

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -58,6 +58,7 @@ seealso:
 author:
 - Andrew Klychkov (@Andersson007)
 - Sebastian Gumprich (@rndmh3ro)
+- Laurent Indermühle (@laurent-indermuehle)
 
 extends_documentation_fragment:
 - community.mysql.mysql

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -207,7 +207,7 @@ slave_hosts:
   sample:
   - { "2": { "Host": "", "Master_id": 1, "Port": 3306 } }
 connector_name:
-  description: Name of the python connector used by the plugin. When the driver is not identified, returns C(Unknown).
+  description: Name of the python connector used by the module. When the connector is not identified, returns C(Unknown).
   returned: always
   type: str
   sample:

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -231,8 +231,8 @@ from ansible_collections.community.mysql.plugins.module_utils.mysql import (
     mysql_common_argument_spec,
     mysql_driver,
     mysql_driver_fail_msg,
-    get_driver_name,
-    get_driver_version,
+    get_connector_name,
+    get_connector_version,
 )
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
@@ -575,8 +575,8 @@ def main():
     if mysql_driver is None:
         module.fail_json(msg=mysql_driver_fail_msg)
 
-    driver_name = get_driver_name(mysql_driver)
-    driver_version = get_driver_version(mysql_driver)
+    connector_name = get_connector_name(mysql_driver)
+    connector_version = get_connector_version(mysql_driver)
 
     try:
         cursor, db_conn = mysql_connect(module, login_user, login_password,
@@ -586,7 +586,7 @@ def main():
     except Exception as e:
         msg = ('unable to connect to database using %s %s, check login_user '
                'and login_password are correct or %s has the credentials. '
-               'Exception message: %s' % (driver_name, driver_version, config_file, to_native(e)))
+               'Exception message: %s' % (connector_name, connector_version, config_file, to_native(e)))
         module.fail_json(msg)
 
     ###############################
@@ -595,8 +595,8 @@ def main():
     mysql = MySQL_Info(module, cursor)
 
     module.exit_json(changed=False,
-                     connector_name=driver_name,
-                     connector_version=driver_version,
+                     connector_name=connector_name,
+                     connector_version=connector_version,
                      **mysql.get_info(filter_, exclude_fields, return_empty_dbs))
 
 

--- a/tests/integration/targets/test_mysql_info/tasks/connector_info.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/connector_info.yml
@@ -1,0 +1,21 @@
+---
+# Added in 3.6.0 in
+# https://github.com/ansible-collections/community.mysql/pull/497
+
+# TODO: Refactor in PR490.
+- name: Connector info | Assert that connector_name exists and contains expected values
+  ansible.builtin.assert:
+    that:
+      - result.connector_name is defined
+      - result.connector_name ==  connector_name.split(' ')[0]
+    success_msg: Assertions passed, connector_name is {{ result.connector_name }}
+
+# TODO: Refactor in PR490.
+- name: Connector info | Assert that connector_version exists and contains expected values
+  ansible.builtin.assert:
+    that:
+      - result.connector_version is defined
+      - >
+        result.connector_version == 'Unknown'
+        or result.connector_version is version(connector_ver, '==')
+    success_msg: Assertions passed, connector_version is {{ result.connector_version }}

--- a/tests/integration/targets/test_mysql_info/tasks/connector_info.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/connector_info.yml
@@ -7,13 +7,13 @@
   ansible.builtin.assert:
     that:
       - result.connector_name is defined
-      - result.connector_name == connector_name.split('=')[0].strip()
-    success_msg: >
+      - result.connector_name is in ['pymysql', 'MySQLdb']
+    success_msg: >-
       Assertions passed, result.connector_name is {{ result.connector_name }}
-    fail_msg: >
+    fail_msg: >-
       Assertion failed, result.connector_name is
       {{ result.connector_name | d('Unknown')}} which is different than expected
-      {{ connector_name.split('=')[0].strip() }}
+      pymysql or MySQLdb
 
 # TODO: Refactor in PR490.
 - name: Connector info | Assert connector_version exists and has expected values
@@ -23,10 +23,10 @@
       - >
         result.connector_version == 'Unknown'
         or result.connector_version is version(connector_ver, '==')
-    success_msg: >
+    success_msg: >-
       Assertions passed, result.connector_version is
       {{ result.connector_version }}
-    fail_msg: >
+    fail_msg: >-
       Assertion failed, result.connector_version is
       {{ result.connector_version }} which is different than expected
       {{ connector_ver }}

--- a/tests/integration/targets/test_mysql_info/tasks/connector_info.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/connector_info.yml
@@ -3,19 +3,30 @@
 # https://github.com/ansible-collections/community.mysql/pull/497
 
 # TODO: Refactor in PR490.
-- name: Connector info | Assert that connector_name exists and contains expected values
+- name: Connector info | Assert connector_name exists and has expected values
   ansible.builtin.assert:
     that:
       - result.connector_name is defined
-      - result.connector_name ==  connector_name.split(' ')[0]
-    success_msg: Assertions passed, connector_name is {{ result.connector_name }}
+      - result.connector_name == connector_name.split('=')[0].strip()
+    success_msg: >
+      Assertions passed, result.connector_name is {{ result.connector_name }}
+    fail_msg: >
+      Assertion failed, result.connector_name is
+      {{ result.connector_name | d('Unknown')}} which is different than expected
+      {{ connector_name.split('=')[0].strip() }}
 
 # TODO: Refactor in PR490.
-- name: Connector info | Assert that connector_version exists and contains expected values
+- name: Connector info | Assert connector_version exists and has expected values
   ansible.builtin.assert:
     that:
       - result.connector_version is defined
       - >
         result.connector_version == 'Unknown'
         or result.connector_version is version(connector_ver, '==')
-    success_msg: Assertions passed, connector_version is {{ result.connector_version }}
+    success_msg: >
+      Assertions passed, result.connector_version is
+      {{ result.connector_version }}
+    fail_msg: >
+      Assertion failed, result.connector_version is
+      {{ result.connector_version }} which is different than expected
+      {{ connector_ver }}

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -55,6 +55,10 @@
         - result.engines != {}
         - result.users != {}
 
+    - name: mysql_info - Test connector informations display
+      ansible.builtin.import_tasks:
+        file: connector_info.yml
+
     # Access by non-default cred file
     - name: mysql_info - check non-default cred file
       mysql_info:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add two returned values for the `mysql_info` plugin : `connector_name` and `connector_version`.
You may have both mysqlclient and pymysql installed. This helps you know which one was used.

This feature is mandatory for #490 who will add a step that verify that all components have expected versions at the start of integrations tests.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# Before                                                                                                                                                                              
    "changed": false,                                                                                                                                                                     
    "databases": {                                                                                                                                                                        
        "information_schema": {                                                         
            "size": 212992                                          
        },                  

# After                                                                                                                                                                           
    "changed": false,
    "connector_name": "pymysql",
    "connector_version": "0.9.3",                                                                                                                                                                     
    "databases": {                                                                                                                                                                        
        "information_schema": {                                                         
            "size": 212992                                          
        },            
```
