### PR TITLE
Fix user plugin changes in check mode

### DIFF
--- a/changelogs/fragments/596-fix-check-changes.yaml
+++ b/changelogs/fragments/596-fix-check-changes.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql_user - Module makes changes when is executed with plugin_auth_string parameter and check mode

--- a/changelogs/fragments/596-fix-check-changes.yaml
+++ b/changelogs/fragments/596-fix-check-changes.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - mysql_user - Module makes changes when is executed with plugin_auth_string parameter and check mode
+  - mysql_user - module makes changes when is executed with ``plugin_auth_string`` parameter and check mode.

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -412,6 +412,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s", (user, host, plugin)
 
                 cursor.execute(*query_with_args)
+                password_changed = True
                 changed = True
 
         # Handle privileges

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -411,7 +411,8 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                 elif not module.check_mode:
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s", (user, host, plugin)
 
-                cursor.execute(*query_with_args)
+                if not module.check_mode:
+                    cursor.execute(*query_with_args)
                 password_changed = True
                 changed = True
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -412,7 +412,6 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s", (user, host, plugin)
 
                 cursor.execute(*query_with_args)
-                password_changed = True
                 changed = True
 
         # Handle privileges

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -396,7 +396,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                 query_with_args = None
                 if plugin_hash_string:
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
-                elif plugin_auth_string and not module.check_mode:
+                elif plugin_auth_string:
                     # Mysql and MariaDB differ in naming pam plugin and syntax to set it
                     if plugin in ('pam', 'ed25519'):
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
@@ -408,7 +408,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                         query_with_args = ("ALTER USER %s@%s IDENTIFIED WITH %s AS 0x" + generated_hash_string), (user, host, plugin)
                     else:
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s BY %s", (user, host, plugin, plugin_auth_string)
-                elif not module.check_mode:
+                else:
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s", (user, host, plugin)
 
                 if not module.check_mode:

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -396,7 +396,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                 query_with_args = None
                 if plugin_hash_string:
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
-                elif plugin_auth_string:
+                elif plugin_auth_string and not module.check_mode:
                     # Mysql and MariaDB differ in naming pam plugin and syntax to set it
                     if plugin in ('pam', 'ed25519'):
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
@@ -408,7 +408,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                         query_with_args = ("ALTER USER %s@%s IDENTIFIED WITH %s AS 0x" + generated_hash_string), (user, host, plugin)
                     else:
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s BY %s", (user, host, plugin, plugin_auth_string)
-                else:
+                elif not module.check_mode:
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s", (user, host, plugin)
 
                 cursor.execute(*query_with_args)

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import yaml
 import os

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import yaml
 import os

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -55,7 +55,7 @@
         user_host: "%"
         priv: "{{ test_default_priv_type }}"
 
-    - name: Plugin auth | Change user plugin in check mode
+    - name: Plugin auth | Change auth user plugin in check mode
       community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
@@ -66,12 +66,12 @@
       check_mode: true
       register: result
 
-    - name: Plugin auth | Check that the module made a change auth plugin
+    - name: Plugin auth | Check that the module reported a change in auth plugin
       ansible.builtin.assert:
         that:
           - result is changed
 
-    - name: Plugin auth | Check that the expected plugin type is set
+    - name: Plugin auth | Check that the expected (previous) plugin type is set
       ansible.builtin.include_tasks: utils/assert_plugin.yml
       vars:
         user_name: "{{ test_user_name }}"
@@ -119,7 +119,7 @@
         user_name: "{{ test_user_name }}"
         plugin_type: "{{ test_plugin_type }}"
 
-    - name: Plugin auth | Set same plugint check that no changes are reported
+    - name: Plugin auth | Set same plugin to check that no changes are reported
       community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -637,25 +637,3 @@
           vars:
             user_name: "{{ test_user_name }}"
             plugin_type: caching_sha2_password
-
-        - name: Plugin auth | Change user password
-          community.mysql.mysql_user:
-            <<: *mysql_params
-            name: "{{ test_user_name }}"
-            host: '%'
-            plugin: caching_sha2_password
-            plugin_auth_string: "{{ test_plugin_new_auth_string }}"
-            salt: "{{ test_salt }}"
-            priv: "{{ test_default_priv }}"
-          register: result
-          failed_when: result is not changed
-
-        - name: Plugin auth | Connect with user and password
-          ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_new_auth_string }} -e "SELECT 1"'
-          changed_when: false
-
-        - name: Plugin auth | Check that the expected plugin type is set after change
-          ansible.builtin.include_tasks: utils/assert_plugin.yml
-          vars:
-            user_name: "{{ test_user_name }}"
-            plugin_type: caching_sha2_password

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -581,6 +581,7 @@
 
         - name: Plugin auth | Connect with user and password
           ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_auth_string }} -e "SELECT 1"'
+          changed_when: false
 
         - name: Plugin auth | Change auth user plugin in check mode
           community.mysql.mysql_user:
@@ -632,6 +633,28 @@
           failed_when: result is changed
 
         - name: Plugin auth | Check that the expected (not changed) plugin type is set
+          ansible.builtin.include_tasks: utils/assert_plugin.yml
+          vars:
+            user_name: "{{ test_user_name }}"
+            plugin_type: caching_sha2_password
+
+        - name: Plugin auth | Change user password
+          community.mysql.mysql_user:
+            <<: *mysql_params
+            name: "{{ test_user_name }}"
+            host: '%'
+            plugin: caching_sha2_password
+            plugin_auth_string: newpass
+            salt: "{{ test_salt }}"
+            priv: "{{ test_default_priv }}"
+          register: result
+          failed_when: result is not changed
+
+        - name: Plugin auth | Connect with user and password
+          ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -pnewpass -e "SELECT 1"'
+          changed_when: false
+
+        - name: Plugin auth | Check that the expected plugin type is set after change
           ansible.builtin.include_tasks: utils/assert_plugin.yml
           vars:
             user_name: "{{ test_user_name }}"

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -578,7 +578,7 @@
         name: '{{ test_user_name }}'
         host: '%'
         plugin: caching_sha2_password
-        plugin_hash_string: '{{ test_plugin_hash }}'
+        plugin_auth_string: '{{ test_plugin_hash }}'
         salt: '{{ test_salt }}'
         priv: '{{ test_default_priv }}'
       check_mode: true
@@ -597,7 +597,7 @@
         name: '{{ test_user_name }}'
         host: '%'
         plugin: caching_sha2_password
-        plugin_hash_string: '{{ test_plugin_hash }}'
+        plugin_auth_string: '{{ test_plugin_hash }}'
         salt: '{{ test_salt }}'
         priv: '{{ test_default_priv }}'
       register: result
@@ -615,7 +615,7 @@
         name: '{{ test_user_name }}'
         host: '%'
         plugin: caching_sha2_password
-        plugin_hash_string: '{{ test_plugin_hash }}'
+        plugin_auth_string: '{{ test_plugin_hash }}'
         salt: '{{ test_salt }}'
         priv: '{{ test_default_priv }}'
       register: result
@@ -626,4 +626,3 @@
       vars:
         user_name: "{{ test_user_name }}"
         plugin_type: caching_sha2_password
-

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -579,60 +579,60 @@
             user_name: "{{ test_user_name }}"
             plugin_type: "{{ test_plugin_type }}"
 
-        # - name: Plugin auth | Connect with user and password
-        #   ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_auth_string }} -e "SELECT 1"'
+        - name: Plugin auth | Connect with user and password
+          ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_auth_string }} -e "SELECT 1"'
 
-        # - name: Plugin auth | Change auth user plugin in check mode
-        #   community.mysql.mysql_user:
-        #     <<: *mysql_params
-        #     name: "{{ test_user_name }}"
-        #     host: '%'
-        #     plugin: caching_sha2_password
-        #     plugin_auth_string: "{{ test_plugin_auth_string }}"
-        #     salt: "{{ test_salt }}"
-        #     priv: "{{ test_default_priv }}"
-        #   check_mode: true
-        #   register: result
-        #   failed_when: result is not changed
+        - name: Plugin auth | Change auth user plugin in check mode
+          community.mysql.mysql_user:
+            <<: *mysql_params
+            name: "{{ test_user_name }}"
+            host: '%'
+            plugin: caching_sha2_password
+            plugin_auth_string: "{{ test_plugin_auth_string }}"
+            salt: "{{ test_salt }}"
+            priv: "{{ test_default_priv }}"
+          check_mode: true
+          register: result
+          failed_when: result is not changed
 
