### PR TITLE
Allow uppercase in variable names for Galera wsrep variables

### DIFF
--- a/changelogs/fragments/mysql_variables_allow_uppercase_identifiers.yml
+++ b/changelogs/fragments/mysql_variables_allow_uppercase_identifiers.yml
@@ -1,0 +1,4 @@
+---
+bugfix:
+  - mysql_variables - Add uppercase character pattern to regex to allow GLOBAL variables containing uppercase characters.
+    This recognises variable names used in Galera, e.g. wsrep_OSU_method, which break the normal pattern of all lowercase characters.  

--- a/changelogs/fragments/mysql_variables_allow_uppercase_identifiers.yml
+++ b/changelogs/fragments/mysql_variables_allow_uppercase_identifiers.yml
@@ -1,6 +1,6 @@
 ---
-bugfix:
-  - mysql_variables - Add uppercase character pattern to regex to allow GLOBAL
+bugfixes:
+  - mysql_variables - add uppercase character pattern to regex to allow GLOBAL
     variables containing uppercase characters.
-    This recognises variable names used in Galera, e.g. wsrep_OSU_method,
-    which break the normal pattern of all lowercase characters.
+    This recognizes variable names used in Galera, for example, ``wsrep_OSU_method``,
+    which breaks the normal pattern of all lowercase characters (https://github.com/ansible-collections/community.mysql/pull/501).

--- a/changelogs/fragments/mysql_variables_allow_uppercase_identifiers.yml
+++ b/changelogs/fragments/mysql_variables_allow_uppercase_identifiers.yml
@@ -1,4 +1,6 @@
 ---
 bugfix:
-  - mysql_variables - Add uppercase character pattern to regex to allow GLOBAL variables containing uppercase characters.
-    This recognises variable names used in Galera, e.g. wsrep_OSU_method, which break the normal pattern of all lowercase characters.  
+  - mysql_variables - Add uppercase character pattern to regex to allow GLOBAL
+    variables containing uppercase characters.
+    This recognises variable names used in Galera, e.g. wsrep_OSU_method,
+    which break the normal pattern of all lowercase characters.

--- a/plugins/modules/mysql_variables.py
+++ b/plugins/modules/mysql_variables.py
@@ -199,7 +199,7 @@ def main():
 
     if mysqlvar is None:
         module.fail_json(msg="Cannot run without variable to operate with")
-    if match('^[0-9a-z_.]+$', mysqlvar) is None:
+    if match('^[0-9A-Za-z_.]+$', mysqlvar) is None:
         module.fail_json(msg="invalid variable name \"%s\"" % mysqlvar)
     if mysql_driver is None:
         module.fail_json(msg=mysql_driver_fail_msg)


### PR DESCRIPTION
##### SUMMARY
Galera wsrep global variables sometimes use uppercase identifiers (e.g. `wsrep_OSU_method`) which causes them to fail validation against the existing regex. While it is possible to refer to these vars with their lowercase equivalents to make them work, this would be more confusing than changing the regex to support legal characters.