### PR TITLE
Add MAX_STATEMENT_TIME resource limit

### DIFF
--- a/changelogs/fragments/523-add-max_statement_time_resource-limit.yml
+++ b/changelogs/fragments/523-add-max_statement_time_resource-limit.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - mysql_user - add ``MAX_STATEMENT_TIME`` support for mariadb to the ``resource_limits`` argument (https://github.com/ansible-collections/community.mysql/issues/211).

--- a/plugins/module_utils/implementations/mariadb/user.py
+++ b/plugins/module_utils/implementations/mariadb/user.py
@@ -17,3 +17,9 @@ def use_old_user_mgmt(cursor):
 
 def supports_identified_by_password(cursor):
     return True
+
+
+def server_supports_alter_user(cursor):
+    version = get_server_version(cursor)
+
+    return LooseVersion(version) >= LooseVersion("10.2")

--- a/plugins/module_utils/implementations/mysql/user.py
+++ b/plugins/module_utils/implementations/mysql/user.py
@@ -18,3 +18,9 @@ def use_old_user_mgmt(cursor):
 def supports_identified_by_password(cursor):
     version = get_server_version(cursor)
     return LooseVersion(version) < LooseVersion("8")
+
+
+def server_supports_alter_user(cursor):
+    version = get_server_version(cursor)
+
+    return LooseVersion(version) >= LooseVersion("5.6")

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -753,33 +753,6 @@ def convert_priv_dict_to_str(priv):
     return '/'.join(priv_list)
 
 
-# Alter user is supported since MySQL 5.6 and MariaDB 10.2.0
-def server_supports_alter_user(cursor):
-    """Check if the server supports ALTER USER statement or doesn't.
-
-    Args:
-        cursor (cursor): DB driver cursor object.
-
-    Returns: True if supports, False otherwise.
-    """
-    cursor.execute("SELECT VERSION()")
-    version_str = cursor.fetchone()[0]
-    version = version_str.split('.')
-
-    if 'mariadb' in version_str.lower():
-        # MariaDB 10.2 and later
-        if int(version[0]) * 1000 + int(version[1]) >= 10002:
-            return True
-        else:
-            return False
-    else:
-        # MySQL 5.6 and later
-        if int(version[0]) * 1000 + int(version[1]) >= 5006:
-            return True
-        else:
-            return False
-
-
 def get_resource_limits(cursor, user, host):
     """Get user resource limits.
 
@@ -869,7 +842,7 @@ def limit_resources(module, cursor, user, host, resource_limits, check_mode):
 
     Returns: True, if changed, False otherwise.
     """
-    if not server_supports_alter_user(cursor):
+    if not impl.server_supports_alter_user(cursor):
         module.fail_json(msg="The server version does not match the requirements "
                              "for resource_limits parameter. See module's documentation.")
 

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -145,7 +145,7 @@ options:
     description:
       - Limit the user for certain server resources. Provided since MySQL 5.6 / MariaDB 10.2.
       - "Available options are C(MAX_QUERIES_PER_HOUR: num), C(MAX_UPDATES_PER_HOUR: num),
-        C(MAX_CONNECTIONS_PER_HOUR: num), C(MAX_USER_CONNECTIONS: num)."
+        C(MAX_CONNECTIONS_PER_HOUR: num), C(MAX_USER_CONNECTIONS: num), C(MAX_STATEMENT_TIME: num) (supported only for MariaDB since collection version 3.7.0)."
       - Used when I(state=present), ignored otherwise.
     type: dict
     version_added: '0.1.0'

--- a/tests/integration/targets/test_mysql_user/tasks/test_resource_limits.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_resource_limits.yml
@@ -129,4 +129,151 @@
         that:
           - result.rowcount[0] == 1
 
+    - name: Resource limits | Drop mysql user {{ user_name_1 }} if exists
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        host_all: true
+        state: absent
+
+    - name: Resource limits | Create mysql user {{ user_name_1 }} with MAX_STATEMENT_TIME in check_mode
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        password: '{{ user_password_1 }}'
+        state: present
+        resource_limits:
+          MAX_QUERIES_PER_HOUR: 10
+          MAX_STATEMENT_TIME: 1
+      check_mode: true
+      register: result
+      ignore_errors: true
+
+    - name: Resource limits | Assert that create user with MAX_STATEMENT_TIME is changed for mariadb
+      ansible.builtin.assert:
+        that:
+          - result is changed
+      when: db_engine == 'mariadb'
+
+    - name: Resource limits | Assert that create user with MAX_STATEMENT_TIME is failed for mysql
+      ansible.builtin.assert:
+        that:
+          - result is failed
+      when: db_engine == 'mysql'
+
+    - name: Resource limits | Create mysql user {{ user_name_1 }} with MAX_STATEMENT_TIME in actual mode
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        password: '{{ user_password_1 }}'
+        state: present
+        resource_limits:
+          MAX_QUERIES_PER_HOUR: 10
+          MAX_STATEMENT_TIME: 1
+      register: result
+      ignore_errors: true
+
+    - name: Resource limits | Assert that create user with MAX_STATEMENT_TIME is changed for MariaDB
+      ansible.builtin.assert:
+        that:
+          - result is changed
+      when: db_engine == 'mariadb'
+
+    - name: Resource limits | Assert that create user with MAX_STATEMENT_TIME is failed for MySQL
+      ansible.builtin.assert:
+        that:
+          - result is failed
+      when: db_engine == 'mysql'
+
+    - name: Resource limits | Retrieve user with MAX_STATEMENT_TIME
+      community.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT User FROM mysql.user
+          WHERE User = '{{ user_name_1 }}'
+          AND Host = 'localhost'
+          AND max_questions = 10
+          AND max_statement_time = 1
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Resource limits | Assert that rowcount is 1 with MAX_STATEMENT_TIME
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 1
+      when: db_engine == 'mariadb'
+
+    - name: Resource limits | Try to set the same limits with MAX_STATEMENT_TIME again in check mode
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        password: '{{ user_password_1 }}'
+        state: present
+        resource_limits:
+          MAX_QUERIES_PER_HOUR: 10
+          MAX_STATEMENT_TIME: 1
+      check_mode: true
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Resource limits | Assert that set same limits with MAX_STATEMENT_TIME again is not changed
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when: db_engine == 'mariadb'
+
+    - name: Resource limits | Try to set the same limits with MAX_STATEMENT_TIME again in actual mode
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        password: '{{ user_password_1 }}'
+        state: present
+        resource_limits:
+          MAX_QUERIES_PER_HOUR: 10
+          MAX_STATEMENT_TIME: 1
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Resource limits | Assert that set same limits with MAX_STATEMENT_TIME again in actual mode is not changed
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when: db_engine == 'mariadb'
+
+    - name: Resource limits | Change limits with MAX_STATEMENT_TIME
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ user_name_1 }}'
+        password: '{{ user_password_1 }}'
+        state: present
+        resource_limits:
+          MAX_QUERIES_PER_HOUR: 5
+          MAX_STATEMENT_TIME: 2
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Resource limits | Assert limits with MAX_STATEMENT_TIME changed
+      ansible.builtin.assert:
+        that:
+          - result is changed
+      when: db_engine == 'mariadb'
+
+    - name: Resource limits | Get user limits with MAX_STATEMENT_TIME
+      community.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT User FROM mysql.user
+          WHERE User = '{{ user_name_1 }}'
+          AND Host = 'localhost'
+          AND max_questions = 5
+          AND max_statement_time = 2
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Resource limits | Assert limit with MAX_STATEMENT_TIME row count
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 1
+      when: db_engine == 'mariadb'
+
   when: (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= '18') or (ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '8')


### PR DESCRIPTION
This MR adds MAX_STATEMENT_TIME to resource_limits as already requested in #211.

MAX_STATEMENT_TIME is supported since mariadb 10.1.1, as resource_limits are only supported by this module for maiadb >= 10.2 there should not be a requirement to add a new version check.

I also refactored the `server_supports_alter_user` function as it was not using the same implementations/impl paradigma as other versions checks, which confused me quite a bit while searching for the version check.