-        # - name: Plugin auth | Check that the expected plugin type is set (not changed)
-        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
-        #   vars:
-        #     user_name: "{{ test_user_name }}"
-        #     plugin_type: "{{ test_plugin_type }}"
+        - name: Plugin auth | Check that the expected plugin type is set (not changed)
+          ansible.builtin.include_tasks: utils/assert_plugin.yml
+          vars:
+            user_name: "{{ test_user_name }}"
+            plugin_type: "{{ test_plugin_type }}"
 
-        # - name: Plugin auth | Change auth user plugin
-        #   community.mysql.mysql_user:
-        #     <<: *mysql_params
-        #     name: "{{ test_user_name }}"
-        #     host: '%'
-        #     plugin: caching_sha2_password
-        #     plugin_auth_string: "{{ test_plugin_auth_string }}"
-        #     salt: "{{ test_salt }}"
-        #     priv: "{{ test_default_priv }}"
-        #   register: result
-        #   failed_when: result is not changed
+        - name: Plugin auth | Change auth user plugin
+          community.mysql.mysql_user:
+            <<: *mysql_params
+            name: "{{ test_user_name }}"
+            host: '%'
+            plugin: caching_sha2_password
+            plugin_auth_string: "{{ test_plugin_auth_string }}"
+            salt: "{{ test_salt }}"
+            priv: "{{ test_default_priv }}"
+          register: result
+          failed_when: result is not changed
 
-        # - name: Plugin auth | Check that the expected (new) plugin type is set
-        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
-        #   vars:
-        #     user_name: "{{ test_user_name }}"
-        #     plugin_type: caching_sha2_password
+        - name: Plugin auth | Check that the expected (new) plugin type is set
+          ansible.builtin.include_tasks: utils/assert_plugin.yml
+          vars:
+            user_name: "{{ test_user_name }}"
+            plugin_type: caching_sha2_password
 
-        # - name: Plugin auth | Change auth user plugin again (should not change)
-        #   community.mysql.mysql_user:
-        #     <<: *mysql_params
-        #     name: "{{ test_user_name }}"
-        #     host: '%'
-        #     plugin: caching_sha2_password
-        #     plugin_auth_string: "{{ test_plugin_auth_string }}"
-        #     salt: "{{ test_salt }}"
-        #     priv: "{{ test_default_priv }}"
-        #   register: result
-        #   failed_when: result is changed
+        - name: Plugin auth | Change auth user plugin again (should not change)
+          community.mysql.mysql_user:
+            <<: *mysql_params
+            name: "{{ test_user_name }}"
+            host: '%'
+            plugin: caching_sha2_password
+            plugin_auth_string: "{{ test_plugin_auth_string }}"
+            salt: "{{ test_salt }}"
+            priv: "{{ test_default_priv }}"
+          register: result
+          failed_when: result is changed
 
-        # - name: Plugin auth | Check that the expected (not changed) plugin type is set
-        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
-        #   vars:
-        #     user_name: "{{ test_user_name }}"
-        #     plugin_type: caching_sha2_password
+        - name: Plugin auth | Check that the expected (not changed) plugin type is set
+          ansible.builtin.include_tasks: utils/assert_plugin.yml
+          vars:
+            user_name: "{{ test_user_name }}"
+            plugin_type: caching_sha2_password

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -564,6 +564,12 @@
         password: "{{ test_plugin_auth_string }}"
         priv: "{{ test_default_priv }}"
 
+    - name: Plugin auth | Check that the expected (previous) plugin type is set
+      ansible.builtin.include_tasks: utils/assert_plugin.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        plugin_type: "{{ test_plugin_type }}"
+
     - name: Plugin auth | Connect with user and password
       ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_auth_string }} -e "SELECT 1"'
 
@@ -583,7 +589,7 @@
       ansible.builtin.include_tasks: utils/assert_plugin.yml
       vars:
         user_name: "{{ test_user_name }}"
-        plugin_type: "{{ caching_sha2_password }}"
+        plugin_type: "{{ test_plugin_type }}"
 
     - name: Plugin auth | Change auth user plugin
       community.mysql.mysql_user:

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -579,6 +579,7 @@
         host: '%'
         plugin: caching_sha2_password
         plugin_hash_string: '{{ test_plugin_hash }}'
+        salt: '{{ test_salt }}'
         priv: '{{ test_default_priv }}'
       check_mode: true
       register: result
@@ -597,11 +598,30 @@
         host: '%'
         plugin: caching_sha2_password
         plugin_hash_string: '{{ test_plugin_hash }}'
+        salt: '{{ test_salt }}'
         priv: '{{ test_default_priv }}'
       register: result
       failed_when: result is not changed
 
     - name: Plugin auth | Check that the expected (new) plugin type is set
+      ansible.builtin.include_tasks: utils/assert_plugin.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        plugin_type: caching_sha2_password
+
+    - name: Plugin auth | Change user plugin again (should not change)
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ test_user_name }}'
+        host: '%'
+        plugin: caching_sha2_password
+        plugin_hash_string: '{{ test_plugin_hash }}'
+        salt: '{{ test_salt }}'
+        priv: '{{ test_default_priv }}'
+      register: result
+      failed_when: result is changed
+
+    - name: Plugin auth | Check that the expected (not changed) plugin type is set
       ansible.builtin.include_tasks: utils/assert_plugin.yml
       vars:
         user_name: "{{ test_user_name }}"

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -591,48 +591,48 @@
             plugin_auth_string: "{{ test_plugin_auth_string }}"
             salt: "{{ test_salt }}"
             priv: "{{ test_default_priv }}"
-          check_mode: true
+          # check_mode: true
           register: result
           failed_when: result is not changed
 
-        - name: Plugin auth | Check that the expected plugin type is set (not changed)
-          ansible.builtin.include_tasks: utils/assert_plugin.yml
-          vars:
-            user_name: "{{ test_user_name }}"
-            plugin_type: "{{ test_plugin_type }}"
+        # - name: Plugin auth | Check that the expected plugin type is set (not changed)
+        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
+        #   vars:
+        #     user_name: "{{ test_user_name }}"
+        #     plugin_type: "{{ test_plugin_type }}"
 
-        - name: Plugin auth | Change auth user plugin
-          community.mysql.mysql_user:
-            <<: *mysql_params
-            name: "{{ test_user_name }}"
-            host: '%'
-            plugin: caching_sha2_password
-            plugin_auth_string: "{{ test_plugin_auth_string }}"
-            salt: "{{ test_salt }}"
-            priv: "{{ test_default_priv }}"
-          register: result
-          failed_when: result is not changed
+        # - name: Plugin auth | Change auth user plugin
+        #   community.mysql.mysql_user:
+        #     <<: *mysql_params
+        #     name: "{{ test_user_name }}"
+        #     host: '%'
+        #     plugin: caching_sha2_password
+        #     plugin_auth_string: "{{ test_plugin_auth_string }}"
+        #     salt: "{{ test_salt }}"
+        #     priv: "{{ test_default_priv }}"
+        #   register: result
+        #   failed_when: result is not changed
 
-        - name: Plugin auth | Check that the expected (new) plugin type is set
-          ansible.builtin.include_tasks: utils/assert_plugin.yml
-          vars:
-            user_name: "{{ test_user_name }}"
-            plugin_type: caching_sha2_password
+        # - name: Plugin auth | Check that the expected (new) plugin type is set
+        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
+        #   vars:
+        #     user_name: "{{ test_user_name }}"
+        #     plugin_type: caching_sha2_password
 
-        - name: Plugin auth | Change auth user plugin again (should not change)
-          community.mysql.mysql_user:
-            <<: *mysql_params
-            name: "{{ test_user_name }}"
-            host: '%'
-            plugin: caching_sha2_password
-            plugin_auth_string: "{{ test_plugin_auth_string }}"
-            salt: "{{ test_salt }}"
-            priv: "{{ test_default_priv }}"
-          register: result
-          failed_when: result is changed
+        # - name: Plugin auth | Change auth user plugin again (should not change)
+        #   community.mysql.mysql_user:
+        #     <<: *mysql_params
+        #     name: "{{ test_user_name }}"
+        #     host: '%'
+        #     plugin: caching_sha2_password
+        #     plugin_auth_string: "{{ test_plugin_auth_string }}"
+        #     salt: "{{ test_salt }}"
+        #     priv: "{{ test_default_priv }}"
+        #   register: result
+        #   failed_when: result is changed
 
-        - name: Plugin auth | Check that the expected (not changed) plugin type is set
-          ansible.builtin.include_tasks: utils/assert_plugin.yml
-          vars:
-            user_name: "{{ test_user_name }}"
-            plugin_type: caching_sha2_password
+        # - name: Plugin auth | Check that the expected (not changed) plugin type is set
+        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
+        #   vars:
+        #     user_name: "{{ test_user_name }}"
+        #     plugin_type: caching_sha2_password

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -591,7 +591,7 @@
             plugin_auth_string: "{{ test_plugin_auth_string }}"
             salt: "{{ test_salt }}"
             priv: "{{ test_default_priv }}"
