### PR TITLE
backport stable-2: fix tests (`include` deprecation)

### DIFF
--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -196,7 +196,7 @@
         name: acme
         state: absent
 
-    - include: issue-28.yml
+    - include_tasks: issue-28.yml
 
     # https://github.com/ansible-collections/community.mysql/issues/204
     - name: Create database containing only views

--- a/tests/integration/targets/test_mysql_query/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/main.yml
@@ -6,4 +6,4 @@
 # mysql_query module initial CI tests
 - import_tasks: mysql_query_initial.yml
 
-- include: issue-28.yml
+- include_tasks: issue-28.yml

--- a/tests/integration/targets/test_mysql_replication/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/main.yml
@@ -21,4 +21,4 @@
 # Tests of resetprimary mode:
 - import_tasks: mysql_replication_resetprimary_mode.yml
 
-- include: issue-28.yml
+- include_tasks: issue-28.yml

--- a/tests/integration/targets/test_mysql_user/tasks/issue-29511.yaml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-29511.yaml
@@ -79,4 +79,6 @@
         - foo
         - bar
 
-    - include: utils/remove_user.yml user_name="{{ user_name_2 }}"
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ user_name_2 }}"

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -35,13 +35,13 @@
 
   block:
 
-    - include: issue-121.yml
+    - include_tasks: issue-121.yml
 
-    - include: issue-28.yml
+    - include_tasks: issue-28.yml
 
-    - include: test_resource_limits.yml
+    - include_tasks: test_resource_limits.yml
 
-    - include: test_idempotency.yml
+    - include_tasks: test_idempotency.yml
 
     # ============================================================
     # Create user with no privileges and verify default privileges are assign
@@ -54,11 +54,19 @@
         state: present
       register: result
 
-    - include: utils/assert_user.yml user_name={{ user_name_1 }} user_host=localhost priv=USAGE
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ user_name_1 }}"
+        user_host: localhost
+        priv: USAGE
 
-    - include: utils/remove_user.yml user_name={{ user_name_1 }}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ user_name_1 }}"
 
-    - include: utils/assert_no_user.yml user_name={{ user_name_1 }}
+    - include_tasks: utils/assert_no_user.yml
+      vars:
+        user_name: "{{ user_name_1 }}"
 
     # ============================================================
     # Create user with select privileges and verify select privileges are assign
@@ -72,11 +80,19 @@
         priv: '*.*:SELECT'
       register: result
 
-    - include: utils/assert_user.yml user_name={{ user_name_2 }} user_host=localhost priv=SELECT
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ user_name_2 }}"
+        user_host: localhost
+        priv: SELECT
 
-    - include: utils/remove_user.yml user_name={{ user_name_2 }}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ user_name_2 }}"
 
-    - include: utils/assert_no_user.yml user_name={{ user_name_2 }}
+    - include_tasks: utils/assert_no_user.yml
+      vars:
+        user_name: "{{ user_name_2 }}"
 
     # ============================================================
     # Assert user has access to multiple databases
@@ -112,9 +128,12 @@
           - "'{{ item }}' in result.stdout"
       with_items: "{{db_names}}"
 
-    - include: utils/remove_user.yml user_name={{ user_name_1 }}
-
-    - include: utils/remove_user.yml user_name={{ user_name_2 }}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ user_name_1 }}"
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ user_name_2 }}"
 
     - name: Give user SELECT access to database via wildcard
       mysql_user:
@@ -172,50 +191,68 @@
           - "'%db' in result.stdout"
           - "'INSERT' in result.stdout"
 
-    - include: utils/remove_user.yml user_name={{user_name_1}}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{user_name_1}}"
 
     # ============================================================
     # Test plaintext and encrypted password scenarios.
     #
-    - include: test_user_password.yml
+    - include_tasks: test_user_password.yml
 
     # ============================================================
     # Test plugin authentication scenarios.
     #
     # FIXME: mariadb sql syntax for create/update user is not compatible
-    - include: test_user_plugin_auth.yml
+    - include_tasks: test_user_plugin_auth.yml
       when: db_engine == 'mysql'
 
     # ============================================================
     # Assert create user with SELECT privileges, attempt to create database and update privileges to create database
     #
-    - include: test_privs.yml current_privilege=SELECT current_append_privs=no
+    - include_tasks: test_privs.yml
+      vars:
+        current_privilege: SELECT
+        current_append_privs: no
 
     # ============================================================
     # Assert creating user with SELECT privileges, attempt to create database and append privileges to create database
     #
