### PR TITLE
mysql_role: enable autocommit

### DIFF
--- a/changelogs/fragments/479_enable_auto_commit_part2.yml
+++ b/changelogs/fragments/479_enable_auto_commit_part2.yml
@@ -1,0 +1,3 @@
+---
+ minor_changes:
+   - mysql_role - enable auto_commit to avoid MySQL metadata table lock (https://github.com/ansible-collections/community.mysql/issues/479).

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -1008,7 +1008,8 @@ def main():
                 cursor, db_conn = mysql_connect(module, 'root', '', config_file,
                                                 ssl_cert, ssl_key, ssl_ca, db,
                                                 connect_timeout=connect_timeout,
-                                                check_hostname=check_hostname)
+                                                check_hostname=check_hostname,
+                                                autocommit=True)
             except Exception:
                 pass
 
@@ -1016,7 +1017,8 @@ def main():
             cursor, db_conn = mysql_connect(module, login_user, login_password,
                                             config_file, ssl_cert, ssl_key,
                                             ssl_ca, db, connect_timeout=connect_timeout,
-                                            check_hostname=check_hostname)
+                                            check_hostname=check_hostname,
+                                            autocommit=True)
 
     except Exception as e:
         module.fail_json(msg='unable to connect to database, '


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enable auto-commit for mysql_role module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #479 (part 2: roles)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_role
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

- I've run flake8. It complains about existing issues related to where you have `import`.
- I've run sanity tests. They pass.
- I've run integration tests. They pass. (FYI: they take 12 minutes on a M1 Macbook Air :joy:)
- I've run unit tests. They pass.
<!--- Paste verbatim command output below, e.g. before and after your change -->