-          # check_mode: true
+          check_mode: true
           register: result
           failed_when: result is not changed
 

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -9,7 +9,6 @@
       login_port: '{{ mysql_primary_port }}'
     test_user_name: 'test_user_plugin_auth'
     test_plugin_type: 'mysql_native_password'
-    test_plugin_type2: 'caching_sha2_password'
     test_plugin_hash: '*0CB5B86F23FDC24DB19A29B8854EB860CBC47793'
     test_plugin_auth_string: 'Fdt8fd^34ds'
     test_plugin_new_hash: '*E74368AC90460FA669F6D41BFB7F2A877DB73745'

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -575,12 +575,12 @@
     - name: Plugin auth | Change auth user plugin in check mode
       community.mysql.mysql_user:
         <<: *mysql_params
-        name: '{{ test_user_name }}'
+        name: "{{ test_user_name }}"
         host: '%'
         plugin: caching_sha2_password
-        plugin_auth_string: '{{ test_plugin_hash }}'
-        salt: '{{ test_salt }}'
-        priv: '{{ test_default_priv }}'
+        plugin_auth_string: "{{ test_plugin_auth_string }}"
+        salt: "{{ test_salt }}"
+        priv: "{{ test_default_priv }}"
       check_mode: true
       register: result
       failed_when: result is not changed
@@ -594,12 +594,12 @@
     - name: Plugin auth | Change auth user plugin
       community.mysql.mysql_user:
         <<: *mysql_params
-        name: '{{ test_user_name }}'
+        name: "{{ test_user_name }}"
         host: '%'
         plugin: caching_sha2_password
-        plugin_auth_string: '{{ test_plugin_hash }}'
-        salt: '{{ test_salt }}'
-        priv: '{{ test_default_priv }}'
+        plugin_auth_string: "{{ test_plugin_auth_string }}"
+        salt: "{{ test_salt }}"
+        priv: "{{ test_default_priv }}"
       register: result
       failed_when: result is not changed
 
@@ -612,12 +612,12 @@
     - name: Plugin auth | Change auth user plugin again (should not change)
       community.mysql.mysql_user:
         <<: *mysql_params
-        name: '{{ test_user_name }}'
+        name: "{{ test_user_name }}"
         host: '%'
         plugin: caching_sha2_password
-        plugin_auth_string: '{{ test_plugin_hash }}'
-        salt: '{{ test_salt }}'
-        priv: '{{ test_default_priv }}'
+        plugin_auth_string: "{{ test_plugin_auth_string }}"
+        salt: "{{ test_salt }}"
+        priv: "{{ test_default_priv }}"
       register: result
       failed_when: result is changed
 

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -545,84 +545,123 @@
       register: result
       failed_when: result is success
 
-    # # ============================================================
-    # # Test auth plugin change
-    # #
 
-    # - name: Cleanup user
-    #   ansible.builtin.include_tasks: utils/remove_user.yml
-    #   vars:
-    #     user_name: "{{ test_user_name }}"
 
-    # - name: Plugin auth | Create user with mysql_native_password
-    #   community.mysql.mysql_user:
-    #     <<: *mysql_params
-    #     name: "{{ test_user_name }}"
-    #     host: "%"
-    #     plugin: "{{ test_plugin_type }}"
-    #     password: "{{ test_plugin_auth_string }}"
-    #     priv: "{{ test_default_priv }}"
 
-    # - name: Plugin auth | Check that the expected plugin type is set
-    #   ansible.builtin.include_tasks: utils/assert_plugin.yml
-    #   vars:
-    #     user_name: "{{ test_user_name }}"
-    #     plugin_type: "{{ test_plugin_type }}"
 
-    # - name: Plugin auth | Connect with user and password
-    #   ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_auth_string }} -e "SELECT 1"'
+    # ============================================================
+    # Test auth plugin change
+    #
 
-    # - name: Plugin auth | Change auth user plugin in check mode
-    #   community.mysql.mysql_user:
-    #     <<: *mysql_params
-    #     name: "{{ test_user_name }}"
-    #     host: '%'
-    #     plugin: caching_sha2_password
-    #     plugin_auth_string: "{{ test_plugin_auth_string }}"
-    #     salt: "{{ test_salt }}"
-    #     priv: "{{ test_default_priv }}"
-    #   check_mode: true
-    #   register: result
-    #   failed_when: result is not changed
+    - name: Cleanup user
+      ansible.builtin.include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
 
-    # - name: Plugin auth | Check that the expected plugin type is set (not changed)
-    #   ansible.builtin.include_tasks: utils/assert_plugin.yml
-    #   vars:
-    #     user_name: "{{ test_user_name }}"
-    #     plugin_type: "{{ test_plugin_type }}"
+    - name: Plugin auth | Create user with mysql_native_password
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: "{{ test_user_name }}"
+        host: "%"
+        plugin: "{{ test_plugin_type }}"
+        password: "{{ test_plugin_auth_string }}"
+        priv: "{{ test_default_priv }}"
 
-    # - name: Plugin auth | Change auth user plugin
-    #   community.mysql.mysql_user:
-    #     <<: *mysql_params
-    #     name: "{{ test_user_name }}"
-    #     host: '%'
-    #     plugin: caching_sha2_password
-    #     plugin_auth_string: "{{ test_plugin_auth_string }}"
-    #     salt: "{{ test_salt }}"
-    #     priv: "{{ test_default_priv }}"
-    #   register: result
-    #   failed_when: result is not changed
+    - name: Plugin auth | Check that the expected plugin type is set
+      ansible.builtin.include_tasks: utils/assert_plugin.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        plugin_type: "{{ test_plugin_type }}"
 
-    # - name: Plugin auth | Check that the expected (new) plugin type is set
-    #   ansible.builtin.include_tasks: utils/assert_plugin.yml
-    #   vars:
-    #     user_name: "{{ test_user_name }}"
-    #     plugin_type: caching_sha2_password
+    - name: Plugin auth | Connect with user and password
+      ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_auth_string }} -e "SELECT 1"'
 
-    # - name: Plugin auth | Change auth user plugin again (should not change)
-    #   community.mysql.mysql_user:
-    #     <<: *mysql_params
-    #     name: "{{ test_user_name }}"
-    #     host: '%'
-    #     plugin: caching_sha2_password
-    #     plugin_auth_string: "{{ test_plugin_auth_string }}"
-    #     salt: "{{ test_salt }}"
-    #     priv: "{{ test_default_priv }}"
-    #   register: result
-    #   failed_when: result is changed
+    - name: Plugin auth | Change auth user plugin in check mode
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: "{{ test_user_name }}"
+        host: '%'
+        plugin: caching_sha2_password
+        plugin_auth_string: "{{ test_plugin_auth_string }}"
+        salt: "{{ test_salt }}"
+        priv: "{{ test_default_priv }}"
+      check_mode: true
+      register: result
+      failed_when: result is not changed
+      when:
+        - >
+          connector_name != 'pymysql'
+          or (
+            connector_name == 'pymysql'
+            and connector_version is version('0.9', '>=')
+          )
 
-    # - name: Plugin auth | Check that the expected (not changed) plugin type is set
-    #   ansible.builtin.include_tasks: utils/assert_plugin.yml
-    #   vars:
-    #     user_name: "{{ test_user_name }}"
-    #     plugin_type: caching_sha2_password
+    - name: Plugin auth | Check that the expected plugin type is set (not changed)
+      ansible.builtin.include_tasks: utils/assert_plugin.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        plugin_type: "{{ test_plugin_type }}"
+
+    - name: Plugin auth | Change auth user plugin
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: "{{ test_user_name }}"
+        host: '%'
+        plugin: caching_sha2_password
+        plugin_auth_string: "{{ test_plugin_auth_string }}"
+        salt: "{{ test_salt }}"
+        priv: "{{ test_default_priv }}"
+      register: result
+      failed_when: result is not changed
+      when:
+        - >
+          connector_name != 'pymysql'
+          or (
+            connector_name == 'pymysql'
+            and connector_version is version('0.9', '>=')
+          )
+
+    - name: Plugin auth | Check that the expected (new) plugin type is set
+      ansible.builtin.include_tasks: utils/assert_plugin.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        plugin_type: caching_sha2_password
+      when:
+        - >
+          connector_name != 'pymysql'
+          or (
+            connector_name == 'pymysql'
+            and connector_version is version('0.9', '>=')
+          )
+
+    - name: Plugin auth | Change auth user plugin again (should not change)
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: "{{ test_user_name }}"
+        host: '%'
+        plugin: caching_sha2_password
+        plugin_auth_string: "{{ test_plugin_auth_string }}"
+        salt: "{{ test_salt }}"
+        priv: "{{ test_default_priv }}"
+      register: result
+      failed_when: result is changed
+      when:
+        - >
+          connector_name != 'pymysql'
+          or (
+            connector_name == 'pymysql'
+            and connector_version is version('0.9', '>=')
+          )
+
+    - name: Plugin auth | Check that the expected (not changed) plugin type is set
+      ansible.builtin.include_tasks: utils/assert_plugin.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        plugin_type: caching_sha2_password
+      when:
+        - >
+          connector_name != 'pymysql'
+          or (
+            connector_name == 'pymysql'
+            and connector_version is version('0.9', '>=')
+          )

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -9,6 +9,7 @@
       login_port: '{{ mysql_primary_port }}'
     test_user_name: 'test_user_plugin_auth'
     test_plugin_type: 'mysql_native_password'