-    - include: test_privs.yml current_privilege=DROP current_append_privs=yes
+    - include_tasks: test_privs.yml
+      vars:
+        current_privilege: DROP
+        current_append_privs: yes
 
     # ============================================================
     # Assert create user with SELECT privileges, attempt to create database and update privileges to create database
     #
-    - include: test_privs.yml current_privilege='UPDATE,ALTER' current_append_privs=no
+    - include_tasks: test_privs.yml
+      vars:
+        current_privilege: 'UPDATE,ALTER'
+        current_append_privs: no
 
     # ============================================================
     # Assert creating user with SELECT privileges, attempt to create database and append privileges to create database
     #
-    - include: test_privs.yml current_privilege='INSERT,DELETE' current_append_privs=yes
+    - include_tasks: test_privs.yml
+      vars:
+        current_privilege: 'INSERT,DELETE'
+        current_append_privs: yes
 
     # Tests for the priv parameter with dict value (https://github.com/ansible/ansible/issues/57533)
-    - include: test_priv_dict.yml
+    - include_tasks: test_priv_dict.yml
 
     # Test that append_privs will not attempt to make a change where current privileges are a superset of new privileges
     # (https://github.com/ansible-collections/community.mysql/issues/69)
-    - include: test_priv_append.yml enable_check_mode=no
-    - include: test_priv_append.yml enable_check_mode=yes
+    - include_tasks: test_priv_append.yml
+      vars:
+        enable_check_mode: no
+    - include_tasks: test_priv_append.yml
+      vars:
+        enable_check_mode: yes
 
     # Tests for the TLS requires dictionary
-    - include: test_tls_requirements.yml
+    - include_tasks: test_tls_requirements.yml
 
     - import_tasks: issue-29511.yaml
       tags:
@@ -226,4 +263,4 @@
         - issue-64560
 
     # https://github.com/ansible-collections/community.mysql/issues/231
-    - include: test_user_grants_with_roles_applied.yml
+    - include_tasks: test_user_grants_with_roles_applied.yml

--- a/tests/integration/targets/test_mysql_user/tasks/test_idempotency.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_idempotency.yml
@@ -10,7 +10,10 @@
     # ========================================================================
     # Creation
     # ========================================================================
-    - include: utils/create_user.yml user_name={{ user_name_1 }} user_password={{ user_password_1 }}
+    - include_tasks: utils/create_user.yml
+      vars:
+        user_name: "{{ user_name_1 }}"
+        user_password: "{{ user_password_1 }}"
 
     - name: Idempotency | Create user that already exist (expect changed=false)
       mysql_user:
@@ -55,7 +58,10 @@
     # ========================================================================
 
     # Create blank  user to be removed later
-    - include: utils/create_user.yml user_name="" user_password='KJFDY&D*Sfuysf'
+    - include_tasks: utils/create_user.yml
+      vars:
+        user_name: ""
+        user_password: 'KJFDY&D*Sfuysf'
 
     - name: Idempotency | Remove blank  user with hosts=all (expect changed)
       mysql_user:

--- a/tests/integration/targets/test_mysql_user/tasks/test_priv_append.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_priv_append.yml
@@ -111,4 +111,6 @@
         - data1
         - data2
 
-    - include: utils/remove_user.yml user_name={{ user_name_4 }}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ user_name_4 }}"

--- a/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_priv_dict.yml
@@ -151,4 +151,6 @@
         - data2
         - data3
 
-    - include: utils/remove_user.yml user_name="{{ user_name_3 }}"
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ user_name_3 }}"

--- a/tests/integration/targets/test_mysql_user/tasks/test_privs.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_privs.yml
@@ -37,7 +37,11 @@
         state: present
       when: current_append_privs ==  "yes"
 
-    - include: utils/assert_user.yml user_name={{ user_name_2 }} user_host=% priv='SELECT'
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ user_name_2 }}"
+        user_host: "%"
+        priv: 'SELECT'
       when: current_append_privs ==  "yes"
 
     - name: Privs | Create user with current privileges (expect changed=true)
@@ -132,7 +136,7 @@
         priv: '*.*:ALL'
         state: present
 
