### PR TITLE
Add filter to prevent rebuild containers on push on stable-(1|2)

### DIFF
--- a/.github/workflows/docker-image-mariadb-py310-mysqlclient211.yml
+++ b/.github/workflows/docker-image-mariadb-py310-mysqlclient211.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mariadb-py310-mysqlclient211/**'
       - '.github/workflows/docker-image-mariadb-py310-mysqlclient211.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-mariadb-py310-pymysql102.yml
+++ b/.github/workflows/docker-image-mariadb-py310-pymysql102.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mariadb-py310-pymysql102/**'
       - '.github/workflows/docker-image-mariadb-py310-pymysql102.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-mariadb-py38-mysqlclient201.yml
+++ b/.github/workflows/docker-image-mariadb-py38-mysqlclient201.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mariadb-py38-mysqlclient201/**'
       - '.github/workflows/docker-image-mariadb-py38-mysqlclient201.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-mariadb-py38-pymysql093.yml
+++ b/.github/workflows/docker-image-mariadb-py38-pymysql093.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mariadb-py38-pymysql093/**'
       - '.github/workflows/docker-image-mariadb-py38-pymysql093.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-mariadb-py39-mysqlclient203.yml
+++ b/.github/workflows/docker-image-mariadb-py39-mysqlclient203.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mariadb-py39-mysqlclient203/**'
       - '.github/workflows/docker-image-mariadb-py39-mysqlclient203.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-mariadb-py39-pymysql093.yml
+++ b/.github/workflows/docker-image-mariadb-py39-pymysql093.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mariadb-py39-pymysql093/**'
       - '.github/workflows/docker-image-mariadb-py39-pymysql093.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-my57-py38-mysqlclient201.yml
+++ b/.github/workflows/docker-image-my57-py38-mysqlclient201.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/my57-py38-mysqlclient201/**'
       - '.github/workflows/docker-image-my57-py38-mysqlclient201.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-my57-py38-pymysql0711.yml
+++ b/.github/workflows/docker-image-my57-py38-pymysql0711.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/my57-py38-pymysql0711/**'
       - '.github/workflows/docker-image-my57-py38-pymysql0711.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-my57-py38-pymysql093.yml
+++ b/.github/workflows/docker-image-my57-py38-pymysql093.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/my57-py38-pymysql093/**'
       - '.github/workflows/docker-image-my57-py38-pymysql093.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-mysql-py310-mysqlclient211.yml
+++ b/.github/workflows/docker-image-mysql-py310-mysqlclient211.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mysql-py310-mysqlclient211/**'
       - '.github/workflows/docker-image-mysql-py310-mysqlclient211.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-mysql-py310-pymysql102.yml
+++ b/.github/workflows/docker-image-mysql-py310-pymysql102.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mysql-py310-pymysql102/**'
       - '.github/workflows/docker-image-mysql-py310-pymysql102.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-mysql-py38-mysqlclient201.yml
+++ b/.github/workflows/docker-image-mysql-py38-mysqlclient201.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mysql-py38-mysqlclient201/**'
       - '.github/workflows/docker-image-mysql-py38-mysqlclient201.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-mysql-py38-pymysql093.yml
+++ b/.github/workflows/docker-image-mysql-py38-pymysql093.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mysql-py38-pymysql093/**'
       - '.github/workflows/docker-image-mysql-py38-pymysql093.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-mysql-py39-mysqlclient203.yml
+++ b/.github/workflows/docker-image-mysql-py39-mysqlclient203.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mysql-py39-mysqlclient203/**'
       - '.github/workflows/docker-image-mysql-py39-mysqlclient203.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 

--- a/.github/workflows/docker-image-mysql-py39-pymysql093.yml
+++ b/.github/workflows/docker-image-mysql-py39-pymysql093.yml
@@ -7,6 +7,8 @@ on:
       - 'test-containers/mysql-py39-pymysql093/*'
       - '.github/workflows/docker-image-mysql-py39-pymysql093.yml'
       - '.github/workflows/build-docker-image.yml'
+    branches-ignore:
+      - stable-*
 
 jobs:
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When we backport changes to stable-1 and stable-2, the workflows responsible to build the containers images are triggered. This is useless because if we backport from main, it means the containers are already published! No need to overwrite them (almost 2GB each...)

Thus I propose to filter out `stable-*` branches from the triggers.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
GHA

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
on:
  push:
    paths:
      - 'test-containers/mysql-py39-pymysql093/*'
      - '.github/workflows/docker-image-mysql-py39-pymysql093.yml'
      - '.github/workflows/build-docker-image.yml'
    branches-ignore:
      - stable-*
```
I think adding `branches-ignore` in the `push` trigger is enough. 

Or maybe it's best to trigger only on `main`? Then if someone changes the images on his fork, the images won't be rebuilt while opening a PR.

But how to update the containers? Do you need to remove the filter on the 15 workflows? And remember to put them back afterward?

Do anyone have experiences with triggers on commit messages? Like this:

```yaml
jobs:
  call-workflow-passing-data:
    if: "contains(github.event.head_commit.message, '[publish]')"
``` 