+    test_plugin_type2: 'caching_sha2_password'
     test_plugin_hash: '*0CB5B86F23FDC24DB19A29B8854EB860CBC47793'
     test_plugin_auth_string: 'Fdt8fd^34ds'
     test_plugin_new_hash: '*E74368AC90460FA669F6D41BFB7F2A877DB73745'
@@ -24,7 +25,7 @@
     #
 
     - name: Plugin auth | Create user with plugin auth (with hash string)
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
         host: '%'
@@ -34,28 +35,107 @@
       register: result
 
     - name: Plugin auth | Get user information (with hash string)
-      command: "{{ mysql_command }} -e \"SELECT user, host, plugin FROM mysql.user WHERE user = '{{ test_user_name }}' and host = '%'\""
+      ansible.builtin.command: "{{ mysql_command }} -e \"SELECT user, host, plugin FROM mysql.user WHERE user = '{{ test_user_name }}' and host = '%'\""
       register: show_create_user
 
     - name: Plugin auth | Check that the module made a change (with hash string)
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
 
     - name: Plugin auth | Check that the expected plugin type is set (with hash string)
-      assert:
+      ansible.builtin.assert:
         that:
           - "'{{ test_plugin_type }}' in show_create_user.stdout"
       when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-    - include_tasks: utils/assert_user.yml
+    - ansible.builtin.include_tasks: utils/assert_user.yml
       vars:
         user_name: "{{ test_user_name }}"
         user_host: "%"
         priv: "{{ test_default_priv_type }}"
 
+    - name: Plugin auth | Change user plugin in check mode
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ test_user_name }}'
+        host: '%'
+        plugin: '{{ test_plugin_type2 }}'
+        plugin_hash_string: '{{ test_plugin_hash }}'
+        priv: '{{ test_default_priv }}'
+      check_mode: true
+      register: result
+
+    - name: Plugin auth | Check that the module made a change auth plugin
+      ansible.builtin.assert:
+        that:
+          - result is changed
+
+    - name: Plugin auth | Check that the expected plugin type is set
+      ansible.builtin.include_tasks: utils/assert_plugin.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        plugin_type: "{{ test_plugin_type }}"
+
+    - name: Plugin auth | Change user auth plugin
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ test_user_name }}'
+        host: '%'
+        plugin: '{{ test_plugin_type2 }}'
+        plugin_hash_string: '{{ test_plugin_hash }}'
+        priv: '{{ test_default_priv }}'
+      register: result
+
+    - name: Plugin auth | Check that the module made a change auth plugin
+      ansible.builtin.assert:
+        that:
+          - result is changed
+
+    - name: Plugin auth | Check that the expected plugin type is set
+      ansible.builtin.include_tasks: utils/assert_plugin.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        plugin_type: "{{ test_plugin_type2 }}"
+
+    - name: Plugin auth | Set main auth plugin again
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ test_user_name }}'
+        host: '%'
+        plugin: '{{ test_plugin_type }}'
+        plugin_hash_string: '{{ test_plugin_hash }}'
+        priv: '{{ test_default_priv }}'
+      register: result
+
+    - name: Plugin auth | Check that the module made a change auth plugin
+      ansible.builtin.assert:
+        that:
+          - result is changed
+
+    - name: Plugin auth | Check that the expected plugin type is set
+      ansible.builtin.include_tasks: utils/assert_plugin.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        plugin_type: "{{ test_plugin_type }}"
+
+    - name: Plugin auth | Set same plugint check that no changes are reported
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ test_user_name }}'
+        host: '%'
+        plugin: '{{ test_plugin_type }}'
+        plugin_hash_string: '{{ test_plugin_hash }}'
+        priv: '{{ test_default_priv }}'
+      register: result
+
+    - name: Plugin auth | Check that the module made a change auth plugin
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+
     - name: Plugin auth | Get the MySQL version using the newly created creds
-      mysql_info:
+      community.mysql.mysql_info:
         login_user: '{{ test_user_name }}'
         login_password: '{{ test_plugin_auth_string }}'
         login_host: '{{ mysql_host }}'
@@ -64,12 +144,12 @@
       register: result
 
     - name: Plugin auth | Assert that mysql_info was successful
-      assert:
+      ansible.builtin.assert:
         that:
           - result is succeeded
 
     - name: Plugin auth | Update the user with a different hash
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
         host: '%'
@@ -78,18 +158,18 @@
       register: result
 
     - name: Plugin auth | Check that the module makes the change because the hash changed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
 
-    - include_tasks: utils/assert_user.yml
+    - ansible.builtin.include_tasks: utils/assert_user.yml
       vars:
         user_name: "{{ test_user_name }}"
         user_host: "%"
         priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Getting the MySQL info with the new password should work
-      mysql_info:
+      community.mysql.mysql_info:
         login_user: '{{ test_user_name }}'
         login_password: '{{ test_plugin_new_auth_string }}'
         login_host: '{{ mysql_host }}'
@@ -98,12 +178,12 @@
       register: result
 
     - name: Plugin auth | Assert that mysql_info was successful
-      assert:
+      ansible.builtin.assert:
         that:
           - result is succeeded
 
     # Cleanup
-    - include_tasks: utils/remove_user.yml
+    - ansible.builtin.include_tasks: utils/remove_user.yml
       vars:
         user_name: "{{ test_user_name }}"
 
@@ -112,7 +192,7 @@
     #
 
     - name: Plugin auth | Create user with plugin auth (with hash string)
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
         host: '%'
@@ -122,28 +202,28 @@
       register: result
 
     - name: Plugin auth | Get user information
-      command: "{{ mysql_command }} -e \"SELECT user, host, plugin FROM mysql.user WHERE user = '{{ test_user_name }}' and host = '%'\""
+      ansible.builtin.command: "{{ mysql_command }} -e \"SELECT user, host, plugin FROM mysql.user WHERE user = '{{ test_user_name }}' and host = '%'\""
       register: show_create_user
 
     - name: Plugin auth | Check that the module made a change (with hash string)
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
 
     - name: Plugin auth | Check that the expected plugin type is set (with hash string)
-      assert:
+      ansible.builtin.assert:
         that:
           - "'{{ test_plugin_type }}' in show_create_user.stdout"
       when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-    - include_tasks: utils/assert_user.yml
+    - ansible.builtin.include_tasks: utils/assert_user.yml
       vars:
         user_name: "{{ test_user_name }}"
         user_host: "%"
         priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Get the MySQL version using the newly created creds
-      mysql_info:
+      community.mysql.mysql_info:
         login_user: '{{ test_user_name }}'
         login_password: '{{ test_plugin_auth_string }}'
         login_host: '{{ mysql_host }}'
@@ -152,12 +232,12 @@
       register: result
 
     - name: Plugin auth | Assert that mysql_info was successful
-      assert:
+      ansible.builtin.assert:
         that:
           - result is succeeded
 
     - name: Plugin auth | Update the user with the same hash (no change expected)
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
         host: '%'
@@ -167,19 +247,19 @@
 
     # FIXME: on mariadb 10.2 there's always a change
     - name: Plugin auth | Check that the module doesn't make a change when the same hash is passed in
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
       when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-    - include_tasks: utils/assert_user.yml
+    - ansible.builtin.include_tasks: utils/assert_user.yml
       vars:
         user_name: "{{ test_user_name }}"
         user_host: "%"
         priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Change the user using the same plugin, but switch to the same auth string in plaintext form
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
         host: '%'
@@ -189,12 +269,12 @@
 
     # Expecting a change is currently by design (see comment in source).
     - name: Plugin auth | Check that the module did not change the password
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
 
     - name: Plugin auth | Getting the MySQL info should still work
