### PR TITLE
cut option maria_role as it has nothing to do with roles

### DIFF
--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -194,6 +194,13 @@ def mysql_common_argument_spec():
     )
 
 
+def get_server_type(cursor):
+    """ Return MySQL or MariaDB after quering the server
+    using SELECT VERSION()"""
+    srv_ver = get_server_version(cursor)
+    return 'mariadb' if 'mariadb' in srv_ver.lower() else "mysql"
+
+
 def get_server_version(cursor):
     """Returns a string representation of the server version."""
     cursor.execute("SELECT VERSION() AS version")

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -16,6 +16,7 @@ from ansible.module_utils.six import iteritems
 
 from ansible_collections.community.mysql.plugins.module_utils.mysql import (
     mysql_driver,
+    get_server_type,
 )
 
 

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -789,8 +789,7 @@ class Role():
         if privs:
             for db_table, priv in iteritems(privs):
                 privileges_grant(self.cursor, self.name, self.host,
-                                 db_table, priv, tls_requires=None,
-                                 maria_role=self.is_mariadb)
+                                 db_table, priv, tls_requires=None)
 
         return True
 
@@ -932,7 +931,7 @@ class Role():
             result = user_mod(self.cursor, self.name, self.host,
                               None, None, None, None, None, None,
                               privs, append_privs, subtract_privs, None,
-                              self.module, role=True, maria_role=self.is_mariadb)
+                              self.module, role=True)
             changed = result['changed']
 
         if admin:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This option was introduced in #189. To my knowledge, there is no difference between MySQL and MariaDB regarding roles or when you call a user by its name alone. Same for roles.

For instance:
```SQL
create user foo;
select user, host from mysql.user;
-- foo, %
show grants for foo;
-- GRANT USAGE ON *.* TO foo@%;

create role role_foo;
select user, host from mysql.user;
-- foo, %
-- role_foo, %
show grants for role_foo;
```
So both in MySQL and MariaDB you can omit the host.

The `mysql_user` plugin defaults host to `localhost`: `host=dict(type='str', default='localhost')`
So all functions will always receive a host. Maybe the option was used to bypass the default, 'localhost' and search for '%' instead of localhost ? This works because when you don't specify a host, MySQL and MariaDB will assume host is '%'.
But then, I don't get why the search for '%' is made by an option called `maria_role`.

I removed this option and if all tests path, I propose the get rid of it.

Sometime we must know if we are in MySQL or MariaDB, like when parsing the return of `SHOW GRANTS FOR`. For those cases I added a new function to the module_utils `mysql.py` called `get_server_type()`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Code clarity Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- mysql_user
- mysql_role
- module_utils: mysql