-    # - include: utils/assert_user.yml user_name={{user_name_2}} user_host=% priv='ALL PRIVILEGES'
+    # - include_tasks: utils/assert_user.yml user_name={{user_name_2}} user_host=% priv='ALL PRIVILEGES'
 
     - name: Privs | Create database using user {{ user_name_2 }}
       mysql_db:
@@ -192,7 +196,9 @@
         - (db_engine == 'mysql' and db_version is version('5.7', '<=')
           or db_engine == 'mariadb' and db_version is version('10.4', '<='))
 
-    - include: utils/remove_user.yml user_name="{{ user_name_2 }}"
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ user_name_2 }}"
 
     # ============================================================
     - name: Privs | Grant all privileges with grant option
@@ -263,4 +269,6 @@
         that:
           - result is failed
 
-    - include: utils/remove_user.yml user_name="{{ user_name_2 }}"
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ user_name_2 }}"

--- a/tests/integration/targets/test_mysql_user/tasks/test_tls_requirements.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_tls_requirements.yml
@@ -23,7 +23,9 @@
         that:
           - result is changed
 
-    - include: utils/assert_no_user.yml user_name={{user_name_1}}
+    - include_tasks: utils/assert_no_user.yml
+      vars:
+        user_name: "{{user_name_1}}"
 
     - name: Tls reqs | Create user with TLS requirements state=present (expect changed=true)
       mysql_user:
@@ -172,14 +174,26 @@
       assert:
         that: "'REQUIRE ' not in result.stdout or 'REQUIRE NONE' in result.stdout"
 
-    - include: utils/remove_user.yml user_name={{user_name_1}}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{user_name_1}}"
 
-    - include: utils/remove_user.yml user_name={{user_name_2}}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{user_name_2}}"
 
-    - include: utils/remove_user.yml user_name={{user_name_3}}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{user_name_3}}"
 
-    - include: utils/assert_no_user.yml user_name={{user_name_1}}
+    - include_tasks: utils/assert_no_user.yml
+      vars:
+        user_name: "{{user_name_1}}"
 
-    - include: utils/assert_no_user.yml user_name={{user_name_2}}
+    - include_tasks: utils/assert_no_user.yml
+      vars:
+        user_name: "{{user_name_2}}"
 
-    - include: utils/assert_no_user.yml user_name={{user_name_3}}
+    - include_tasks: utils/assert_no_user.yml
+      vars:
+        user_name: "{{user_name_3}}"

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_grants_with_roles_applied.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_grants_with_roles_applied.yml
@@ -81,7 +81,9 @@
         - data1
         - data2
 
-    - include: utils/remove_user.yml user_name={{ user_name_3 }}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ user_name_3 }}"
 
     - name: User grants with roles applied | Drop test role
       mysql_role:

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_password.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_password.yml
@@ -36,7 +36,11 @@
         that:
           - result is changed
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=% priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: "%"
+        priv: "{{ test_default_priv_type }}"
 
     - name: Password | Get the MySQL version using the newly created used creds
       mysql_info:
@@ -68,7 +72,11 @@
         that:
           - result is not changed
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=% priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: '%'
+        priv: "{{ test_default_priv_type }}"
 
     - name: Password | Update the user password
       mysql_user:
@@ -84,7 +92,11 @@
         that:
           - result is changed
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=% priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: '%'
+        priv: "{{ test_default_priv_type }}"
 
     - name: Password | Get the MySQL version data using the original password (should fail)
       mysql_info:
@@ -117,7 +129,9 @@
           - result is succeeded
 
     # Cleanup
-    - include: utils/remove_user.yml user_name={{ test_user_name }}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
 
     # ============================================================
     # Test setting a plaintext password and then the same password encrypted to ensure there isn't a change detected.
@@ -137,7 +151,11 @@
         that:
           - result is changed
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=localhost priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: localhost
+        priv: "{{ test_default_priv_type }}"
 
     - name: Password | Pass in the same password as before, but in the encrypted form (no change expected)
       mysql_user:
@@ -155,7 +173,9 @@
           - result is not changed
 
     # Cleanup
-    - include: utils/remove_user.yml user_name={{ test_user_name }}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
 
     # ============================================================
     # Test setting an encrypted password and then the same password in plaintext to ensure there isn't a change.
@@ -177,7 +197,11 @@
         that:
           - result is changed
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=% priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: "%"
+        priv: "{{ test_default_priv_type }}"
 
     - name: Password | Get the MySQL version data using the new creds
       mysql_info:
@@ -209,7 +233,9 @@
           - result is not changed
 
     # Cleanup
-    - include: utils/remove_user.yml user_name={{ test_user_name }}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
 
     # ============================================================
     # Test setting an empty password.
@@ -274,4 +300,6 @@
           - result is not changed
 
     # Cleanup
-    - include: utils/remove_user.yml user_name={{ test_user_name }}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -47,7 +47,11 @@
           - "'{{ test_plugin_type }}' in show_create_user.stdout"
       when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=% priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: "%"
+        priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Get the MySQL version using the newly created creds
       mysql_info:
@@ -77,7 +81,11 @@
         that:
           - result is changed
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=% priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: "%"
+        priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Getting the MySQL info with the new password should work
       mysql_info:
@@ -94,7 +102,9 @@
           - result is succeeded
 
     # Cleanup
-    - include: utils/remove_user.yml user_name={{ test_user_name }}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
 
     # ============================================================
     # Test plugin auth initially setting a hash and then switching to a plaintext auth string.
@@ -125,7 +135,11 @@
           - "'{{ test_plugin_type }}' in show_create_user.stdout"
       when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=% priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: "%"
+        priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Get the MySQL version using the newly created creds
       mysql_info:
@@ -157,7 +171,11 @@
           - result is not changed
       when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=% priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: "%"
+        priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Change the user using the same plugin, but switch to the same auth string in plaintext form
       mysql_user:
@@ -189,7 +207,9 @@
           - result is succeeded
 
     # Cleanup
-    - include: utils/remove_user.yml user_name={{ test_user_name }}
+    - include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
 
     # ============================================================
     # Test plugin auth initially setting a plaintext auth string and then switching to a hash.
@@ -220,7 +240,11 @@
           - test_plugin_type in show_create_user.stdout
       when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=% priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: "%"
+        priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Get the MySQL version using the newly created creds
       mysql_info:
@@ -252,7 +276,11 @@
         that:
           - result is changed
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=% priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: "%"
+        priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Change the user using the same plugin, but switch to the same auth string in hash form
       mysql_user:
@@ -283,7 +311,9 @@
           - result is succeeded
 
     # Cleanup
-    - include: utils/remove_user.yml user_name={{ test_user_name }}
+    - include_tasks:
+      vars:
+        user_name: "{{ test_user_name }}"
 
     # ============================================================
     # Test plugin auth with an empty auth string.
@@ -313,7 +343,11 @@
           - "'{{ test_plugin_type }}' in show_create_user.stdout"
       when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-    - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=% priv={{ test_default_priv_type }}
+    - include_tasks: utils/assert_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        user_host: "%"
+        priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Get the MySQL version using an empty password for the newly created user
       mysql_info:
@@ -360,7 +394,9 @@
           - result is not changed
 
     # Cleanup
-    - include: utils/remove_user.yml user_name={{ test_user_name }}
+    - include_tasks:
+      vars:
+        user_name: "{{ test_user_name }}"
 
     # ============================================================
     # Test plugin auth switching from one type of plugin to another without an auth string or hash. The only other
@@ -400,7 +436,11 @@
               - test_plugin_type in show_create_user.stdout
           when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-        - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=localhost priv={{ test_default_priv_type }}
+        - include_tasks: utils/assert_user.yml
+          vars:
+            user_name: "{{ test_user_name }}"
+            user_host: localhost
+            priv: "{{ test_default_priv_type }}"
 
         - name: Plugin auth | Switch user to sha256_password auth plugin
           mysql_user:
@@ -425,7 +465,13 @@
               - "'sha256_password' in show_create_user.stdout"
           when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-        - include: utils/assert_user.yml user_name={{ test_user_name }} user_host=localhost priv={{ test_default_priv_type }}
+        - include_tasks: utils/assert_user.yml
+          vars:
+            user_name: "{{ test_user_name }}"
+            user_host: localhost
+            priv: "{{ test_default_priv_type }}"
 
         # Cleanup
-        - include: utils/remove_user.yml user_name={{ test_user_name }}
+        - include_tasks:
+          vars:
+            user_name: "{{ test_user_name }}"

--- a/tests/integration/targets/test_mysql_variables/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/main.yml
@@ -5,4 +5,4 @@
 
 - import_tasks: mysql_variables.yml
 
-- include: issue-28.yml
+- include_tasks: issue-28.yml

