### PR TITLE
feat: Add support for the connector pymysql 1.0.2

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -139,6 +139,9 @@ jobs:
             python: '3.9'
 
           - python: '3.8'
+            connector_version: 1.0.2
+
+          - python: '3.8'
             connector_version: 2.0.3
 
           - python: '3.8'
@@ -146,6 +149,9 @@ jobs:
 
           - python: '3.9'
             connector_version: 0.7.11
+
+          - python: '3.9'
+            connector_version: 1.0.2
 
           - python: '3.9'
             connector_version: 2.0.1

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -64,15 +64,7 @@ jobs:
         connector_version:
           - 0.7.11
           - 0.9.3
-          # Before we can activate test with pymysql 1.0.2 we should debug the
-          # following plugins:
-          #
-          # mysql_query:
-          # test "Assert that create table IF NOT EXISTS is not changed with pymysql" failed
-          #
-          # mysql_replication:
-          # test "Assert that startreplica is not changed" failed
-          # - 1.0.2
+          - 1.0.2
           - 2.0.1
           - 2.0.3
           - 2.1.1

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For MariaDB, only Long Term releases are tested.
 
 - pymysql 0.7.11 (Only tested with MySQL 5.7)
 - pymysql 0.9.3
-- pymysql 1.0.2 (only collection version >= ???) !!! Unsuported until future release !!!
+- pymysql 1.0.2 (only collection version >= 3.6.1)
 - mysqlclient 2.0.1
 - mysqlclient 2.0.3 (only collection version >= 3.5.2)
 - mysqlclient 2.1.1 (only collection version >= 3.5.2)

--- a/TESTING.md
+++ b/TESTING.md
@@ -131,7 +131,7 @@ make ansible="stable-2.14" db_engine_name="mysql" db_engine_version="5.7.40" pyt
 
 # Keep databases and ansible tests containers alives
 # A single target and continue on errors
-make ansible="stable-2.14" db_engine_name="mysql" db_engine_version="8.0.31" python="3.9" connector_name="mysqlclient" connector_version="2.0.3"
+make ansible="stable-2.14" db_engine_name="mysql" db_engine_version="8.0.31" python="3.9" connector_name="mysqlclient" connector_version="2.0.3" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
 
 # If your system has an usupported version of Python:
 make local_python_version="3.8" ansible="stable-2.14" db_engine_name="mariadb" db_engine_version="10.6.11" python="3.9" connector_name="pymysql" connector_version="0.9.3"

--- a/TESTING.md
+++ b/TESTING.md
@@ -77,7 +77,7 @@ The Makefile accept the following options
   - Choices:
     - "pymysql
     - "mysqlclient"
-  - Description: The python package of the connector to use. This value is used to filter tests meant for other connectors.
+  - Description: The python package of the connector to use. In addition to selecting the test container, this value is also used for tests filtering: `when: connector_name == 'pymysql'`.
 
 - `connector_version`
   - Mandatory: true
@@ -113,11 +113,11 @@ The Makefile accept the following options
 - `keep_containers_alive`
   - Mandatory: false
   - Description: This option keeps all tree databases containers and the ansible-test container alive at the end of tests or in case of failure. This is useful to enter one of the containers with `podman exec -it <container-name> bash` for debugging. Rerunning the
-test will recreate those containers so no need to kill it. Add any value to activate this option: `keep_containers_alive=1`
+tests will recreate those containers so no need to kill them in advance. Add any value to activate this option: `keep_containers_alive=1`
 
 - `continue_on_errors`
   - Mandatory: false
-  - Description: Tells ansible-test to retry on errors and also continue on errors. This is the way the GitHub Action's workflow runs the tests. This can be use to catch all errors in a single run, but you'll need to scroll up to find them. Add any value to activate this option: `continue_on_errors=1`
+  - Description: Tells ansible-test to retry on errors and also continue on errors. This is the way the GitHub Action's workflow runs the tests. This can be used to catch all errors in a single run, but you'll need to scroll up to find them. Add any value to activate this option: `continue_on_errors=1`
 
 
 #### Makefile usage examples:

--- a/TESTING.md
+++ b/TESTING.md
@@ -82,12 +82,12 @@ The Makefile accept the following options
 - `connector_version`
   - Mandatory: true
   - Choices:
-    - "0.7.11" <- Only for MySQL 5.7
-    - "0.9.3"
-    - "1.0.2" <- Not working, need fix
-    - "2.0.1"
-    - "2.0.3"
-    - "2.1.1"
+    - "0.7.11" <- pymysql (Only for MySQL 5.7)
+    - "0.9.3" <- pymysql
+    - "1.0.2" <- pymysql (Not working, need fix)
+    - "2.0.1" <- mysqlclient
+    - "2.0.3" <- mysqlclient
+    - "2.1.1" <- mysqlclient
   - Description: The version of the python package of the connector to use. This value is used to filter tests meant for other connectors.
 
 - `python`

--- a/TESTING.md
+++ b/TESTING.md
@@ -127,7 +127,7 @@ test will recreate those containers so no need to kill it. Add any value to acti
 make ansible="stable-2.12" db_engine_name="mysql" db_engine_version="5.7.40" python="3.8" connector_name="pymysql" connector_version="0.7.11"
 
 # A single target
