### PR TITLE
Remove ansible devel from stable-2's test matrix

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -25,7 +25,6 @@ jobs:
           - stable-2.12
           - stable-2.13
           - stable-2.14
-          - devel
     steps:
       - name: Perform sanity testing
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -44,7 +43,6 @@ jobs:
           - stable-2.12
           - stable-2.13
           - stable-2.14
-          - devel
         db_engine_name:
           - mysql
           - mariadb
@@ -125,9 +123,6 @@ jobs:
           - db_engine_version: 5.7.40
             ansible: stable-2.14
 
-          - db_engine_version: 5.7.40
-            ansible: devel
-
           - db_engine_version: 8.0.31
             python: '3.8'
 
@@ -136,9 +131,6 @@ jobs:
 
           - db_engine_version: 10.4.27
             python: '3.10'
-
-          - db_engine_version: 10.4.27
-            ansible: devel
 
           - db_engine_version: 10.6.11
             python: '3.8'
@@ -179,14 +171,8 @@ jobs:
           - python: '3.8'
             ansible: stable-2.14
 
-          - python: '3.8'
-            ansible: devel
-
           - python: '3.9'
             ansible: stable-2.12
-
-          - python: '3.9'
-            ansible: devel
 
           - python: '3.10'
             ansible: stable-2.12
@@ -339,7 +325,6 @@ jobs:
           - stable-2.12
           - stable-2.13
           - stable-2.14
-          - devel
         python:
           - 3.8
           - 3.9
@@ -348,8 +333,6 @@ jobs:
             ansible: stable-2.13
           - python: '3.8'
             ansible: stable-2.14
-          - python: '3.8'
-            ansible: devel
           - python: '3.9'
             ansible: stable-2.12
 

--- a/.github/workflows/ansible-test-roles.yml
+++ b/.github/workflows/ansible-test-roles.yml
@@ -27,7 +27,6 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
-          - devel
         python:
           - 3.6
           - 3.8
@@ -37,14 +36,10 @@ jobs:
             ansible: stable-2.12
           - python: 3.6
             ansible: stable-2.13
-          - python: 3.6
-            ansible: devel
           - python: 3.8
             ansible: stable-2.11
           - python: 3.8
             ansible: stable-2.13
-          - python: 3.8
-            ansible: devel
           - python: 3.9
             ansible: stable-2.11
           - python: 3.9

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Every voice is important and every idea is valuable. If you have something on yo
 - 2.12
 - 2.13
 - 2.14
-- current development version
 
 ### Databases
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,7 +52,6 @@ The Makefile accept the following options
     - "stable-2.12"
     - "stable-2.13"
     - "stable-2.14"
-    - "devel"
   - Description: Version of ansible to install in a venv to run ansible-test
 
 - `db_engine_name`


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`stable-2` has old ansible syntax like bare `include:`. This fails the sanity tests with ansible 2.17 (the target for devel today). We don't test stable-2 for 2.15 and 2.16 so why we should test 2.17?

This made me realize I don't know if I need to backport newer versions of ansible, mysql and mariadb or not. To answer that, I'm opening a discussion [here: https://github.com/ansible-collections/community.mysql/discussions/586](https://github.com/ansible-collections/community.mysql/discussions/586)

In the meantime, I propose to merge this to help me backport other PR. In 1 month stable-2 is EoL anyway.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI tests
