### PR TITLE
Doc Attributes

### DIFF
--- a/plugins/doc_fragments/mysql.py
+++ b/plugins/doc_fragments/mysql.py
@@ -110,4 +110,7 @@ notes:
    - Alternatively, to avoid using I(login_unix_socket) argument on each invocation you can specify the socket path
      using the `socket` option in your MySQL config file (usually C(~/.my.cnf)) on the destination host, for
      example C(socket=/var/lib/mysql/mysql.sock).
+attributes:
+  check_mode:
+    description: Can run in check_mode and return changed status prediction without modifying target.
 '''

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -188,10 +188,12 @@ requirements:
    - mysql (command line binary)
    - mysqldump (command line binary)
 notes:
-   - Supports C(check_mode).
    - Requires the mysql and mysqldump binaries on the remote host.
    - This module is B(not idempotent) when I(state) is C(import),
      and will import the dump file each time if run more than once.
+attributes:
+  check_mode:
+    support: full
 extends_documentation_fragment:
 - community.mysql.mysql
 

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -196,7 +196,6 @@ attributes:
     support: full
 extends_documentation_fragment:
 - community.mysql.mysql
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -47,7 +47,10 @@ options:
 notes:
 - Calculating the size of a database might be slow, depending on the number and size of tables in it.
   To avoid this, use I(exclude_fields=db_size).
-- Supports C(check_mode).
+
+attributes:
+  check_mode:
+    support: full
 
 seealso:
 - module: community.mysql.mysql_variables

--- a/plugins/modules/mysql_query.py
+++ b/plugins/modules/mysql_query.py
@@ -50,6 +50,9 @@ options:
     - Where passed queries run in a single transaction (C(yes)) or commit them one-by-one (C(no)).
     type: bool
     default: false
+attributes:
+  check_mode:
+    support: none
 seealso:
 - module: community.mysql.mysql_db
 author:

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -190,9 +190,12 @@ options:
 notes:
 - If an empty value for the parameter of string type is needed, use an empty string.
 
+attributes:
+  check_mode:
+    support: none
+
 extends_documentation_fragment:
 - community.mysql.mysql
-
 
 seealso:
 - module: community.mysql.mysql_info

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -125,7 +125,10 @@ notes:
   - Pay attention that the module runs C(SET DEFAULT ROLE ALL TO)
     all the I(members) passed by default when the state has changed.
     If you want to avoid this behavior, set I(set_default_role_all) to C(no).
-  - Supports C(check_mode).
+
+attributes:
+  check_mode:
+    support: full
 
 seealso:
   - module: community.mysql.mysql_user

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -163,7 +163,10 @@ notes:
      2) drop a C(~/.my.cnf) file containing the new root credentials.
      Subsequent runs of the playbook will then succeed by reading the new credentials from the file."
    - Currently, there is only support for the C(mysql_native_password) encrypted password hash module.
-   - Supports (check_mode).
+
+attributes:
+  check_mode:
+    support: full
 
 seealso:
 - module: community.mysql.mysql_info
@@ -180,7 +183,6 @@ author:
 - Lukasz Tomaszkiewicz (@tomaszkiewicz)
 extends_documentation_fragment:
 - community.mysql.mysql
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/mysql_variables.py
+++ b/plugins/modules/mysql_variables.py
@@ -44,8 +44,9 @@ options:
     default: global
     version_added: '0.1.0'
 
-notes:
-- Does not support C(check_mode).
+attributes:
+  check_mode:
+    support: none
 
 seealso:
 - module: community.mysql.mysql_info


### PR DESCRIPTION
##### SUMMARY
Added Attributes section to modules docs
Fixes #515

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
All modules documentation

##### ADDITIONAL INFORMATION
This will make it easier to spot in the Documentation the support (or lack of) for the `check` mode.
It is interesting to find that these three modules don't support the `check` mode:
* mysql_query
* mysql_replication
* mysql_variables