### PR TITLE
Add ansible-core stable-2.15 and stable-2.16 to tests matrix now that "devel" links to 2.17

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -22,8 +22,6 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.12
-          - stable-2.13
           - stable-2.14
           - stable-2.15
           - stable-2.16
@@ -43,8 +41,6 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.12
-          - stable-2.13
           - stable-2.14
           - stable-2.15
           - stable-2.16
@@ -116,9 +112,6 @@ jobs:
             python: '3.10'
 
           - db_engine_version: 5.7.40
-            ansible: stable-2.13
-
-          - db_engine_version: 5.7.40
             ansible: stable-2.14
 
           - db_engine_version: 5.7.40
@@ -182,9 +175,6 @@ jobs:
             connector_version: 2.0.3
 
           - python: '3.8'
-            ansible: stable-2.13
-
-          - python: '3.8'
             ansible: stable-2.14
 
           - python: '3.8'
@@ -197,9 +187,6 @@ jobs:
             ansible: devel
 
           - python: '3.9'
-            ansible: stable-2.12
-
-          - python: '3.9'
             ansible: stable-2.15
 
           - python: '3.9'
@@ -207,9 +194,6 @@ jobs:
 
           - python: '3.9'
             ansible: devel
-
-          - python: '3.10'
-            ansible: stable-2.12
 
     services:
       db_primary:
@@ -356,8 +340,6 @@ jobs:
       fail-fast: true
       matrix:
         ansible:
-          - stable-2.12
-          - stable-2.13
           - stable-2.14
           - stable-2.15
           - stable-2.16
@@ -367,8 +349,6 @@ jobs:
           - 3.9
         exclude:
           - python: '3.8'
-            ansible: stable-2.13
-          - python: '3.8'
             ansible: stable-2.14
           - python: '3.8'
             ansible: stable-2.15
@@ -376,8 +356,6 @@ jobs:
             ansible: stable-2.16
           - python: '3.8'
             ansible: devel
-          - python: '3.9'
-            ansible: stable-2.12
 
     steps:
       - name: >-

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -25,6 +25,8 @@ jobs:
           - stable-2.12
           - stable-2.13
           - stable-2.14
+          - stable-2.15
+          - stable-2.16
           - devel
     steps:
       - name: Perform sanity testing
@@ -44,6 +46,8 @@ jobs:
           - stable-2.12
           - stable-2.13
           - stable-2.14
+          - stable-2.15
+          - stable-2.16
           - devel
         db_engine_name:
           - mysql
@@ -118,6 +122,12 @@ jobs:
             ansible: stable-2.14
 
           - db_engine_version: 5.7.40
+            ansible: stable-2.15
+
+          - db_engine_version: 5.7.40
+            ansible: stable-2.16
+
+          - db_engine_version: 5.7.40
             ansible: devel
 
           - db_engine_version: 8.0.31
@@ -178,10 +188,22 @@ jobs:
             ansible: stable-2.14
 
           - python: '3.8'
+            ansible: stable-2.15
+
+          - python: '3.8'
+            ansible: stable-2.16
+
+          - python: '3.8'
             ansible: devel
 
           - python: '3.9'
             ansible: stable-2.12
+
+          - python: '3.9'
+            ansible: stable-2.15
+
+          - python: '3.9'
+            ansible: stable-2.16
 
           - python: '3.9'
             ansible: devel
@@ -337,6 +359,8 @@ jobs:
           - stable-2.12
           - stable-2.13
           - stable-2.14
+          - stable-2.15
+          - stable-2.16
           - devel
         python:
           - 3.8
@@ -346,6 +370,10 @@ jobs:
             ansible: stable-2.13
           - python: '3.8'
             ansible: stable-2.14
+          - python: '3.8'
+            ansible: stable-2.15
+          - python: '3.8'
+            ansible: stable-2.16
           - python: '3.8'
             ansible: devel
           - python: '3.9'

--- a/.github/workflows/ansible-test-roles.yml
+++ b/.github/workflows/ansible-test-roles.yml
@@ -24,31 +24,16 @@ jobs:
         mysql:
           - 2.0.12
         ansible:
-          - stable-2.11
-          - stable-2.12
           - stable-2.13
