### PR TITLE
fix connection arguments mysql driver compatability

### DIFF
--- a/changelogs/fragments/551-fix_connection_arguments_driver_compatability.yaml
+++ b/changelogs/fragments/551-fix_connection_arguments_driver_compatability.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql module utils - use the connection arguments ``db`` instead of ``database`` and ``passwd`` instead of ``password`` when running with older mysql drivers (MySQLdb < 2.1.0 or PyMySQL < 1.0.0) (https://github.com/ansible-collections/community.mysql/pull/551).

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -144,18 +144,24 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if _mysql_cursor_param == 'cursor':
         # In case of PyMySQL driver:
         if mysql_driver.version_info[0] < 1:
-            # for PyMySQL < 1.0.0, use 'db' instead of 'database'
+            # for PyMySQL < 1.0.0, use 'db' instead of 'database' and 'passwd' instead of 'password'
             if 'database' in config:
                 config['db'] = config['database']
                 del config['database']
+            if 'password' in config:
+                config['passwd'] = config['password']
+                del config['password']
         db_connection = mysql_driver.connect(autocommit=autocommit, **config)
     else:
         # In case of MySQLdb driver
         if mysql_driver.version_info[0] < 2 and mysql_driver.version_info[1] < 1:
-            # for MySQLdb < 2.1.0, use 'db' instead of 'database'
+            # for MySQLdb < 2.1.0, use 'db' instead of 'database' and 'passwd' instead of 'password'
             if 'database' in config:
                 config['db'] = config['database']
                 del config['database']
+            if 'password' in config:
+                config['passwd'] = config['password']
+                del config['password']
         db_connection = mysql_driver.connect(**config)
         if autocommit:
             db_connection.autocommit(True)

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -134,14 +134,14 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if connect_timeout is not None:
         config['connect_timeout'] = connect_timeout
     if check_hostname is not None:
-        if mysql_driver.__name__ == "pymysql":
+        if get_connector_name(mysql_driver) == 'pymysql':
             version_tuple = (n for n in mysql_driver.__version__.split('.') if n != 'None')
             if reduce(lambda x, y: int(x) * 100 + int(y), version_tuple) >= 711:
                 config['ssl']['check_hostname'] = check_hostname
             else:
                 module.fail_json(msg='To use check_hostname, pymysql >= 0.7.11 is required on the target host')
 
-    if _mysql_cursor_param == 'cursor':
+    if get_connector_name(mysql_driver) == 'pymysql':
         # In case of PyMySQL driver:
         if mysql_driver.version_info[0] < 1:
             # for PyMySQL < 1.0.0, use 'db' instead of 'database' and 'passwd' instead of 'password'

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -145,15 +145,17 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         # In case of PyMySQL driver:
         if mysql_driver.version_info[0] < 1:
             # for PyMySQL < 1.0.0, use 'db' instead of 'database'
-            config['db'] = config.get('database')
-            del config['database']
+            if 'database' in config:
+                config['db'] = config['database']
+                del config['database']
         db_connection = mysql_driver.connect(autocommit=autocommit, **config)
     else:
         # In case of MySQLdb driver
-        if mysql_driver.version_info[0] < 2 or mysql_driver.version_info[1] < 1:
+        if mysql_driver.version_info[0] < 2 and mysql_driver.version_info[1] < 1:
             # for MySQLdb < 2.1.0, use 'db' instead of 'database'
-            config['db'] = config.get('database')
-            del config['database']
+            if 'database' in config:
+                config['db'] = config['database']
+                del config['database']
         db_connection = mysql_driver.connect(**config)
         if autocommit:
             db_connection.autocommit(True)

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -145,14 +145,14 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         # In case of PyMySQL driver:
         if mysql_driver.version_info[0] < 1:
             # for PyMySQL < 1.0.0, use 'db' instead of 'database'
-            config['db'] = config['database']
+            config['db'] = config.get('database')
             del config['database']
         db_connection = mysql_driver.connect(autocommit=autocommit, **config)
     else:
         # In case of MySQLdb driver
         if mysql_driver.version_info[0] < 2 or mysql_driver.version_info[1] < 1:
             # for MySQLdb < 2.1.0, use 'db' instead of 'database'
-            config['db'] = config['database']
+            config['db'] = config.get('database')
             del config['database']
         db_connection = mysql_driver.connect(**config)
         if autocommit:

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -143,9 +143,17 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
 
     if _mysql_cursor_param == 'cursor':
         # In case of PyMySQL driver:
+        if mysql_driver.version_info[0] < 1:
+            # for PyMySQL < 1.0.0, use 'db' instead of 'database'
+            config['db'] = config['database']
+            del config['database']
         db_connection = mysql_driver.connect(autocommit=autocommit, **config)
     else:
         # In case of MySQLdb driver
+        if mysql_driver.version_info[0] < 2 or mysql_driver.version_info[1] < 1:
+            # for MySQLdb < 2.1.0, use 'db' instead of 'database'
+            config['db'] = config['database']
+            del config['database']
         db_connection = mysql_driver.connect(**config)
         if autocommit:
             db_connection.autocommit(True)


### PR DESCRIPTION
bugfix for #546, relates to #116


### what arguments are supported in what drivers

- pymysql has deprecated the `db` argument in [1.0.0](https://github.com/PyMySQL/PyMySQL/blob/main/CHANGELOG.md#v100) (2021), but it will probably still work for some time. I'm not sure since when pymysql supports the `database` argument, but at least since 0.7.11, which we test.
- mysql-python (MySQLdb) only seems to support `db`. The project was last changed in 2014 so we could discuss if we want to support it. The current issue is about this old driver, see https://github.com/ansible-collections/community.mysql/issues/546#issuecomment-1544078481.
- The successor of mysql-python, mysqlclient, also deprecated the `db` argument in [2.1.0](https://github.com/PyMySQL/mysqlclient/releases/tag/v2.1.0) (2021), like pymysql.

The same way, `passwd` is deprecated in favor of `password`.

### proposed fix

Check the mysql driver version to determine what argument to use. Use `db` and `passwd` until it's deprecated, then `database` and `password`.