-make ansible="stable-2.14" db_engine_name="mysql" db_engine_version="5.7.40" python="3.8" connector_name="pymysql" connector_version="0.7.11"
+make ansible="stable-2.14" db_engine_name="mysql" db_engine_version="5.7.40" python="3.8" connector_name="pymysql" connector_version="0.7.11" target="test_mysql_info"
 
 # Keep databases and ansible tests containers alives
 # A single target and continue on errors

--- a/TESTING.md
+++ b/TESTING.md
@@ -84,7 +84,7 @@ The Makefile accept the following options
   - Choices:
     - "0.7.11" <- pymysql (Only for MySQL 5.7)
     - "0.9.3" <- pymysql
-    - "1.0.2" <- pymysql (Not working, need fix)
+    - "1.0.2" <- pymysql
     - "2.0.1" <- mysqlclient
     - "2.0.3" <- mysqlclient
     - "2.1.1" <- mysqlclient

--- a/plugins/modules/mysql_query.py
+++ b/plugins/modules/mysql_query.py
@@ -222,7 +222,8 @@ def main():
                     # When something is run with IF NOT EXISTS
                     # and there's "already exists" MySQL warning,
                     # set the flag as True.
-                    # PyMySQL throws the warning, mysqlclinet does NOT.
+                    # PyMySQL < 0.10.0 throws the warning, mysqlclient
+                    # and PyMySQL 0.10.0+ does NOT.
                     already_exists = True
 
         except Exception as e:

--- a/plugins/modules/mysql_query.py
+++ b/plugins/modules/mysql_query.py
@@ -26,9 +26,9 @@ options:
       as a formatting character. All literal C(%) characters in the query should be
       escaped as C(%%).
     - Note that if you use the C(IF EXISTS/IF NOT EXISTS) clauses in your query
-      and C(mysqlclient) connector, the module will report that
-      the state has been changed even if it has not. If it is important in your
-      workflow, use the C(PyMySQL) connector instead.
+      and C(mysqlclient) or C(PyMySQL 0.10.0+) connectors, the module will report
+      that the state has been changed even if it has not. If it is important in your
+      workflow, use the C(PyMySQL 0.9.3) connector instead.
     type: raw
     required: true
   positional_args:

--- a/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
@@ -363,21 +363,27 @@
   - name: Assert that create table IF NOT EXISTS is not changed with pymysql
     assert:
       that:
-        # PyMySQL driver throws a warning, so the following is correct
+        # PyMySQL driver throws a warning for version before 0.10.0
         - result is not changed
     when:
       - connector_name == 'pymysql'
+      - connector_version is version('0.10.0', '<')
 
   # Issue https://github.com/ansible-collections/community.mysql/issues/268
   - name: Assert that create table IF NOT EXISTS is changed with mysqlclient
     assert:
       that:
-        # Mysqlclient 2.0.1, driver throws nothing with mysql, so it's
-        # impossible to figure out  if the state was changed or not.
+        # Mysqlclient 2.0.1 and pymysql 0.10.0+ drivers throws no warning,
+        # so it's impossible to figure out if the state was changed or not.
         # We assume that it was for DDL queries by default in the code
         - result is changed
     when:
-      - connector_name == 'mysqlclient'
+      - >
+        connector_name == 'mysqlclient'
+        or (
+          connector_name == 'pymysql'
+          and connector_version is version('0.10.0', '>')
+        )
 
   - name: Drop db {{ test_db }}
     mysql_query:

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -247,13 +247,14 @@
         fail_on_error: true
       register: result
 
-    # mysqlclient 2.0.1 always return "changed"
+    # mysqlclient 2.0.1 and pymysql 0.10.0+ always return "changed"
     - name: Assert that startreplica is not changed
       assert:
         that:
           - result is not changed
       when:
         - connector_name == 'pymysql'
+        - connector_version is version('0.10.0', '<')
 
     # Test stopreplica mode:
     - name: Stop replica
@@ -274,7 +275,7 @@
         timeout: 2
 
     # Test stopreplica mode:
-    # mysqlclient 2.0.1 always return "changed"
+    # mysqlclient 2.0.1 and pymysql 0.10.0+ always return "changed"
     - name: Stop replica that is no longer running
       mysql_replication:
         <<: *mysql_params
@@ -289,6 +290,7 @@
           - result is not changed
       when:
         - connector_name == 'pymysql'
+        - connector_version is version('0.10.0', '<')
 
     # master / slave related choices were removed in 3.0.0
     # https://github.com/ansible-collections/community.mysql/pull/252


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR add the connector PyMySQL 1.0.2 to the integration tests matrix.

I know PyMySQL 1.0.3 is here since 2 months, but the test containers for 1.0.2 was already present so I use that version.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
All modules

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

I had to disable tests for "changed" state in two places. This is not ideal but the only solution would be to patch the connectors to allow to read the warning from a query with `IF EXISTS`. But I took care to document that PyMySQL stopped returning a correct `changed` status since version 0.10.0.

Unless we run a new query `SHOW WARNINGS;`  after each query? If someone think it's possible, I'll happy to try this in another PR.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
