### PR TITLE
Document the Releases Support Timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ Every voice is important and every idea is valuable. If you have something on yo
   - [mysql_user](https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_user_module.html)
   - [mysql_variables](https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_variables_module.html)
 
+
+## Releases Support Timeline
+
+In https://github.com/ansible-collections/community.mysql/discussions/537 it has been decided to maintain each major release (1.x.y, 2.x.y, ...) for two years after the release date.
+
+Here is the table for the support timeline:
+
+- 1.x.y: released 2020-08-17, EOL
+- 2.x.y: released 2021-04-15, EOL
+- 3.x.y: released 2021-12-01, supported until 2023-12-01
+- 4.x.y: To be released
+
+
 ## Tested with
 
 ### ansible-core

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Every voice is important and every idea is valuable. If you have something on yo
 
 ## Releases Support Timeline
 
-In https://github.com/ansible-collections/community.mysql/discussions/537 it has been decided to maintain each major release (1.x.y, 2.x.y, ...) for two years after the release date.
+It has been [decided](https://github.com/ansible-collections/community.mysql/discussions/537) to maintain each major release (1.x.y, 2.x.y, ...) for two years after the next major version is released.
 
 Here is the table for the support timeline:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Here is the table for the support timeline:
 
 - 1.x.y: released 2020-08-17, EOL
 - 2.x.y: released 2021-04-15, EOL
-- 3.x.y: released 2021-12-01, supported until 2023-12-01
+- 3.x.y: released 2021-12-01, current
 - 4.x.y: To be released
 
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ It has been [decided](https://github.com/ansible-collections/community.mysql/dis
 Here is the table for the support timeline:
 
 - 1.x.y: released 2020-08-17, EOL
-- 2.x.y: released 2021-04-15, supported until 2021-12-01
+- 2.x.y: released 2021-04-15, supported until 2023-12-01
 - 3.x.y: released 2021-12-01, current
 - 4.x.y: To be released
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ It has been [decided](https://github.com/ansible-collections/community.mysql/dis
 Here is the table for the support timeline:
 
 - 1.x.y: released 2020-08-17, EOL
-- 2.x.y: released 2021-04-15, EOL
+- 2.x.y: released 2021-04-15, supported until 2021-12-01
 - 3.x.y: released 2021-12-01, current
 - 4.x.y: To be released
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
After discussing [should we drop stable-1 and/or stable-2](https://github.com/ansible-collections/community.mysql/discussions/537) we decided to support each major version for 2 years after the next major release is published. 

Here is my attempt to document this in the README.md.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

