### PR TITLE
Fix revoke only grant

### DIFF
--- a/changelogs/fragments/503-fix-revoke-grant-only.yml
+++ b/changelogs/fragments/503-fix-revoke-grant-only.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql_user - when revoke privs consists only of ``GRANT``, a 2nd revoke query is executed with empty privs to revoke that ended in an SQL exception (https://github.com/ansible-collections/community.mysql/pull/503).

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -692,17 +692,19 @@ def privileges_revoke(cursor, user, host, db_table, priv, grant_option, maria_ro
         query = ' '.join(query)
         cursor.execute(query, (user, host))
     priv_string = ",".join([p for p in priv if p not in ('GRANT', )])
-    query = ["REVOKE %s ON %s" % (priv_string, db_table)]
 
-    if not maria_role:
-        query.append("FROM %s@%s")
-        params = (user, host)
-    else:
-        query.append("FROM %s")
-        params = (user,)
+    if priv_string != "":
+        query = ["REVOKE %s ON %s" % (priv_string, db_table)]
 
-    query = ' '.join(query)
-    cursor.execute(query, params)
+        if not maria_role:
+            query.append("FROM %s@%s")
+            params = (user, host)
+        else:
+            query.append("FROM %s")
+            params = (user,)
+
+        query = ' '.join(query)
+        cursor.execute(query, params)
     cursor.execute("FLUSH PRIVILEGES")
 
 

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -322,3 +322,5 @@
 
     # https://github.com/ansible-collections/community.mysql/issues/231
     - include: test_user_grants_with_roles_applied.yml
+
+    - include: revoke_only_grant.yml

--- a/tests/integration/targets/test_mysql_user/tasks/revoke_only_grant.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/revoke_only_grant.yml
@@ -1,0 +1,58 @@
+---
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: 127.0.0.1
+      login_port: '{{ mysql_primary_port }}'
+  block:
+    - name: Drop mysql user if exists
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        state: absent
+      ignore_errors: true
+
+    - name: create user with two grants
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        update_password: on_create
+        priv: '*.*:SELECT,GRANT'
+
+    - name: user must have only on priv, grant priv must be dropped
+      register: result
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        update_password: on_create
+        priv: '*.*:SELECT'
+
+    - assert:
+        that:
+          - result is not failed
+          - result is changed
+
+    - name: immutable - user must have only on priv, grant priv must be dropped
+      register: result
+      mysql_user:
+        <<: *mysql_params
+        name: "{{ user_name_1 }}"
+        password: "{{ user_password_1 }}"
+        update_password: on_create
+        priv: '*.*:SELECT'
+
+    - assert:
+        that:
+          - result is not failed
+          - result is not changed
+
+  always:
+    - name: drop user
+      mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        state: absent
+      ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

When only `grant` is revoked by `mysql_user`, it results in a 2nd sql query, where empty privs are tried to revoked.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
plugs/module_utils/user.py


