### PR TITLE
Using `show all slaves status` when using MariaDB to be consistent with MySQL

### DIFF
--- a/changelogs/fragments/602-show-all-slaves-status.yaml
+++ b/changelogs/fragments/602-show-all-slaves-status.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - slave_status - The mysql_info returns an empty list for slave_status when using MariaDB with multiple named replication channels/sources. Fix now returns all replication channels/sources on MariaDB by running `SHOW ALL SLAVES STATUS` when the server is MariaDB (https://github.com/ansible-collections/community.mysql/issues/603).
+  - mysql_info - The `slave_status` filter was returning an empty list on MariaDB with multiple replication channels. It now returns all channels by running `SHOW ALL SLAVES STATUS` for MariaDB servers. (https://github.com/ansible-collections/community.mysql/issues/603).

--- a/changelogs/fragments/602-show-all-slaves-status.yaml
+++ b/changelogs/fragments/602-show-all-slaves-status.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - slave_status - The mysql_info returns an empty list for slave_status when using MariaDB with multiple named replication channels/sources. Fix now returns all replication channels/sources on MariaDB by running `SHOW ALL SLAVES STATUS` when the server is MariaDB (https://github.com/ansible-collections/community.mysql/issues/603).

--- a/changelogs/fragments/602-show-all-slaves-status.yaml
+++ b/changelogs/fragments/602-show-all-slaves-status.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - mysql_info - The `slave_status` filter was returning an empty list on MariaDB with multiple replication channels. It now returns all channels by running `SHOW ALL SLAVES STATUS` for MariaDB servers. (https://github.com/ansible-collections/community.mysql/issues/603).
+  - mysql_info - the ``slave_status`` filter was returning an empty list on MariaDB with multiple replication channels. It now returns all channels by running ``SHOW ALL SLAVES STATUS`` for MariaDB servers (https://github.com/ansible-collections/community.mysql/issues/603).

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -206,11 +206,13 @@ def get_server_version(cursor):
 
     return version_str
 
+
 def get_server_implementation(cursor):
     if 'mariadb' in get_server_version(cursor).lower():
         return "mariadb"
     else:
         return "mysql"
+
 
 def is_mariadb(implementation):
     if implementation == "mariadb":
@@ -223,6 +225,7 @@ def is_mysql(implementation):
         return True
     else:
         return False
+
 
 def set_session_vars(module, cursor, session_vars):
     """Set session vars."""

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -214,20 +214,6 @@ def get_server_implementation(cursor):
         return "mysql"
 
 
-def is_mariadb(implementation):
-    if implementation == "mariadb":
-        return True
-    else:
-        return False
-
-
-def is_mysql(implementation):
-    if implementation == "mysql":
-        return True
-    else:
-        return False
-
-
 def set_session_vars(module, cursor, session_vars):
     """Set session vars."""
     for var, value in session_vars.items():

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -206,6 +206,23 @@ def get_server_version(cursor):
 
     return version_str
 
+def get_server_implementation(cursor):
+    if 'mariadb' in get_server_version(cursor).lower():
+        return "mariadb"
+    else:
+        return "mysql"
+
+def is_mariadb(implementation):
+    if implementation == "mariadb":
+        return True
+    else:
+        return False
+
+def is_mysql(implementation):
+    if implementation == "mysql":
+        return True
+    else:
+        return False
 
 def set_session_vars(module, cursor, session_vars):
     """Set session vars."""

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -220,6 +220,7 @@ def is_mariadb(implementation):
     else:
         return False
 
+
 def is_mysql(implementation):
     if implementation == "mysql":
         return True

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -756,7 +756,7 @@ def main():
         module.fail_json(msg)
 
     cursor.execute("SELECT VERSION()")
-    if 'mariadb' in cursor.fetchone()[0].lower():
+    if 'mariadb' in cursor.fetchone()["VERSION()"].lower():
         server_implementation = "mariadb"
     else:
         server_implementation = "mysql"

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -294,7 +294,6 @@ from ansible_collections.community.mysql.plugins.module_utils.mysql import (
     get_connector_name,
     get_connector_version,
     get_server_implementation,
-    is_mariadb,
 )
 
 from ansible_collections.community.mysql.plugins.module_utils.user import (
@@ -501,7 +500,7 @@ class MySQL_Info(object):
 
     def __get_slave_status(self):
         """Get slave status if the instance is a slave."""
-        if is_mariadb(self.server_implementation):
+        if self.server_implementation == "mariadb":
             res = self.__exec_sql('SHOW ALL SLAVES STATUS')
         else:
             res = self.__exec_sql('SHOW SLAVE STATUS')

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -511,9 +511,9 @@ class MySQL_Info(object):
 
     def __get_slave_status(self):
         """Get slave status if the instance is a slave."""
-        if(self.is_mariadb()):
+        if self.is_mariadb():
             res = self.__exec_sql('SHOW ALL SLAVES STATUS')
-        else:    
+        else:
             res = self.__exec_sql('SHOW SLAVE STATUS')
         if res:
             for line in res:
@@ -757,9 +757,9 @@ def main():
 
     cursor.execute("SELECT VERSION()")
     if 'mariadb' in cursor.fetchone()[0].lower():
-        server_implementation="mariadb"
+        server_implementation = "mariadb"
     else:
-        server_implementation="mysql"
+        server_implementation = "mysql"
 
     ###############################
     # Create object and do main job

--- a/tests/unit/plugins/module_utils/test_mysql.py
+++ b/tests/unit/plugins/module_utils/test_mysql.py
@@ -45,12 +45,12 @@ def test_is_mysql():
     """
     Test that server is_mysql return expect results
     """
-    assert is_mysql("mysql") == True
-    assert is_mysql("mariadb") == False
+    assert is_mysql("mysql") is True
+    assert is_mysql("mariadb") is False
 
 def test_is_mariadb():
     """
     Test that server is_mariadb return expect results
     """
-    assert is_mariadb("mariadb") == True
-    assert is_mariadb("mysql") == False
+    assert is_mariadb("mariadb") is True
+    assert is_mariadb("mysql") is False

--- a/tests/unit/plugins/module_utils/test_mysql.py
+++ b/tests/unit/plugins/module_utils/test_mysql.py
@@ -1,9 +1,10 @@
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 import pytest
 
-from ansible_collections.community.mysql.plugins.module_utils.mysql import get_server_version
+from ansible_collections.community.mysql.plugins.module_utils.mysql import get_server_version, get_server_implementation, is_mariadb, is_mysql
 from ..utils import dummy_cursor_class
 
 
@@ -22,3 +23,34 @@ def test_get_server_version(cursor_return_version, cursor_return_type):
     """
     cursor = dummy_cursor_class(cursor_return_version, cursor_return_type)
     assert get_server_version(cursor) == cursor_return_version
+
+@pytest.mark.parametrize(
+    'cursor_return_version,cursor_return_type,server_implementation',
+    [
+        ('5.7.0-mysql', 'dict', 'mysql'),
+        ('8.0.0-mysql', 'list', 'mysql'),
+        ('10.5.0-mariadb', 'dict', 'mariadb'),
+        ('10.5.1-mariadb', 'list', 'mariadb'),
+    ]
+)
+def test_get_server_implamentation(cursor_return_version, cursor_return_type, server_implementation):
+    """
+    Test that server implementation are handled properly by get_server_implementation() whether the server version returned as a list or dict.
+    """
+    cursor = dummy_cursor_class(cursor_return_version, cursor_return_type)
+
+    assert get_server_implementation(cursor) == server_implementation
+
+def test_is_mysql():
+    """
+    Test that server is_mysql return expect results
+    """
+    assert is_mysql("mysql") == True
+    assert is_mysql("mariadb") == False
+
+def test_is_mariadb():
+    """
+    Test that server is_mariadb return expect results
+    """
+    assert is_mariadb("mariadb") == True
+    assert is_mariadb("mysql") == False

--- a/tests/unit/plugins/module_utils/test_mysql.py
+++ b/tests/unit/plugins/module_utils/test_mysql.py
@@ -24,6 +24,7 @@ def test_get_server_version(cursor_return_version, cursor_return_type):
     cursor = dummy_cursor_class(cursor_return_version, cursor_return_type)
     assert get_server_version(cursor) == cursor_return_version
 
+
 @pytest.mark.parametrize(
     'cursor_return_version,cursor_return_type,server_implementation',
     [
@@ -41,12 +42,14 @@ def test_get_server_implamentation(cursor_return_version, cursor_return_type, se
 
     assert get_server_implementation(cursor) == server_implementation
 
+
 def test_is_mysql():
     """
     Test that server is_mysql return expect results
     """
     assert is_mysql("mysql") is True
     assert is_mysql("mariadb") is False
+
 
 def test_is_mariadb():
     """

--- a/tests/unit/plugins/module_utils/test_mysql.py
+++ b/tests/unit/plugins/module_utils/test_mysql.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 
 import pytest
 
-from ansible_collections.community.mysql.plugins.module_utils.mysql import get_server_version, get_server_implementation, is_mariadb, is_mysql
+from ansible_collections.community.mysql.plugins.module_utils.mysql import get_server_version, get_server_implementation
 from ..utils import dummy_cursor_class
 
 
@@ -41,19 +41,3 @@ def test_get_server_implamentation(cursor_return_version, cursor_return_type, se
     cursor = dummy_cursor_class(cursor_return_version, cursor_return_type)
 
     assert get_server_implementation(cursor) == server_implementation
-
-
-def test_is_mysql():
-    """
-    Test that server is_mysql return expect results
-    """
-    assert is_mysql("mysql") is True
-    assert is_mysql("mariadb") is False
-
-
-def test_is_mariadb():
-    """
-    Test that server is_mariadb return expect results
-    """
-    assert is_mariadb("mariadb") is True
-    assert is_mariadb("mysql") is False

--- a/tests/unit/plugins/modules/test_mysql_info.py
+++ b/tests/unit/plugins/modules/test_mysql_info.py
@@ -14,15 +14,15 @@ from ansible_collections.community.mysql.plugins.modules.mysql_info import MySQL
 
 
 @pytest.mark.parametrize(
-    'suffix,cursor_output',
+    'suffix,cursor_output,server_implementation',
     [
-        ('mysql', '5.5.1-mysql'),
-        ('log', '5.7.31-log'),
-        ('mariadb', '10.5.0-mariadb'),
-        ('', '8.0.22'),
+        ('mysql', '5.5.1-mysql','mysql'),
+        ('log', '5.7.31-log','mysql'),
+        ('mariadb', '10.5.0-mariadb','mariadb'),
+        ('', '8.0.22','mysql'),
     ]
 )
-def test_get_info_suffix(suffix, cursor_output):
+def test_get_info_suffix(suffix, cursor_output, server_implementation):
     def __cursor_return_value(input_parameter):
         if input_parameter == "SHOW GLOBAL VARIABLES":
             cursor.fetchall.return_value = [{"Variable_name": "version", "Value": cursor_output}]
@@ -32,6 +32,6 @@ def test_get_info_suffix(suffix, cursor_output):
     cursor = MagicMock()
     cursor.execute.side_effect = __cursor_return_value
 
-    info = MySQL_Info(MagicMock(), cursor)
+    info = MySQL_Info(MagicMock(), cursor, server_implementation)
 
     assert info.get_info([], [], False)['version']['suffix'] == suffix

--- a/tests/unit/plugins/modules/test_mysql_info.py
+++ b/tests/unit/plugins/modules/test_mysql_info.py
@@ -36,16 +36,32 @@ def test_get_info_suffix(suffix, cursor_output, server_implementation):
 
     assert info.get_info([], [], False)['version']['suffix'] == suffix
 
+
+@pytest.mark.parametrize(
+    'server_implementation',
+    [
+        ('mysql'),
+        ('mariadb'),
+    ]
+)
 def test_is_mariadb(server_implementation):
     cursor = MagicMock()
 
     info = MySQL_Info(MagicMock(), cursor, server_implementation)
 
-    assert info.is_mariadb() == ( server_implementation == "mariadb" )
+    assert info.is_mariadb() == (server_implementation == "mariadb")
 
+
+@pytest.mark.parametrize(
+    'server_implementation',
+    [
+        ('mysql'),
+        ('mariadb'),
+    ]
+)
 def test_is_mysql(server_implementation):
     cursor = MagicMock()
 
     info = MySQL_Info(MagicMock(), cursor, server_implementation)
 
-    assert info.is_mysql() == ( server_implementation == "mysql" )
+    assert info.is_mysql() == (server_implementation == "mysql")

--- a/tests/unit/plugins/modules/test_mysql_info.py
+++ b/tests/unit/plugins/modules/test_mysql_info.py
@@ -16,10 +16,10 @@ from ansible_collections.community.mysql.plugins.modules.mysql_info import MySQL
 @pytest.mark.parametrize(
     'suffix,cursor_output,server_implementation',
     [
-        ('mysql', '5.5.1-mysql','mysql'),
-        ('log', '5.7.31-log','mysql'),
-        ('mariadb', '10.5.0-mariadb','mariadb'),
-        ('', '8.0.22','mysql'),
+        ('mysql', '5.5.1-mysql', 'mysql'),
+        ('log', '5.7.31-log', 'mysql'),
+        ('mariadb', '10.5.0-mariadb', 'mariadb'),
+        ('', '8.0.22', 'mysql'),
     ]
 )
 def test_get_info_suffix(suffix, cursor_output, server_implementation):

--- a/tests/unit/plugins/modules/test_mysql_info.py
+++ b/tests/unit/plugins/modules/test_mysql_info.py
@@ -35,33 +35,3 @@ def test_get_info_suffix(suffix, cursor_output, server_implementation):
     info = MySQL_Info(MagicMock(), cursor, server_implementation)
 
     assert info.get_info([], [], False)['version']['suffix'] == suffix
-
-
-@pytest.mark.parametrize(
-    'server_implementation',
-    [
-        ('mysql'),
-        ('mariadb'),
-    ]
-)
-def test_is_mariadb(server_implementation):
-    cursor = MagicMock()
-
-    info = MySQL_Info(MagicMock(), cursor, server_implementation)
-
-    assert info.is_mariadb() == (server_implementation == "mariadb")
-
-
-@pytest.mark.parametrize(
-    'server_implementation',
-    [
-        ('mysql'),
-        ('mariadb'),
-    ]
-)
-def test_is_mysql(server_implementation):
-    cursor = MagicMock()
-
-    info = MySQL_Info(MagicMock(), cursor, server_implementation)
-
-    assert info.is_mysql() == (server_implementation == "mysql")

--- a/tests/unit/plugins/modules/test_mysql_info.py
+++ b/tests/unit/plugins/modules/test_mysql_info.py
@@ -35,3 +35,17 @@ def test_get_info_suffix(suffix, cursor_output, server_implementation):
     info = MySQL_Info(MagicMock(), cursor, server_implementation)
 
     assert info.get_info([], [], False)['version']['suffix'] == suffix
+
+def test_is_mariadb(server_implementation):
+    cursor = MagicMock()
+
+    info = MySQL_Info(MagicMock(), cursor, server_implementation)
+
+    assert info.is_mariadb() == ( server_implementation == "mariadb" )
+
+def test_is_mysql(server_implementation):
+    cursor = MagicMock()
+
+    info = MySQL_Info(MagicMock(), cursor, server_implementation)
+
+    assert info.is_mysql() == ( server_implementation == "mysql" )


### PR DESCRIPTION
##### SUMMARY
Using `show all slaves status` when using MariaDB to be consistent with MySQL behaviour

According to MySQL [documentation](https://dev.mysql.com/doc/refman/8.0/en/replication-multi-source-monitoring.html) if we run `SHOW SLAVE STATUS` (without a specific replication channel) it should return all replication channels. 
But In MariaDB, if we want to get all replication channels we need to use the `SHOW ALL SLAVES STATUS` otherwise it will only return the default channel.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #603

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
mysql_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before the change:
$ ansible-playbook -i inventories/ --check --diff  -l mariadb.example.com playbooks/mariadb.yml
PLAY [Install/Configure MariaDB] ****************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************************
Thursday 04 January 2024  19:01:25 +0000 (0:00:00.035)       0:00:00.079 ****** 
ok: [mariadb.example.com]

TASK [example.mariadb : Populate facts] *************************************************************************************************************************************
Thursday 04 January 2024  19:01:44 +0000 (0:00:19.369)       0:00:19.448 ****** 
included: /home/example/Documents/example-ansible_base/roles/example.mariadb/tasks/facts.yml for mariadb.example.com

TASK [example.mariadb : Get mysql_info] *************************************************************************************************************************************
Thursday 04 January 2024  19:01:44 +0000 (0:00:00.023)       0:00:19.471 ****** 
ok: [mariadb.example.com]

TASK [example.mariadb : debug] **********************************************************************************************************************************************
Thursday 04 January 2024  19:02:04 +0000 (0:00:20.055)       0:00:39.526 ****** 
ok: [mariadb.example.com] => {
    "msg": {}
}

After the change:
$ ansible-playbook -i inventories/ --check --diff  -l mariadb.example.com playbooks/mariadb.yml
PLAY [Install/Configure MariaDB] ****************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************************
Thursday 04 January 2024  19:03:03 +0000 (0:00:00.035)       0:00:00.079 ****** 
ok: [mariadb.example.com]

TASK [example.mariadb : Populate facts] *************************************************************************************************************************************
Thursday 04 January 2024  19:03:23 +0000 (0:00:19.892)       0:00:19.971 ****** 
included: /home/example/Documents/example-ansible_base/roles/example.mariadb/tasks/facts.yml for mariadb.example.com

TASK [example.mariadb : Get mysql_info] *************************************************************************************************************************************
Thursday 04 January 2024  19:03:23 +0000 (0:00:00.022)       0:00:19.993 ****** 
ok: [mariadb.example.com]

TASK [example.mariadb : debug] **********************************************************************************************************************************************
Thursday 04 January 2024  19:03:42 +0000 (0:00:19.362)       0:00:39.355 ****** 
ok: [mariadb.example.com] => {
    "msg": {
        "replication.example.com": {
            "3306": {
                "replicate_db_001": {
                    "Connect_Retry": 60,
                    "Connection_name": "example1",
                    "Exec_Master_Log_Pos": 170041708,
                    "Executed_log_entries": 25973857,
                    "Gtid_IO_Pos": "0-8723-1512347238,366-8723-1534994784,466-233-464430931",
                    "Gtid_Slave_Pos": "0-22190-1512603882,366-8723-1536396267,466-233-464430931",
                    "Last_Errno": 0,
                    "Last_Error": "",
                    "Last_IO_Errno": 0,
                    "Last_IO_Error": "",
                    "Last_SQL_Errno": 0,
                    "Last_SQL_Error": "",
                    "Master_Log_File": "log-bin.006904",
                    "Master_SSL_Allowed": "No",
                    "Master_SSL_CA_File": "",
                    "Master_SSL_CA_Path": "",
                    "Master_SSL_Cert": "",
                    "Master_SSL_Cipher": "",
                    "Master_SSL_Crl": "",
                    "Master_SSL_Crlpath": "",
                    "Master_SSL_Key": "",
                    "Master_SSL_Verify_Server_Cert": "No",
                    "Master_Server_Id": 233,
                    "Max_relay_log_size": 1073741824,
                    "Parallel_Mode": "optimistic",
                    "Read_Master_Log_Pos": 170041708,
                    "Relay_Log_File": "relay-bin-example1.000028",
                    "Relay_Log_Pos": 101696731,
                    "Relay_Log_Space": 101697091,
                    "Relay_Master_Log_File": "log-bin.006904",
                    "Replicate_Do_DB": "",
                    "Replicate_Do_Domain_Ids": "",
                    "Replicate_Do_Table": "",
                    "Replicate_Ignore_DB": "mysql,performance_schema,information_schema",
                    "Replicate_Ignore_Domain_Ids": "",
                    "Replicate_Ignore_Server_Ids": "",
                    "Replicate_Ignore_Table": "",
                    "Replicate_Wild_Do_Table": "",
                    "Replicate_Wild_Ignore_Table": "mysql.%,performance_schema.%,information_schema.%",
                    "Retried_transactions": 0,
                    "SQL_Delay": 0,
                    "SQL_Remaining_Delay": null,
                    "Seconds_Behind_Master": 0,
                    "Skip_Counter": 0,
                    "Slave_DDL_Groups": 0,
                    "Slave_IO_Running": "Yes",
                    "Slave_IO_State": "Waiting for master to send event",
                    "Slave_Non_Transactional_Groups": 0,
                    "Slave_SQL_Running": "Yes",
                    "Slave_SQL_Running_State": "Slave has read all relay log; waiting for more updates",
                    "Slave_SQL_State": "Slave has read all relay log; waiting for more updates",
                    "Slave_Transactional_Groups": 1125363,
                    "Slave_heartbeat_period": 30,
                    "Slave_received_heartbeats": 0,
                    "Until_Condition": "None",
                    "Until_Log_File": "",
                    "Until_Log_Pos": 0,
                    "Using_Gtid": "Slave_Pos"
                }
            }
        },
        "master2.example.com": {
            "3306": {
                "replicate_db_001": {
                    "Connect_Retry": 60,
                    "Connection_name": "example2",
                    "Exec_Master_Log_Pos": 298086447,
                    "Executed_log_entries": 9608214,
                    "Gtid_IO_Pos": "0-8723-1512347238,366-8723-1536396267,466-233-463305575",
                    "Gtid_Slave_Pos": "0-22190-1512603882,366-8723-1536396267,466-233-464430931",
                    "Last_Errno": 0,
                    "Last_Error": "",
                    "Last_IO_Errno": 0,
                    "Last_IO_Error": "",
                    "Last_SQL_Errno": 0,
                    "Last_SQL_Error": "",
                    "Master_Log_File": "binlog.000784",
                    "Master_SSL_Allowed": "No",
                    "Master_SSL_CA_File": "",
                    "Master_SSL_CA_Path": "",
                    "Master_SSL_Cert": "",
                    "Master_SSL_Cipher": "",
                    "Master_SSL_Crl": "",
                    "Master_SSL_Crlpath": "",
                    "Master_SSL_Key": "",
                    "Master_SSL_Verify_Server_Cert": "No",
                    "Master_Server_Id": 273,
                    "Max_relay_log_size": 1073741824,
                    "Parallel_Mode": "optimistic",
                    "Read_Master_Log_Pos": 298086447,
                    "Relay_Log_File": "relay-bin-example2.000012",
                    "Relay_Log_Pos": 177215035,
                    "Relay_Log_Space": 177215386,
                    "Relay_Master_Log_File": "binlog.000784",
                    "Replicate_Do_DB": "",
                    "Replicate_Do_Domain_Ids": "",
                    "Replicate_Do_Table": "",
                    "Replicate_Ignore_DB": "mysql,performance_schema,information_schema",
                    "Replicate_Ignore_Domain_Ids": "",
                    "Replicate_Ignore_Server_Ids": "",
                    "Replicate_Ignore_Table": "",
                    "Replicate_Wild_Do_Table": "",
                    "Replicate_Wild_Ignore_Table": "mysql.%,performance_schema.%,information_schema.%",
                    "Retried_transactions": 0,
                    "SQL_Delay": 0,
                    "SQL_Remaining_Delay": null,
                    "Seconds_Behind_Master": 0,
                    "Skip_Counter": 0,
                    "Slave_DDL_Groups": 0,
                    "Slave_IO_Running": "Yes",
                    "Slave_IO_State": "Waiting for master to send event",
                    "Slave_Non_Transactional_Groups": 0,
                    "Slave_SQL_Running": "Yes",
                    "Slave_SQL_Running_State": "Slave has read all relay log; waiting for more updates",
                    "Slave_SQL_State": "Slave has read all relay log; waiting for more updates",
                    "Slave_Transactional_Groups": 1401474,
                    "Slave_heartbeat_period": 30,
                    "Slave_received_heartbeats": 0,
                    "Until_Condition": "None",
                    "Until_Log_File": "",
                    "Until_Log_Pos": 0,
                    "Using_Gtid": "Slave_Pos"
                }
            }
        }
    }
}
```