-      mysql_info:
+      community.mysql.mysql_info:
         login_user: '{{ test_user_name }}'
         login_password: '{{ test_plugin_auth_string }}'
         login_host: '{{ mysql_host }}'
@@ -203,12 +283,12 @@
       register: result
 
     - name: Plugin auth | Assert that mysql_info was successful
-      assert:
+      ansible.builtin.assert:
         that:
           - result is succeeded
 
     # Cleanup
-    - include_tasks: utils/remove_user.yml
+    - ansible.builtin.include_tasks: utils/remove_user.yml
       vars:
         user_name: "{{ test_user_name }}"
 
@@ -217,7 +297,7 @@
     #
 
     - name: Plugin auth | Create user with plugin auth (with auth string)
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
         host: '%'
@@ -227,28 +307,28 @@
       register: result
 
     - name: Plugin auth | Get user information(with auth string)
-      command: "{{ mysql_command }} -e \"SHOW CREATE USER '{{ test_user_name }}'@'%'\""
+      ansible.builtin.command: "{{ mysql_command }} -e \"SHOW CREATE USER '{{ test_user_name }}'@'%'\""
       register: show_create_user
 
     - name: Plugin auth | Check that the module made a change (with auth string)
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
 
     - name: Plugin auth | Check that the expected plugin type is set (with auth string)
-      assert:
+      ansible.builtin.assert:
         that:
           - test_plugin_type in show_create_user.stdout
       when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-    - include_tasks: utils/assert_user.yml
+    - ansible.builtin.include_tasks: utils/assert_user.yml
       vars:
         user_name: "{{ test_user_name }}"
         user_host: "%"
         priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Get the MySQL version using the newly created creds
-      mysql_info:
+      community.mysql.mysql_info:
         login_user: '{{ test_user_name }}'
         login_password: '{{ test_plugin_auth_string }}'
         login_host: '{{ mysql_host }}'
@@ -257,12 +337,12 @@
       register: result
 
     - name: Plugin auth | Assert that mysql_info was successful
-      assert:
+      ansible.builtin.assert:
         that:
           - result is succeeded
 
     - name: Plugin auth | Update the user with the same auth string
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
         host: '%'
@@ -273,18 +353,18 @@
     # This is the current expected behavior because there isn't a reliable way to hash the password in the mysql_user
     # module in order to be able to compare this password with the stored hash. See the source for more info.
     - name: Plugin auth | The module should detect a change even though the password is the same
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
 
-    - include_tasks: utils/assert_user.yml
+    - ansible.builtin.include_tasks: utils/assert_user.yml
       vars:
         user_name: "{{ test_user_name }}"
         user_host: "%"
         priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Change the user using the same plugin, but switch to the same auth string in hash form
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
         host: '%'
@@ -293,12 +373,12 @@
       register: result
 
     - name: Plugin auth | Check that the module did not change the password
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
 
     - name: Plugin auth | Get the MySQL version using the newly created creds
-      mysql_info:
+      community.mysql.mysql_info:
         login_user: '{{ test_user_name }}'
         login_password: '{{ test_plugin_auth_string }}'
         login_host: '{{ mysql_host }}'
@@ -307,12 +387,12 @@
       register: result
 
     - name: Plugin auth | Assert that mysql_info was successful
-      assert:
+      ansible.builtin.assert:
         that:
           - result is succeeded
 
     # Cleanup
-    - include_tasks: utils/remove_user.yml
+    - ansible.builtin.include_tasks: utils/remove_user.yml
       vars:
         user_name: "{{ test_user_name }}"
 
@@ -321,7 +401,7 @@
     #
 
     - name: Plugin auth | Create user with plugin auth (empty auth string)
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
         host: '%'
@@ -330,28 +410,28 @@
       register: result
 
     - name: Plugin auth | Get user information (empty auth string)
-      command: "{{ mysql_command }} -e \"SHOW CREATE USER '{{ test_user_name }}'@'%'\""
+      ansible.builtin.command: "{{ mysql_command }} -e \"SHOW CREATE USER '{{ test_user_name }}'@'%'\""
       register: show_create_user
 
     - name: Plugin auth | Check that the module made a change (empty auth string)
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
 
     - name: Plugin auth | Check that the expected plugin type is set (empty auth string)
-      assert:
+      ansible.builtin.assert:
         that:
           - "'{{ test_plugin_type }}' in show_create_user.stdout"
       when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-    - include_tasks: utils/assert_user.yml
+    - ansible.builtin.include_tasks: utils/assert_user.yml
       vars:
         user_name: "{{ test_user_name }}"
         user_host: "%"
         priv: "{{ test_default_priv_type }}"
 
     - name: Plugin auth | Get the MySQL version using an empty password for the newly created user
-      mysql_info:
+      community.mysql.mysql_info:
         login_user: '{{ test_user_name }}'
         login_password: ''
         login_host: '{{ mysql_host }}'
@@ -361,12 +441,12 @@
       ignore_errors: true
 
     - name: Plugin auth | Assert that mysql_info was successful
-      assert:
+      ansible.builtin.assert:
         that:
           - result is succeeded
 
     - name: Plugin auth | Get the MySQL version using an non-empty password (should fail)
-      mysql_info:
+      community.mysql.mysql_info:
         login_user: '{{ test_user_name }}'
         login_password: 'some_password'
         login_host: '{{ mysql_host }}'
@@ -376,12 +456,12 @@
       ignore_errors: true
 
     - name: Plugin auth | Assert that mysql_info failed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is failed
 
     - name: Plugin auth | Update the user without changing the auth mechanism
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
         host: '%'
@@ -390,12 +470,12 @@
       register: result
 
     - name: Plugin auth | Assert that the user wasn't changed because the auth string is still empty
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
 
     # Cleanup
-    - include_tasks: utils/remove_user.yml
+    - ansible.builtin.include_tasks: utils/remove_user.yml
       vars:
         user_name: "{{ test_user_name }}"
 
@@ -415,7 +495,7 @@
       block:
 
         - name: Plugin auth | Create user with plugin auth (empty auth string)
-          mysql_user:
+          community.mysql.mysql_user:
             <<: *mysql_params
             name: '{{ test_user_name }}'
             plugin: '{{ test_plugin_type }}'
@@ -423,28 +503,28 @@
           register: result
 
         - name: Plugin auth | Get user information (empty auth string)
-          command: "{{ mysql_command }} -e \"SHOW CREATE USER '{{ test_user_name }}'@'localhost'\""
+          ansible.builtin.command: "{{ mysql_command }} -e \"SHOW CREATE USER '{{ test_user_name }}'@'localhost'\""
           register: show_create_user
 
         - name: Plugin auth | Check that the module made a change (empty auth string)
-          assert:
+          ansible.builtin.assert:
             that:
               - result is changed
 
         - name: Plugin auth | Check that the expected plugin type is set (empty auth string)
-          assert:
+          ansible.builtin.assert:
             that:
               - test_plugin_type in show_create_user.stdout
           when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-        - include_tasks: utils/assert_user.yml
+        - ansible.builtin.include_tasks: utils/assert_user.yml
           vars:
             user_name: "{{ test_user_name }}"
             user_host: localhost
             priv: "{{ test_default_priv_type }}"
 
         - name: Plugin auth | Switch user to sha256_password auth plugin
-          mysql_user:
+          community.mysql.mysql_user:
             <<: *mysql_params
             name: '{{ test_user_name }}'
             plugin: sha256_password
@@ -452,28 +532,28 @@
           register: result
 
         - name: Plugin auth | Get user information (sha256_password)
-          command: "{{ mysql_command }} -e \"SHOW CREATE USER '{{ test_user_name }}'@'localhost'\""
+          ansible.builtin.command: "{{ mysql_command }} -e \"SHOW CREATE USER '{{ test_user_name }}'@'localhost'\""
           register: show_create_user
 
         - name: Plugin auth | Check that the module made a change (sha256_password)
-          assert:
+          ansible.builtin.assert:
             that:
               - result is changed
 
         - name: Plugin auth | Check that the expected plugin type is set (sha256_password)
-          assert:
+          ansible.builtin.assert:
             that:
               - "'sha256_password' in show_create_user.stdout"
           when: db_engine == 'mysql' or (db_engine == 'mariadb' and db_version is version('10.3', '>='))
 
-        - include_tasks: utils/assert_user.yml
+        - ansible.builtin.include_tasks: utils/assert_user.yml
           vars:
             user_name: "{{ test_user_name }}"
             user_host: localhost
             priv: "{{ test_default_priv_type }}"
 
         # Cleanup