--- a/tests/integration/targets/test_mysql_variables/tasks/mysql_variables.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/mysql_variables.yml
@@ -37,7 +37,11 @@
         variable: '{{ set_name }}'
       register: result
 
-    - include: assert_var_output.yml changed=false output={{ result }} var_name={{ set_name }}
+    - include_tasks: assert_var_output.yml
+      vars:
+        changed: false
+        output: "{{ result }}"
+        var_name: "{{ set_name }}"
 
     # ============================================================
     # Verify mysql_variable successfully updates a variable (issue:4568)
@@ -59,7 +63,12 @@
         value: '{{ set_value }}'
       register: result
 
-    - include: assert_var.yml changed=false output={{ result }} var_name={{ set_name }} var_value={{ set_value }}
+    - include_tasks: assert_var.yml
+      vars:
+        changed: false
+        output: "{{ result }}"
+        var_name: "{{ set_name }}"
+        var_value: "{{ set_value }}"
 
     # ============================================================
     # Verify mysql_variable successfully updates a variable using single quotes
@@ -85,7 +94,12 @@
         that:
         - result.queries == ["SET GLOBAL `{{ set_name }}` = {{ set_value }}"]
 
-    - include: assert_var.yml changed=true output={{ result }} var_name={{ set_name }} var_value='{{ set_value }}'
+    - include_tasks: assert_var.yml
+      vars:
+        changed: true
+        output: "{{ result }}"
+        var_name: "{{ set_name }}"
+        var_value: "{{ set_value }}"
 
     # ============================================================
     # Verify mysql_variable successfully updates a variable using double quotes
@@ -107,7 +121,12 @@
         value: '{{ set_value }}'
       register: result
 
-    - include: assert_var.yml changed=true output={{ result }} var_name={{ set_name }} var_value='{{ set_value }}'
+    - include_tasks: assert_var.yml
+      vars:
+        changed: true
+        output: "{{ result }}"
+        var_name: "{{ set_name }}"
+        var_value: "{{ set_value }}"
 
     # ============================================================
     # Verify mysql_variable successfully updates a variable using no quotes
@@ -129,7 +148,12 @@
         value: '{{ set_value }}'
       register: result
 
-    - include: assert_var.yml changed=true output={{ result }} var_name={{ set_name }} var_value='{{ set_value }}'
+    - include_tasks: assert_var.yml
+      vars:
+        changed: true
+        output: "{{ result }}"
+        var_name: "{{ set_name }}"
+        var_value: "{{ set_value }}"
 
     # ============================================================
     # Verify mysql_variable successfully updates a variable using an expression (e.g. 1024*4)
@@ -142,7 +166,10 @@
       register: result
       ignore_errors: true
 
-    - include: assert_fail_msg.yml output={{ result }}  msg='Incorrect argument type to variable'
+    - include_tasks: assert_fail_msg.yml
+      vars:
+        output: "{{ result }}"
+        msg: 'Incorrect argument type to variable'
 
     # ============================================================
     # Verify mysql_variable fails when setting an incorrect value (out of range)
@@ -155,12 +182,20 @@
       register: oor_result
       ignore_errors: true
 
-    - include: assert_var.yml changed=true output={{ oor_result }} var_name=max_connect_errors var_value=1
+    - include_tasks: assert_var.yml
+      vars:
+        changed: true
+        output: "{{ oor_result }}"
+        var_name: max_connect_errors
+        var_value: 1
       when:
         - connector_name == 'mysqlclient'
         - db_engine == 'mysql'  # mysqlclient returns "changed" with MariaDB
 
-    - include: assert_fail_msg.yml output={{ oor_result }}  msg='Truncated incorrect'
+    - include_tasks: assert_fail_msg.yml
+      vars:
+        output: "{{ oor_result }}"
+        msg: 'Truncated incorrect'
       when:
         - connector_name == 'pymsql'
 
@@ -175,7 +210,10 @@
       register: nvv_result
       ignore_errors: true
 
-    - include: assert_fail_msg.yml output={{ nvv_result }}  msg='Incorrect argument type to variable'
+    - include_tasks: assert_fail_msg.yml
+      vars:
+        output: "{{ nvv_result }}"
+        msg: 'Incorrect argument type to variable'
 
     # ============================================================
     # Verify mysql_variable fails when setting an unknown variable
@@ -188,7 +226,10 @@
       register: result
       ignore_errors: true
 
