### PR TITLE
chore[CI]: fix conditional statements should not include jinja 2 templating

### DIFF
--- a/tests/integration/targets/setup_controller/tasks/verify.yml
+++ b/tests/integration/targets/setup_controller/tasks/verify.yml
@@ -19,8 +19,11 @@
     - name: Assert that test container runs the expected MySQL/MariaDB version
       assert:
         that:
-          - "'{{ primary_info.version.major }}.{{ primary_info.version.minor }}\
-          .{{ primary_info.version.release }}' == '{{ db_version }}'"
+          - registred_db_version == db_version
+      vars:
+        registred_db_version:
+          "{{ primary_info.version.major }}.{{ primary_info.version.minor }}\
+          .{{ primary_info.version.release }}"
 
     - name: Assert that mysql_info module used the expected version of pymysql
       assert:
@@ -52,8 +55,9 @@
     - name: Assert that we run the expected ansible version
       assert:
         that:
-          - >
-            "{{ ansible_version.major }}.{{ ansible_version.minor }}"
-            is version(test_ansible_version, '==')
+          - ansible_running_version == test_ansible_version
+      vars:
+        ansible_running_version:
+          "{{ ansible_version.major }}.{{ ansible_version.minor }}"
       when:
         - test_ansible_version != 'devel'  # Devel will change overtime

--- a/tests/integration/targets/test_mysql_db/tasks/state_dump_import.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/state_dump_import.yml
@@ -339,7 +339,7 @@
   assert:
     that:
       - result is changed
-      - "result.db =='{{ db_name }}'"
+      - result.db == db_name
 
 # - name: Dump and Import | Assert database was backed up successfully
 #   command: "file {{ db_file_name }}"

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_channel.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_channel.yml
@@ -34,8 +34,14 @@
 
     - assert:
         that:
-        - result is changed
-        - result.queries == ["CHANGE MASTER TO MASTER_HOST='{{ mysql_host }}',MASTER_USER='{{ replication_user }}',MASTER_PASSWORD='********',MASTER_PORT={{ mysql_primary_port }},MASTER_LOG_FILE='{{ mysql_primary_status.File }}',MASTER_LOG_POS={{ mysql_primary_status.Position }} FOR CHANNEL '{{ test_channel }}'"]
+          - result is changed
+          - result.queries == result_query
+      vars:
+        result_query: ["CHANGE MASTER TO MASTER_HOST='{{ mysql_host }}',\
+          MASTER_USER='{{ replication_user }}',MASTER_PASSWORD='********',\
+          MASTER_PORT={{ mysql_primary_port }},MASTER_LOG_FILE=\
+          '{{ mysql_primary_status.File }}',MASTER_LOG_POS=\
+          {{ mysql_primary_status.Position }} FOR CHANNEL '{{ test_channel }}'"]
 
     # Test startreplica mode:
     - name: Start replica with channel
@@ -48,8 +54,11 @@
 
     - assert:
         that:
-        - result is changed
-        - result.queries == ["START SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["START REPLICA FOR CHANNEL '{{ test_channel }}'"]
+          - result is changed
+          - result.queries == result_query or result_query2
+      vars:
+        result_query: ["START SLAVE FOR CHANNEL '{{ test_channel }}'"]
+        result_query2: ["START REPLICA FOR CHANNEL '{{ test_channel }}'"]
 
     # Test getreplica mode:
     - name: Get standby status with channel
@@ -62,26 +71,34 @@
 
     - assert:
         that:
-        - replica_status.Is_Replica == true
-        - replica_status.Master_Host == '{{ mysql_host }}'
-        - replica_status.Exec_Master_Log_Pos == mysql_primary_status.Position
-        - replica_status.Master_Port == {{ mysql_primary_port }}
-        - replica_status.Last_IO_Errno == 0
-        - replica_status.Last_IO_Error == ''
-        - replica_status.Channel_Name == '{{ test_channel }}'
-        - replica_status is not changed
+          - replica_status.Is_Replica is truthy(convert_bool=True)
+          - replica_status.Master_Host == mysql_host_value
+          - replica_status.Exec_Master_Log_Pos == mysql_primary_status.Position
+          - replica_status.Master_Port == mysql_primary_port_value
+          - replica_status.Last_IO_Errno == 0
+          - replica_status.Last_IO_Error == ''
+          - replica_status.Channel_Name == test_channel_value
+          - replica_status is not changed
+      vars:
+        mysql_host_value: '{{ mysql_host }}'
+        mysql_primary_port_value: '{{ mysql_primary_port }}'
+        test_channel_value: '{{ test_channel }}'
       when: mysql8022_and_higher == false
 
     - assert:
         that:
-        - replica_status.Is_Replica == true
-        - replica_status.Source_Host == '{{ mysql_host }}'
-        - replica_status.Exec_Source_Log_Pos == mysql_primary_status.Position
-        - replica_status.Source_Port == {{ mysql_primary_port }}
-        - replica_status.Last_IO_Errno == 0
-        - replica_status.Last_IO_Error == ''
-        - replica_status.Channel_Name == '{{ test_channel }}'
-        - replica_status is not changed
+          - replica_status.Is_Replica is truthy(convert_bool=True)
+          - replica_status.Source_Host == mysql_host_value
+          - replica_status.Exec_Source_Log_Pos == mysql_primary_status.Position
+          - replica_status.Source_Port == mysql_primary_port_value
+          - replica_status.Last_IO_Errno == 0
+          - replica_status.Last_IO_Error == ''
+          - replica_status.Channel_Name == test_channel_value
+          - replica_status is not changed
+      vars:
+        mysql_host_value: '{{ mysql_host }}'
+        mysql_primary_port_value: '{{ mysql_primary_port }}'
+        test_channel_value: '{{ test_channel }}'
       when: mysql8022_and_higher == true
 
 
@@ -96,8 +113,11 @@
 
     - assert:
         that:
-        - result is changed
-        - result.queries == ["STOP SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["STOP REPLICA FOR CHANNEL '{{ test_channel }}'"]
+          - result is changed
+          - result.queries == result_query or result.queries == result_query2
+      vars:
+        result_query: ["STOP SLAVE FOR CHANNEL '{{ test_channel }}'"]
+        result_query2: ["STOP REPLICA FOR CHANNEL '{{ test_channel }}'"]
 
     # Test reset
     - name: Reset replica with channel
@@ -110,8 +130,11 @@
 
     - assert:
         that:
-        - result is changed
-        - result.queries == ["RESET SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["RESET REPLICA FOR CHANNEL '{{ test_channel }}'"]
+          - result is changed
+          - result.queries == result_query or result.queries == result_query2
+      vars:
+        result_query: ["RESET SLAVE FOR CHANNEL '{{ test_channel }}'"]
+        result_query2: ["RESET REPLICA FOR CHANNEL '{{ test_channel }}'"]
 
     # Test reset all
     - name: Reset replica all with channel
@@ -124,5 +147,8 @@
 
     - assert:
         that:
-        - result is changed
-        - result.queries == ["RESET SLAVE ALL FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["RESET REPLICA ALL FOR CHANNEL '{{ test_channel }}'"]
+          - result is changed
+          - result.queries == result_query or result.queries == result_query2
+      vars:
+        result_query: ["RESET SLAVE ALL FOR CHANNEL '{{ test_channel }}'"]
+        result_query2: ["RESET REPLICA ALL FOR CHANNEL '{{ test_channel }}'"]

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -158,7 +158,13 @@
       assert:
         that:
           - result is changed
-          - result.queries == ["CHANGE MASTER TO MASTER_HOST='{{ mysql_host }}',MASTER_USER='{{ replication_user }}',MASTER_PASSWORD='********',MASTER_PORT={{ mysql_primary_port }},MASTER_LOG_FILE='{{ mysql_primary_status.File }}',MASTER_LOG_POS={{ mysql_primary_status.Position }},MASTER_SSL=0,MASTER_SSL_CA=''"]
+          - result.queries == expected_queries
+      vars:
+        expected_queries: ["CHANGE MASTER TO MASTER_HOST='{{ mysql_host }}',\
+          MASTER_USER='{{ replication_user }}',MASTER_PASSWORD='********',\
+          MASTER_PORT={{ mysql_primary_port }},MASTER_LOG_FILE=\
+          '{{ mysql_primary_status.File }}',MASTER_LOG_POS=\
+          {{ mysql_primary_status.Position }},MASTER_SSL=0,MASTER_SSL_CA=''"]
 
     # Test startreplica mode:
     - name: Start replica
@@ -185,26 +191,32 @@
     - name: Assert that getreplica returns expected values for MySQL older than 8.0.22 and Mariadb
       assert:
         that:
-          - replica_status.Is_Replica == true
-          - replica_status.Master_Host == '{{ mysql_host }}'
+          - replica_status.Is_Replica is truthy(convert_bool=True)
+          - replica_status.Master_Host == mysql_host_value
           - replica_status.Exec_Master_Log_Pos == mysql_primary_status.Position
-          - replica_status.Master_Port == {{ mysql_primary_port }}
+          - replica_status.Master_Port == mysql_primary_port_value
           - replica_status.Last_IO_Errno == 0
           - replica_status.Last_IO_Error == ''
           - replica_status is not changed
-      when: mysql8022_and_higher == false
+      vars:
+        mysql_host_value: "{{ mysql_host }}"
+        mysql_primary_port_value: "{{ mysql_primary_port }}"
+      when: mysql8022_and_higher is falsy(convert_bool=True)
 
     - name: Assert that getreplica returns expected values for MySQL newer than 8.0.22
       assert:
         that:
-          - replica_status.Is_Replica == true
-          - replica_status.Source_Host == '{{ mysql_host }}'
+          - replica_status.Is_Replica is truthy(convert_bool=True)
+          - replica_status.Source_Host == mysql_host_value
           - replica_status.Exec_Source_Log_Pos == mysql_primary_status.Position
-          - replica_status.Source_Port == {{ mysql_primary_port }}
+          - replica_status.Source_Port == mysql_primary_port_value
           - replica_status.Last_IO_Errno == 0
           - replica_status.Last_IO_Error == ''
           - replica_status is not changed
-      when: mysql8022_and_higher == true
+      vars:
+        mysql_host_value: "{{ mysql_host }}"
+        mysql_primary_port_value: "{{ mysql_primary_port }}"
+      when: mysql8022_and_higher is truthy(convert_bool=True)
 
     # Create test table and add data to it:
     - name: Create test table

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -117,8 +117,8 @@
     - name: Assert grant access for user1 on multiple database
       assert:
         that:
-          - "'{{ item }}' in result.stdout"
-      with_items: "{{ db_names }}"
+          - item in result.stdout
+      loop: "{{ db_names }}"
 
     - name: Show grants access for user2 on multiple database
       command: "{{ mysql_command }} -e \"SHOW GRANTS FOR '{{ user_name_2 }}'@'localhost'\""
@@ -127,8 +127,8 @@
     - name: Assert grant access for user2 on multiple database
       assert:
         that:
-          - "'{{ item }}' in result.stdout"
-      with_items: "{{db_names}}"
+          - item in result.stdout
+      loop: "{{db_names}}"
 
     - include_tasks: utils/remove_user.yml
       vars:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
2 days ago, our integration tests for plugins failed with all Ansible versions except devel. We can found  the following kind of errors:

```yml
TASK [setup_controller : Assert that test container runs the expected MySQL/MariaDB version] ***
task path: /root/ansible_collections/community/mysql/tests/output/.tmp/integration/test_mysql_variables-z1orxk82-ÅÑŚÌβŁÈ/tests/integration/targets/setup_controller/tasks/verify.yml:19
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: '{{ primary_info.version.major }}.{{
primary_info.version.minor }}.{{ primary_info.version.release }}' == '{{
db_version }}'
fatal: [testhost]: FAILED! => {
    "msg": "The conditional check ''{{ primary_info.version.major }}.{{ primary_info.version.minor }}.{{ primary_info.version.release }}' == '{{ db_version }}'' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated."
}
```

This is due to this breaking change in Ansible-core: https://github.com/ansible/ansible/blob/v2.14.12rc1/changelogs/CHANGELOG-v2.14.rst#breaking-changes--porting-guide

This PR address this by removing all the jinja templating from the assertions. Thanks to @tompal3 for your work as most of the fixes comes from you.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
CI integrations