-        - include_tasks: utils/remove_user.yml
+        - ansible.builtin.include_tasks: utils/remove_user.yml
           vars:
             user_name: "{{ test_user_name }}"
 
@@ -505,7 +585,7 @@
       register: result
       failed_when: result is changed
 
-    - name: cleanup user
+    - name: Cleanup user
       ansible.builtin.include_tasks: utils/remove_user.yml
       vars:
         user_name: "{{ test_user_name }}"

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -563,7 +563,7 @@
         password: "{{ test_plugin_auth_string }}"
         priv: "{{ test_default_priv }}"
 
-    - name: Plugin auth | Check that the expected (previous) plugin type is set
+    - name: Plugin auth | Check that the expected plugin type is set
       ansible.builtin.include_tasks: utils/assert_plugin.yml
       vars:
         user_name: "{{ test_user_name }}"
@@ -584,7 +584,7 @@
       register: result
       failed_when: result is not changed
 
-    - name: Plugin auth | Check that the expected (previous) plugin type is set
+    - name: Plugin auth | Check that the expected plugin type is set (not changed)
       ansible.builtin.include_tasks: utils/assert_plugin.yml
       vars:
         user_name: "{{ test_user_name }}"
@@ -601,7 +601,7 @@
       register: result
       failed_when: result is not changed
 
-    - name: Plugin auth | Check that the expected (previous) plugin type is set
+    - name: Plugin auth | Check that the expected (new) plugin type is set
       ansible.builtin.include_tasks: utils/assert_plugin.yml
       vars:
         user_name: "{{ test_user_name }}"

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -55,85 +55,6 @@
         user_host: "%"
         priv: "{{ test_default_priv_type }}"
 
-    - name: Plugin auth | Change auth user plugin in check mode
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: '{{ test_user_name }}'
-        host: '%'
-        plugin: '{{ test_plugin_type2 }}'
-        plugin_hash_string: '{{ test_plugin_hash }}'
-        priv: '{{ test_default_priv }}'
-      check_mode: true
-      register: result
-
-    - name: Plugin auth | Check that the module reported a change in auth plugin
-      ansible.builtin.assert:
-        that:
-          - result is changed
-
-    - name: Plugin auth | Check that the expected (previous) plugin type is set
-      ansible.builtin.include_tasks: utils/assert_plugin.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-        plugin_type: "{{ test_plugin_type }}"
-
-    - name: Plugin auth | Change user auth plugin
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: '{{ test_user_name }}'
-        host: '%'
-        plugin: '{{ test_plugin_type2 }}'
-        plugin_hash_string: '{{ test_plugin_hash }}'
-        priv: '{{ test_default_priv }}'
-      register: result
-
-    - name: Plugin auth | Check that the module made a change auth plugin
-      ansible.builtin.assert:
-        that:
-          - result is changed
-
-    - name: Plugin auth | Check that the expected plugin type is set
-      ansible.builtin.include_tasks: utils/assert_plugin.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-        plugin_type: "{{ test_plugin_type2 }}"
-
-    - name: Plugin auth | Set main auth plugin again
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: '{{ test_user_name }}'
-        host: '%'
-        plugin: '{{ test_plugin_type }}'
-        plugin_hash_string: '{{ test_plugin_hash }}'
-        priv: '{{ test_default_priv }}'
-      register: result
-
-    - name: Plugin auth | Check that the module made a change auth plugin
-      ansible.builtin.assert:
-        that:
-          - result is changed
-
-    - name: Plugin auth | Check that the expected plugin type is set
-      ansible.builtin.include_tasks: utils/assert_plugin.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-        plugin_type: "{{ test_plugin_type }}"
-
-    - name: Plugin auth | Set same plugin to check that no changes are reported
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: '{{ test_user_name }}'
-        host: '%'
-        plugin: '{{ test_plugin_type }}'
-        plugin_hash_string: '{{ test_plugin_hash }}'
-        priv: '{{ test_default_priv }}'
-      register: result
-
-    - name: Plugin auth | Check that the module made a change auth plugin
-      ansible.builtin.assert:
-        that:
-          - result is not changed
-
     - name: Plugin auth | Get the MySQL version using the newly created creds
       community.mysql.mysql_info:
         login_user: '{{ test_user_name }}'
@@ -624,3 +545,59 @@
         priv: "{{ test_default_priv }}"
       register: result
       failed_when: result is success
+
+    # ============================================================
+    # Test auth plugin change
+    #
+
+    - name: Cleanup user
+      ansible.builtin.include_tasks: utils/remove_user.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+
+    - name: Plugin auth | Create user with mysql_native_password
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: "{{ test_user_name }}"
+        host: "%"
+        plugin: "{{ test_plugin_type }}"
+        password: "{{ test_plugin_auth_string }}"
+        priv: "{{ test_default_priv }}"
+
+    - name: Plugin auth | Connect with user and password
+      ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_auth_string }} -e "SELECT 1"'
+
+    - name: Plugin auth | Change auth user plugin in check mode
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ test_user_name }}'
+        host: '%'
+        plugin: caching_sha2_password
+        plugin_hash_string: '{{ test_plugin_hash }}'
+        priv: '{{ test_default_priv }}'
+      check_mode: true
+      register: result
+      failed_when: result is not changed
+
+    - name: Plugin auth | Check that the expected (previous) plugin type is set
+      ansible.builtin.include_tasks: utils/assert_plugin.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        plugin_type: "{{ caching_sha2_password }}"
+
+    - name: Plugin auth | Change auth user plugin
+      community.mysql.mysql_user:
+        <<: *mysql_params
+        name: '{{ test_user_name }}'
+        host: '%'
+        plugin: caching_sha2_password
+        plugin_hash_string: '{{ test_plugin_hash }}'
+        priv: '{{ test_default_priv }}'
+      register: result
+      failed_when: result is not changed
+
+    - name: Plugin auth | Check that the expected (previous) plugin type is set
+      ansible.builtin.include_tasks: utils/assert_plugin.yml
+      vars:
+        user_name: "{{ test_user_name }}"
+        plugin_type: caching_sha2_password

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -609,7 +609,7 @@
         user_name: "{{ test_user_name }}"
         plugin_type: caching_sha2_password
 
-    - name: Plugin auth | Change user plugin again (should not change)
+    - name: Plugin auth | Change auth user plugin again (should not change)
       community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ test_user_name }}'
@@ -626,3 +626,4 @@
       vars:
         user_name: "{{ test_user_name }}"
         plugin_type: caching_sha2_password
+

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -545,84 +545,84 @@
       register: result
       failed_when: result is success
 
-    # ============================================================
-    # Test auth plugin change
-    #
+    # # ============================================================
+    # # Test auth plugin change
+    # #
 
-    - name: Cleanup user
-      ansible.builtin.include_tasks: utils/remove_user.yml
-      vars:
-        user_name: "{{ test_user_name }}"
+    # - name: Cleanup user
+    #   ansible.builtin.include_tasks: utils/remove_user.yml
+    #   vars:
+    #     user_name: "{{ test_user_name }}"
 
-    - name: Plugin auth | Create user with mysql_native_password
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: "{{ test_user_name }}"
-        host: "%"
-        plugin: "{{ test_plugin_type }}"
-        password: "{{ test_plugin_auth_string }}"
-        priv: "{{ test_default_priv }}"
+    # - name: Plugin auth | Create user with mysql_native_password
+    #   community.mysql.mysql_user:
+    #     <<: *mysql_params
+    #     name: "{{ test_user_name }}"
+    #     host: "%"
+    #     plugin: "{{ test_plugin_type }}"
+    #     password: "{{ test_plugin_auth_string }}"
+    #     priv: "{{ test_default_priv }}"
 
-    - name: Plugin auth | Check that the expected plugin type is set
-      ansible.builtin.include_tasks: utils/assert_plugin.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-        plugin_type: "{{ test_plugin_type }}"
+    # - name: Plugin auth | Check that the expected plugin type is set
+    #   ansible.builtin.include_tasks: utils/assert_plugin.yml
+    #   vars:
+    #     user_name: "{{ test_user_name }}"
+    #     plugin_type: "{{ test_plugin_type }}"
 
-    - name: Plugin auth | Connect with user and password
-      ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_auth_string }} -e "SELECT 1"'
+    # - name: Plugin auth | Connect with user and password
+    #   ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_auth_string }} -e "SELECT 1"'
 