+          - stable-2.14
+          - stable-2.15
           - devel
         python:
-          - 3.6
           - 3.8
           - 3.9
         exclude:
-          - python: 3.6
-            ansible: stable-2.12
-          - python: 3.6
-            ansible: stable-2.13
-          - python: 3.6
-            ansible: devel
-          - python: 3.8
-            ansible: stable-2.11
-          - python: 3.8
-            ansible: stable-2.13
           - python: 3.8
             ansible: devel
-          - python: 3.9
-            ansible: stable-2.11
-          - python: 3.9
-            ansible: stable-2.12
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ Here is the table for the support timeline:
 
 ### ansible-core
 
-- 2.12
-- 2.13
-- 2.14
+- stable-2.12
+- stable-2.13
+- stable-2.14
+- stable-2.15
+- stable-2.16
 - current development version
 
 ### Databases

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,6 +52,8 @@ The Makefile accept the following options
     - "stable-2.12"
     - "stable-2.13"
     - "stable-2.14"
+    - "stable-2.15"
+    - "stable-2.16"
     - "devel"
   - Description: Version of ansible to install in a venv to run ansible-test
 

--- a/changelogs/fragments/drop_ansible_core_2_12_and_2_13.yml
+++ b/changelogs/fragments/drop_ansible_core_2_12_and_2_13.yml
@@ -1,0 +1,11 @@
+---
+
+major_changes:
+
+  - The community.mysql collection no longer supports ``ansible-core 2.12`` and
+    ``ansible-core 2.13``. While we take no active measures to prevent usage
+    and there are no plans to introduce incompatible code to the modules, we
+    will stop testing those versions. Both are or will soon be End of Life and
+    if you are still using them, you should consider upgrading to the
+    ``latest Ansible / ansible-core 2.15 or later`` as soon as possible
+    (https://github.com/ansible-collections/community.mysql/pull/574).

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,8 +1,0 @@
-plugins/modules/mysql_db.py validate-modules:doc-elements-mismatch
-plugins/modules/mysql_db.py validate-modules:parameter-list-no-elements
-plugins/modules/mysql_db.py validate-modules:use-run-command-not-popen
-plugins/modules/mysql_info.py validate-modules:doc-elements-mismatch
-plugins/modules/mysql_info.py validate-modules:parameter-list-no-elements
-plugins/modules/mysql_query.py validate-modules:parameter-list-no-elements
-plugins/modules/mysql_user.py validate-modules:undocumented-parameter
-plugins/modules/mysql_variables.py validate-modules:doc-required-mismatch

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,8 +1,0 @@
-plugins/modules/mysql_db.py validate-modules:doc-elements-mismatch
-plugins/modules/mysql_db.py validate-modules:parameter-list-no-elements
-plugins/modules/mysql_db.py validate-modules:use-run-command-not-popen
-plugins/modules/mysql_info.py validate-modules:doc-elements-mismatch
-plugins/modules/mysql_info.py validate-modules:parameter-list-no-elements
-plugins/modules/mysql_query.py validate-modules:parameter-list-no-elements
-plugins/modules/mysql_user.py validate-modules:undocumented-parameter
-plugins/modules/mysql_variables.py validate-modules:doc-required-mismatch

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,10 @@
+plugins/modules/mysql_db.py validate-modules:doc-elements-mismatch
+plugins/modules/mysql_db.py validate-modules:parameter-list-no-elements
+plugins/modules/mysql_db.py validate-modules:use-run-command-not-popen
+plugins/modules/mysql_info.py validate-modules:doc-elements-mismatch
+plugins/modules/mysql_info.py validate-modules:parameter-list-no-elements
+plugins/modules/mysql_query.py validate-modules:parameter-list-no-elements
+plugins/modules/mysql_user.py validate-modules:undocumented-parameter
+plugins/modules/mysql_variables.py validate-modules:doc-required-mismatch
+plugins/module_utils/mysql.py pylint:unused-import
+plugins/module_utils/version.py pylint:unused-import


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Add ansible-core 2.15 and 2.16 to the sanity, integration and unit tests matrix now that "devel" links to ansible-core 2.17. This is in response to this [announcement](https://github.com/ansible-collections/news-for-maintainers/issues/58)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
CI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
