### PR TITLE
fix list of tested ansible-core versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ Here is the table for the support timeline:
 
 ### ansible-core
 
-- stable-2.12
-- stable-2.13
 - stable-2.14
 - stable-2.15
 - stable-2.16


### PR DESCRIPTION
##### SUMMARY
The CI is already updated to tests from 2.14 and newer but the README.md didn't follow. This PR removes 2.12 and 2.13 from the list of the ansible-core versions we use in our tests.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