-    - include: assert_fail_msg.yml output={{ result }}  msg='Variable not available'
+    - include_tasks: assert_fail_msg.yml
+      vars:
+        output: "{{ result }}"
+        msg: 'Variable not available'
 
     # ============================================================
     # Verify mysql_variable fails when setting a read-only variable
@@ -201,7 +242,10 @@
       register: result
       ignore_errors: true
 
-    - include: assert_fail_msg.yml output={{ result }}  msg='read only variable'
+    - include_tasks: assert_fail_msg.yml
+      vars:
+        output: "{{ result }}"
+        msg: 'read only variable'
 
     #=============================================================
     # Verify mysql_variable works with the login_user and login_password parameters
@@ -216,7 +260,11 @@
         variable: '{{ set_name }}'
       register: result
 
-    - include: assert_var_output.yml changed=false output={{ result }} var_name={{ set_name }}
+    - include_tasks: assert_var_output.yml
+      vars:
+        changed: false
+        output: "{{ result }}"
+        var_name: "{{ set_name }}"
 
     - name: set mysql variable to temp value using user login and password (expect changed=true)
       mysql_variables:
@@ -232,7 +280,12 @@
         value: '{{set_value}}'
       register: result
 
-    - include: assert_var.yml changed=true output={{result}} var_name={{set_name}} var_value='{{set_value}}'
+    - include_tasks: assert_var.yml
+      vars:
+        changed: true
+        output: "{{result}}"
+        var_name: "{{set_name}}"
+        var_value: "{{set_value}}"
 
     #============================================================
     # Verify mysql_variable fails with an incorrect login_password parameter
@@ -251,7 +304,10 @@
       register: result
       ignore_errors: true
 
-    - include: assert_fail_msg.yml output={{ result }}  msg='unable to connect to database'
+    - include_tasks: assert_fail_msg.yml
+      vars:
+        output: "{{ result }}"
+        msg: 'unable to connect to database'
 
     - name: update mysql variable value using incorrect login_password (expect failed=true)
       mysql_variables:
@@ -264,7 +320,10 @@
       register: result
       ignore_errors: true
 
-    - include: assert_fail_msg.yml output={{ result }}  msg='unable to connect to database'
+    - include_tasks: assert_fail_msg.yml
+      vars:
+        output: "{{ result }}"
+        msg: 'unable to connect to database'
 
     #============================================================
     # Verify mysql_variable fails with an incorrect login_host parameter
@@ -280,7 +339,10 @@
       register: result
       ignore_errors: true
 
-    - include: assert_fail_msg.yml output={{ result }}  msg='unable to connect to database'
+    - include_tasks: assert_fail_msg.yml
+      vars:
+        output: "{{ result }}"
+        msg: 'unable to connect to database'
 
     - block:
 
@@ -299,7 +361,12 @@
             that:
             - result.queries == ["SET PERSIST `{{ set_name }}` = {{ set_value }}"]
 
-        - include: assert_var.yml changed=true output={{ result }} var_name={{ set_name }} var_value='{{ set_value }}'
+        - include_tasks: assert_var.yml
+          vars:
+            changed: true
+            output: "{{ result }}"
+            var_name: "{{ set_name }}"
+            var_value: "{{ set_value }}"
 
         - name: try to update mysql variable value (expect changed=false) in persist mode again
           mysql_variables:
@@ -309,7 +376,12 @@
             mode: persist
           register: result
 
-        - include: assert_var.yml changed=false output={{ result }} var_name={{ set_name }} var_value='{{ set_value }}'
+        - include_tasks: assert_var.yml
+          vars:
+            changed: false
+            output: "{{ result }}"
+            var_name: "{{ set_name }}"
+            var_value: "{{ set_value }}"
 
         - name: set mysql variable to a temp value
           mysql_variables:
@@ -356,7 +428,12 @@
             mode: persist_only
           register: result
 
-        - include: assert_var.yml changed=true output={{ result }} var_name={{ set_name }} var_value='{{ def_val }}'
+        - include_tasks: assert_var.yml
+          vars:
+            changed: true
+            output: "{{ result }}"
+            var_name: "{{ set_name }}"
+            var_value: "{{ def_val }}"
 
       when:
         - db_engine == 'mysql'


### PR DESCRIPTION
backport of #554

This PR tries to replace the deprecated `include` with `include_tasks`.