-    - name: Plugin auth | Change auth user plugin in check mode
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: "{{ test_user_name }}"
-        host: '%'
-        plugin: caching_sha2_password
-        plugin_auth_string: "{{ test_plugin_auth_string }}"
-        salt: "{{ test_salt }}"
-        priv: "{{ test_default_priv }}"
-      check_mode: true
-      register: result
-      failed_when: result is not changed
+    # - name: Plugin auth | Change auth user plugin in check mode
+    #   community.mysql.mysql_user:
+    #     <<: *mysql_params
+    #     name: "{{ test_user_name }}"
+    #     host: '%'
+    #     plugin: caching_sha2_password
+    #     plugin_auth_string: "{{ test_plugin_auth_string }}"
+    #     salt: "{{ test_salt }}"
+    #     priv: "{{ test_default_priv }}"
+    #   check_mode: true
+    #   register: result
+    #   failed_when: result is not changed
 
-    - name: Plugin auth | Check that the expected plugin type is set (not changed)
-      ansible.builtin.include_tasks: utils/assert_plugin.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-        plugin_type: "{{ test_plugin_type }}"
+    # - name: Plugin auth | Check that the expected plugin type is set (not changed)
+    #   ansible.builtin.include_tasks: utils/assert_plugin.yml
+    #   vars:
+    #     user_name: "{{ test_user_name }}"
+    #     plugin_type: "{{ test_plugin_type }}"
 
-    - name: Plugin auth | Change auth user plugin
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: "{{ test_user_name }}"
-        host: '%'
-        plugin: caching_sha2_password
-        plugin_auth_string: "{{ test_plugin_auth_string }}"
-        salt: "{{ test_salt }}"
-        priv: "{{ test_default_priv }}"
-      register: result
-      failed_when: result is not changed
+    # - name: Plugin auth | Change auth user plugin
+    #   community.mysql.mysql_user:
+    #     <<: *mysql_params
+    #     name: "{{ test_user_name }}"
+    #     host: '%'
+    #     plugin: caching_sha2_password
+    #     plugin_auth_string: "{{ test_plugin_auth_string }}"
+    #     salt: "{{ test_salt }}"
+    #     priv: "{{ test_default_priv }}"
+    #   register: result
+    #   failed_when: result is not changed
 
-    - name: Plugin auth | Check that the expected (new) plugin type is set
-      ansible.builtin.include_tasks: utils/assert_plugin.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-        plugin_type: caching_sha2_password
+    # - name: Plugin auth | Check that the expected (new) plugin type is set
+    #   ansible.builtin.include_tasks: utils/assert_plugin.yml
+    #   vars:
+    #     user_name: "{{ test_user_name }}"
+    #     plugin_type: caching_sha2_password
 
-    - name: Plugin auth | Change auth user plugin again (should not change)
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: "{{ test_user_name }}"
-        host: '%'
-        plugin: caching_sha2_password
-        plugin_auth_string: "{{ test_plugin_auth_string }}"
-        salt: "{{ test_salt }}"
-        priv: "{{ test_default_priv }}"
-      register: result
-      failed_when: result is changed
+    # - name: Plugin auth | Change auth user plugin again (should not change)
+    #   community.mysql.mysql_user:
+    #     <<: *mysql_params
+    #     name: "{{ test_user_name }}"
+    #     host: '%'
+    #     plugin: caching_sha2_password
+    #     plugin_auth_string: "{{ test_plugin_auth_string }}"
+    #     salt: "{{ test_salt }}"
+    #     priv: "{{ test_default_priv }}"
+    #   register: result
+    #   failed_when: result is changed
 
-    - name: Plugin auth | Check that the expected (not changed) plugin type is set
-      ansible.builtin.include_tasks: utils/assert_plugin.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-        plugin_type: caching_sha2_password
+    # - name: Plugin auth | Check that the expected (not changed) plugin type is set
+    #   ansible.builtin.include_tasks: utils/assert_plugin.yml
+    #   vars:
+    #     user_name: "{{ test_user_name }}"
+    #     plugin_type: caching_sha2_password

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -545,49 +545,11 @@
       register: result
       failed_when: result is success
 
-
-
-
-
     # ============================================================
     # Test auth plugin change
     #
 
-    - name: Cleanup user
-      ansible.builtin.include_tasks: utils/remove_user.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-
-    - name: Plugin auth | Create user with mysql_native_password
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: "{{ test_user_name }}"
-        host: "%"
-        plugin: "{{ test_plugin_type }}"
-        password: "{{ test_plugin_auth_string }}"
-        priv: "{{ test_default_priv }}"
-
-    - name: Plugin auth | Check that the expected plugin type is set
-      ansible.builtin.include_tasks: utils/assert_plugin.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-        plugin_type: "{{ test_plugin_type }}"
-
-    - name: Plugin auth | Connect with user and password
-      ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_auth_string }} -e "SELECT 1"'
-
-    - name: Plugin auth | Change auth user plugin in check mode
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: "{{ test_user_name }}"
-        host: '%'
-        plugin: caching_sha2_password
-        plugin_auth_string: "{{ test_plugin_auth_string }}"
-        salt: "{{ test_salt }}"
-        priv: "{{ test_default_priv }}"
-      check_mode: true
-      register: result
-      failed_when: result is not changed
+    - name: Plugin auth | Test plugin auth switching which doesn't work on pymysql < 0.9
       when:
         - >
           connector_name != 'pymysql'
@@ -595,73 +557,82 @@
             connector_name == 'pymysql'
             and connector_version is version('0.9', '>=')
           )
+      block:
 
-    - name: Plugin auth | Check that the expected plugin type is set (not changed)
-      ansible.builtin.include_tasks: utils/assert_plugin.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-        plugin_type: "{{ test_plugin_type }}"
+        - name: Cleanup user
+          ansible.builtin.include_tasks: utils/remove_user.yml
+          vars:
+            user_name: "{{ test_user_name }}"
 
-    - name: Plugin auth | Change auth user plugin
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: "{{ test_user_name }}"
-        host: '%'
-        plugin: caching_sha2_password
-        plugin_auth_string: "{{ test_plugin_auth_string }}"
-        salt: "{{ test_salt }}"
-        priv: "{{ test_default_priv }}"
-      register: result
-      failed_when: result is not changed
-      when:
-        - >
-          connector_name != 'pymysql'
-          or (
-            connector_name == 'pymysql'
-            and connector_version is version('0.9', '>=')
-          )
+        - name: Plugin auth | Create user with mysql_native_password
+          community.mysql.mysql_user:
+            <<: *mysql_params
+            name: "{{ test_user_name }}"
+            host: "%"
+            plugin: "{{ test_plugin_type }}"
+            password: "{{ test_plugin_auth_string }}"
+            priv: "{{ test_default_priv }}"
 
-    - name: Plugin auth | Check that the expected (new) plugin type is set
-      ansible.builtin.include_tasks: utils/assert_plugin.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-        plugin_type: caching_sha2_password
-      when:
-        - >
-          connector_name != 'pymysql'
-          or (
-            connector_name == 'pymysql'
-            and connector_version is version('0.9', '>=')
-          )
+        - name: Plugin auth | Check that the expected plugin type is set
+          ansible.builtin.include_tasks: utils/assert_plugin.yml
+          vars:
+            user_name: "{{ test_user_name }}"
+            plugin_type: "{{ test_plugin_type }}"
 
-    - name: Plugin auth | Change auth user plugin again (should not change)
-      community.mysql.mysql_user:
-        <<: *mysql_params
-        name: "{{ test_user_name }}"
-        host: '%'
-        plugin: caching_sha2_password
-        plugin_auth_string: "{{ test_plugin_auth_string }}"
-        salt: "{{ test_salt }}"
-        priv: "{{ test_default_priv }}"
-      register: result
-      failed_when: result is changed
-      when:
-        - >
-          connector_name != 'pymysql'
-          or (
-            connector_name == 'pymysql'
-            and connector_version is version('0.9', '>=')
-          )
+        # - name: Plugin auth | Connect with user and password
+        #   ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_auth_string }} -e "SELECT 1"'
 
-    - name: Plugin auth | Check that the expected (not changed) plugin type is set
-      ansible.builtin.include_tasks: utils/assert_plugin.yml
-      vars:
-        user_name: "{{ test_user_name }}"
-        plugin_type: caching_sha2_password
-      when:
-        - >
-          connector_name != 'pymysql'
-          or (
-            connector_name == 'pymysql'
-            and connector_version is version('0.9', '>=')
-          )
+        # - name: Plugin auth | Change auth user plugin in check mode
+        #   community.mysql.mysql_user:
+        #     <<: *mysql_params
+        #     name: "{{ test_user_name }}"
+        #     host: '%'
+        #     plugin: caching_sha2_password
+        #     plugin_auth_string: "{{ test_plugin_auth_string }}"
+        #     salt: "{{ test_salt }}"
+        #     priv: "{{ test_default_priv }}"
+        #   check_mode: true
+        #   register: result
+        #   failed_when: result is not changed
+
+        # - name: Plugin auth | Check that the expected plugin type is set (not changed)
+        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
+        #   vars:
+        #     user_name: "{{ test_user_name }}"
+        #     plugin_type: "{{ test_plugin_type }}"
+
+        # - name: Plugin auth | Change auth user plugin
+        #   community.mysql.mysql_user:
+        #     <<: *mysql_params
+        #     name: "{{ test_user_name }}"
+        #     host: '%'
+        #     plugin: caching_sha2_password
+        #     plugin_auth_string: "{{ test_plugin_auth_string }}"
+        #     salt: "{{ test_salt }}"
+        #     priv: "{{ test_default_priv }}"
+        #   register: result
+        #   failed_when: result is not changed
+
+        # - name: Plugin auth | Check that the expected (new) plugin type is set
+        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
+        #   vars:
+        #     user_name: "{{ test_user_name }}"
+        #     plugin_type: caching_sha2_password
+
+        # - name: Plugin auth | Change auth user plugin again (should not change)
+        #   community.mysql.mysql_user:
+        #     <<: *mysql_params
+        #     name: "{{ test_user_name }}"
+        #     host: '%'
+        #     plugin: caching_sha2_password
+        #     plugin_auth_string: "{{ test_plugin_auth_string }}"
+        #     salt: "{{ test_salt }}"
+        #     priv: "{{ test_default_priv }}"
+        #   register: result
+        #   failed_when: result is changed
+
+        # - name: Plugin auth | Check that the expected (not changed) plugin type is set
+        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
+        #   vars:
+        #     user_name: "{{ test_user_name }}"
+        #     plugin_type: caching_sha2_password

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -644,14 +644,14 @@
             name: "{{ test_user_name }}"
             host: '%'
             plugin: caching_sha2_password
-            plugin_auth_string: newpass
+            plugin_auth_string: "{{ test_plugin_new_auth_string }}"
             salt: "{{ test_salt }}"
             priv: "{{ test_default_priv }}"
           register: result
           failed_when: result is not changed
 
         - name: Plugin auth | Connect with user and password
-          ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -pnewpass -e "SELECT 1"'
+          ansible.builtin.command: '{{ mysql_command }} -u {{ test_user_name }} -p{{ test_plugin_new_auth_string }} -e "SELECT 1"'
           changed_when: false
 
         - name: Plugin auth | Check that the expected plugin type is set after change

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -595,44 +595,44 @@
           register: result
           failed_when: result is not changed
 
-        # - name: Plugin auth | Check that the expected plugin type is set (not changed)
-        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
-        #   vars:
-        #     user_name: "{{ test_user_name }}"
-        #     plugin_type: "{{ test_plugin_type }}"
+        - name: Plugin auth | Check that the expected plugin type is set (not changed)
+          ansible.builtin.include_tasks: utils/assert_plugin.yml
+          vars:
+            user_name: "{{ test_user_name }}"
+            plugin_type: "{{ test_plugin_type }}"
 
-        # - name: Plugin auth | Change auth user plugin
-        #   community.mysql.mysql_user:
-        #     <<: *mysql_params
-        #     name: "{{ test_user_name }}"
-        #     host: '%'
-        #     plugin: caching_sha2_password
-        #     plugin_auth_string: "{{ test_plugin_auth_string }}"
-        #     salt: "{{ test_salt }}"
-        #     priv: "{{ test_default_priv }}"
-        #   register: result
-        #   failed_when: result is not changed
+        - name: Plugin auth | Change auth user plugin
+          community.mysql.mysql_user:
+            <<: *mysql_params
+            name: "{{ test_user_name }}"
+            host: '%'
+            plugin: caching_sha2_password
+            plugin_auth_string: "{{ test_plugin_auth_string }}"
+            salt: "{{ test_salt }}"
+            priv: "{{ test_default_priv }}"
+          register: result
+          failed_when: result is not changed
 
-        # - name: Plugin auth | Check that the expected (new) plugin type is set
-        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
-        #   vars:
-        #     user_name: "{{ test_user_name }}"
-        #     plugin_type: caching_sha2_password
+        - name: Plugin auth | Check that the expected (new) plugin type is set
+          ansible.builtin.include_tasks: utils/assert_plugin.yml
+          vars:
+            user_name: "{{ test_user_name }}"
+            plugin_type: caching_sha2_password
 
-        # - name: Plugin auth | Change auth user plugin again (should not change)
-        #   community.mysql.mysql_user:
-        #     <<: *mysql_params
-        #     name: "{{ test_user_name }}"
-        #     host: '%'
-        #     plugin: caching_sha2_password
-        #     plugin_auth_string: "{{ test_plugin_auth_string }}"
-        #     salt: "{{ test_salt }}"
-        #     priv: "{{ test_default_priv }}"
-        #   register: result
-        #   failed_when: result is changed
+        - name: Plugin auth | Change auth user plugin again (should not change)
+          community.mysql.mysql_user:
+            <<: *mysql_params
+            name: "{{ test_user_name }}"
+            host: '%'
+            plugin: caching_sha2_password
+            plugin_auth_string: "{{ test_plugin_auth_string }}"
+            salt: "{{ test_salt }}"
+            priv: "{{ test_default_priv }}"
+          register: result
+          failed_when: result is changed
 
-        # - name: Plugin auth | Check that the expected (not changed) plugin type is set
-        #   ansible.builtin.include_tasks: utils/assert_plugin.yml
-        #   vars:
-        #     user_name: "{{ test_user_name }}"
-        #     plugin_type: caching_sha2_password
+        - name: Plugin auth | Check that the expected (not changed) plugin type is set
+          ansible.builtin.include_tasks: utils/assert_plugin.yml
+          vars:
+            user_name: "{{ test_user_name }}"
+            plugin_type: caching_sha2_password

--- a/tests/integration/targets/test_mysql_user/tasks/utils/assert_plugin.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/utils/assert_plugin.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Utils | Assert plugin | Query for user {{ user_name }}
+  ansible.builtin.command: "{{ mysql_command }} -e \"SELECT {{ plugin_type }} FROM mysql.user where user='{{ user_name }}'\""
+  register: result
+
+- name: Utils | Assert plugin | Assert plugin is correct
+  ansible.builtinassert:
+    that:
+      - plugin_type in result.stdout

--- a/tests/integration/targets/test_mysql_user/tasks/utils/assert_plugin.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/utils/assert_plugin.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Utils | Assert plugin | Query for user {{ user_name }}
-  ansible.builtin.command: "{{ mysql_command }} -e \"SELECT {{ plugin_type }} FROM mysql.user where user='{{ user_name }}'\""
+  ansible.builtin.command: "{{ mysql_command }} -e \"SELECT plugin FROM mysql.user where user='{{ user_name }}'\""
   register: result
 
 - name: Utils | Assert plugin | Assert plugin is correct

--- a/tests/integration/targets/test_mysql_user/tasks/utils/assert_plugin.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/utils/assert_plugin.yml
@@ -3,7 +3,7 @@
 - name: Utils | Assert plugin | Query for user {{ user_name }}
   ansible.builtin.command: "{{ mysql_command }} -e \"SELECT plugin FROM mysql.user where user='{{ user_name }}'\""
   register: result
-  changed_when: never
+  changed_when: False
 
 - name: Utils | Assert plugin | Assert plugin is correct
   ansible.builtin.assert:

--- a/tests/integration/targets/test_mysql_user/tasks/utils/assert_plugin.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/utils/assert_plugin.yml
@@ -3,6 +3,7 @@
 - name: Utils | Assert plugin | Query for user {{ user_name }}
   ansible.builtin.command: "{{ mysql_command }} -e \"SELECT plugin FROM mysql.user where user='{{ user_name }}'\""
   register: result
+  changed_when: never
 
 - name: Utils | Assert plugin | Assert plugin is correct
   ansible.builtin.assert:

--- a/tests/integration/targets/test_mysql_user/tasks/utils/assert_plugin.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/utils/assert_plugin.yml
@@ -5,6 +5,6 @@
   register: result
 
 - name: Utils | Assert plugin | Assert plugin is correct
-  ansible.builtinassert:
+  ansible.builtin.assert:
     that:
       - plugin_type in result.stdout


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The user module makes changes to the user's [plugin](https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_user_module.html#parameter-plugin) parameter when [plugin_auth_string](https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_user_module.html#parameter-plugin_auth_string) and [plugin_hash_string](https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_user_module.html#parameter-plugin_hash_string)  are not defined and is running in check mode.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user_module
