### PR TITLE
feat[mysql_user]: add support for mysql user attributes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,18 +6,6 @@ Community MySQL Collection Release Notes
 
 This changelog describes changes after version 2.0.0.
 
-v3.9.0
-======
-
-This is the minor release of the ``community.mysql`` collection.
-This changelog contains all changes to the modules and plugins in this
-collection that have been made after the previous release.
-
-Minor Changes
--------------
-
-- mysql_user - add user attribute support via the ``attributes`` parameter and return value (https://github.com/ansible-collections/community.mysql/pull/604).
-
 v3.8.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ Community MySQL Collection Release Notes
 
 This changelog describes changes after version 2.0.0.
 
+v3.9.0
+======
+
+This is the minor release of the ``community.mysql`` collection.
+This changelog contains all changes to the modules and plugins in this
+collection that have been made after the previous release.
+
+Minor Changes
+-------------
+
+- mysql_user - add user attribute support via the ``attributes`` parameter and return value (https://github.com/ansible-collections/community.mysql/pull/604).
+
 v3.8.0
 ======
 

--- a/changelogs/fragments/604-user-attributes.yaml
+++ b/changelogs/fragments/604-user-attributes.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "mysql_user - add user attribute support via the ``attributes`` parameter and return value (https://github.com/ansible-collections/community.mysql/pull/604)."

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -155,7 +155,7 @@ def user_add(cursor, user, host, host_all, password, encrypted,
              attributes, tls_requires, reuse_existing_password, module):
     # If attributes are set, perform a sanity check to ensure server supports user attributes before creating user
     if attributes and not get_attribute_support(cursor):
-        module.fail_json(msg="user attributes were specified but the mysql server does not support user attributes")
+        module.fail_json(msg="user attributes were specified but the server does not support user attributes")
 
     # we cannot create users without a proper hostname
     if host_all:
@@ -431,15 +431,14 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
 
         if attributes:
             if not attribute_support:
-                module.fail_json(msg="user attributes were specified but the mysql server does not support user attributes")
+                module.fail_json(msg="user attributes were specified but the server does not support user attributes")
             else:
                 current_attributes = attributes_get(cursor, user, host)
                 attributes_to_change = {}
 
                 for key, value in attributes.items():
                     if key not in current_attributes or current_attributes[key] != value:
-                        # The mysql null value (None in python) is used to delete an attribute; we use False to represent None in the attributes parameter
-                        attributes_to_change[key] = None if not value else value
+                        attributes_to_change[key] = value
 
                 if attributes_to_change:
                     msg = "Attributes updated: %s" % (", ".join(["%s: %s" % (key, value) for key, value in attributes_to_change.items()]))
@@ -451,7 +450,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     else:
                         # Final if statements excludes items whose values are None in attributes_to_change, i.e. attributes that will be deleted
                         final_attributes = {k: v for d in (current_attributes, attributes_to_change) for k, v in d.items() if k not in attributes_to_change or
-                                            attributes_to_change[k]}
+                                            attributes_to_change[k] is not None}
                     changed = True
                 else:
                     final_attributes = current_attributes

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -931,7 +931,7 @@ class Role():
         if privs:
             result = user_mod(self.cursor, self.name, self.host,
                               None, None, None, None, None, None,
-                              privs, append_privs, subtract_privs, None,
+                              privs, append_privs, subtract_privs, None, None,
                               self.module, role=True, maria_role=self.is_mariadb)
             changed = result['changed']
 

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -168,7 +168,7 @@ options:
     description:
       - "Create, update, or delete user attributes (arbitrary 'key: value' comments) for the user."
       - MySQL server must support the INFORMATION_SCHEMA.USER_ATTRIBUTES table. Provided since MySQL 8.0.
-      - To delete an existing attribute, set its value to False.
+      - To delete an existing attribute, set its value to null.
     type: dict
     version_added: '3.9.0'
 
@@ -268,7 +268,7 @@ EXAMPLES = r'''
     name: bob
     attributes:
       foo: "foo"
-      bar: False
+      bar: null
 
 - name: Modify user to require TLS connection with a valid client certificate
   community.mysql.mysql_user:

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -515,7 +515,7 @@ def main():
 
         priv = privileges_unpack(priv, mode, column_case_sensitive, ensure_usage=not subtract_privs)
     password_changed = False
-    final_attributes = {}
+    final_attributes = None
     if state == "present":
         if user_exists(cursor, user, host, host_all):
             try:

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -155,7 +155,6 @@ options:
       - Cannot be used to set global variables, use the M(community.mysql.mysql_variables) module instead.
     type: dict
     version_added: '3.6.0'
-
   column_case_sensitive:
     description:
       - The default is C(false).
@@ -165,6 +164,13 @@ options:
         fields names in privileges.
     type: bool
     version_added: '3.8.0'
+  attributes:
+    description:
+      - Create, update, or delete user attributes (arbitrary "key: value" comments) for the user.
+      - MySQL server must support the INFORMATION_SCHEMA.USER_ATTRIBUTES table. Provided since MySQL 8.0.
+      - To delete an existing attribute, set its value to False.
+    type: dict
+    version_added: '3.9.0'
 
 notes:
    - "MySQL server installs with default I(login_user) of C(root) and no password.
@@ -256,6 +262,13 @@ EXAMPLES = r'''
     priv:
       FUNCTION my_db.my_function: EXECUTE
     state: present
+
+- name: Modify user attributes, creating the attribute 'foo' and removing the attribute 'bar'
+  community.mysql.mysql_user:
+    name: bob
+    attributes:
+      foo: "foo"
+      bar: False
 
 - name: Modify user to require TLS connection with a valid client certificate
   community.mysql.mysql_user:
@@ -405,6 +418,7 @@ def main():
         tls_requires=dict(type='dict'),
         append_privs=dict(type='bool', default=False),
         subtract_privs=dict(type='bool', default=False),
+        attributes=dict(type='dict'),
         check_implicit_admin=dict(type='bool', default=False),
         update_password=dict(type='str', default='always', choices=['always', 'on_create', 'on_new_username'], no_log=False),
         sql_log_bin=dict(type='bool', default=True),
@@ -437,6 +451,7 @@ def main():
     append_privs = module.boolean(module.params["append_privs"])
     subtract_privs = module.boolean(module.params['subtract_privs'])
     update_password = module.params['update_password']
+    attributes = module.params['attributes']
     ssl_cert = module.params["client_cert"]
     ssl_key = module.params["client_key"]
     ssl_ca = module.params["ca_cert"]
@@ -500,21 +515,23 @@ def main():
 
         priv = privileges_unpack(priv, mode, column_case_sensitive, ensure_usage=not subtract_privs)
     password_changed = False
+    final_attributes = {}
     if state == "present":
         if user_exists(cursor, user, host, host_all):
             try:
                 if update_password == "always":
                     result = user_mod(cursor, user, host, host_all, password, encrypted,
                                       plugin, plugin_hash_string, plugin_auth_string,
-                                      priv, append_privs, subtract_privs, tls_requires, module)
+                                      priv, append_privs, subtract_privs, attributes, tls_requires, module)
 
                 else:
                     result = user_mod(cursor, user, host, host_all, None, encrypted,
                                       None, None, None,
-                                      priv, append_privs, subtract_privs, tls_requires, module)
+                                      priv, append_privs, subtract_privs, attributes, tls_requires, module)
                 changed = result['changed']
                 msg = result['msg']
                 password_changed = result['password_changed']
+                final_attributes = result['attributes']
 
             except (SQLParseError, InvalidPrivsError, mysql_driver.Error) as e:
                 module.fail_json(msg=to_native(e))
@@ -527,9 +544,10 @@ def main():
                 reuse_existing_password = update_password == 'on_new_username'
                 result = user_add(cursor, user, host, host_all, password, encrypted,
                                   plugin, plugin_hash_string, plugin_auth_string,
-                                  priv, tls_requires, module.check_mode, reuse_existing_password)
+                                  priv, attributes, tls_requires, reuse_existing_password, module)
                 changed = result['changed']
                 password_changed = result['password_changed']
+                final_attributes = result['attributes']
                 if changed:
                     msg = "User added"
 
@@ -546,7 +564,7 @@ def main():
         else:
             changed = False
             msg = "User doesn't exist"
-    module.exit_json(changed=changed, user=user, msg=msg, password_changed=password_changed)
+    module.exit_json(changed=changed, user=user, msg=msg, password_changed=password_changed, attributes=final_attributes)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -166,7 +166,7 @@ options:
     version_added: '3.8.0'
   attributes:
     description:
-      - Create, update, or delete user attributes (arbitrary "key: value" comments) for the user.
+      - "Create, update, or delete user attributes (arbitrary 'key: value' comments) for the user."
       - MySQL server must support the INFORMATION_SCHEMA.USER_ATTRIBUTES table. Provided since MySQL 8.0.
       - To delete an existing attribute, set its value to False.
     type: dict

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -267,6 +267,9 @@
       tags:
         - issue_465
 
+    # Tests for user attributes
+    - include_tasks: test_user_attributes.yml
+
     # Tests for the TLS requires dictionary
     - include_tasks: test_tls_requirements.yml
 

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_attributes.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_attributes.yml
@@ -11,6 +11,11 @@
     - when: db_engine == 'mariadb'
       block:
 
+      # ============================================================
+      # Fail creating a user with mariadb
+      #
+
+      # Check mode
       - name: Attributes | Attempt to create user with attributes with mariadb in check mode
         mysql_user:
           <<: *mysql_params
@@ -20,14 +25,23 @@
           attributes:
             key1: "value1"
         ignore_errors: yes
-        register: result
+        register: result_module
         check_mode: yes
 
-      - name: Attributes | Assert that creating user with attributes fails with mariadb
+      - name: Attributes | Run query to verify user creation with attributes fails with mariadb in check mode
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT user FROM mysql.user WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        ignore_errors: yes
+        register: result_query
+
+      - name: Attributes | Assert that creating user with attributes fails with mariadb in check mode
         assert:
           that:
-            - result is failed
+            - result_module is failed
+            - not result_query.query_result[0]
 
+      # Real mode
       - name: Attributes | Attempt to create user with attributes with mariadb
         mysql_user:
           <<: *mysql_params
@@ -37,17 +51,28 @@
           attributes:
             key1: "value1"
         ignore_errors: yes
-        register: result
+        register: result_module
+
+      - name: Attributes | Run query to verify user creation with attributes fails with mariadb
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT user FROM mysql.user WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that creating user with attributes fails with mariadb
         assert:
           that:
-            - result is failed
+            - result_module is failed
+            - not result_query.query_result[0]
 
     - when: db_engine == 'mysql'
       block:
 
+      # ============================================================
       # Create user with attributes
+      #
+
+      # Check mode
       - name: Attributes | Test creating a user with attributes in check mode
         mysql_user:
           <<: *mysql_params
@@ -56,15 +81,23 @@
           password: '{{ user_password_2 }}'
           attributes:
             key1: "value1"
-        register: result
+        register: result_module
         check_mode: yes
+
+      - name: Attributes | Run query to verify user creation did not take place in check mode
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT user FROM mysql.user WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that user would have been created with attributes
         assert:
           that:
-            - result is changed
-            - result.attributes.key1 == "value1"
+            - result_module is changed
+            - result_module.attributes.key1 == "value1"
+            - not result_query.query_result[0]
 
+      # Real mode
       - name: Attributes | Test creating a user with attributes
         mysql_user:
           <<: *mysql_params
@@ -73,15 +106,26 @@
           password: '{{ user_password_2 }}'
           attributes:
             key1: "value1"
-        register: result
+        register: result_module
+
+      - name: Attributes | Run query to verify created user attributes
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that user was created with attributes
         assert:
           that:
-            - result is changed
-            - result.attributes.key1 == "value1"
+            - result_module is changed
+            - result_module.attributes.key1 == "value1"
+            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key1'] == "value1"
 
+      # ============================================================
       # Append attributes on an existing user
+      #
+
+      # Check mode
       - name: Attributes | Test appending attributes to an existing user in check mode
         mysql_user:
           <<: *mysql_params
@@ -89,16 +133,24 @@
           host: '%'
           attributes:
             key2: "value2"
-        register: result
+        register: result_module
         check_mode: yes
+
+      - name: Attributes | Run query to check appended attributes in check mode
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that attribute would have been appended and existing attribute stays
         assert:
           that:
-            - result is changed
-            - result.attributes.key1 == "value1"
-            - result.attributes.key2 == "value2"
+            - result_module is changed
+            - result_module.attributes.key1 == "value1"
+            - result_module.attributes.key2 == "value2"
+            - "'key2' not in result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml"
 
+      # Real mode
       - name: Attributes | Test appending attributes to an existing user
         mysql_user:
           <<: *mysql_params
@@ -106,16 +158,28 @@
           host: '%'
           attributes:
             key2: "value2"
-        register: result
+        register: result_module
+
+      - name: Attributes | Run query to check appended attributes
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that new attribute was appended and existing attribute stays
         assert:
           that:
-            - result is changed
-            - result.attributes.key1 == "value1"
-            - result.attributes.key2 == "value2"
+            - result_module is changed
+            - result_module.attributes.key1 == "value1"
+            - result_module.attributes.key2 == "value2"
+            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key1'] == "value1"
+            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key2'] == "value2"
 
+      # ============================================================
       # Test updating existing attributes
+      #
+
+      # Check mode
       - name: Attributes | Test updating attributes on an existing user in check mode
         mysql_user:
           <<: *mysql_params
@@ -124,14 +188,22 @@
           attributes:
             key2: "new_value2"
         check_mode: yes
-        register: result
+        register: result_module
+
+      - name: Attributes | Run query to verify updated attribute in check mode
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that attribute would have been updated
         assert:
           that:
-            - result is changed
-            - result.attributes.key2 == "new_value2"
+            - result_module is changed
+            - result_module.attributes.key2 == "new_value2"
+            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key2'] == "value2"
 
+      # Real mode
       - name: Attributes | Test updating attributes on an existing user
         mysql_user:
           <<: *mysql_params
@@ -139,47 +211,77 @@
           host: '%'
           attributes:
             key2: "new_value2"
-        register: result
+        register: result_module
+
+      - name: Attributes | Run query to verify updated attribute
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that attribute was updated
         assert:
           that:
-            - result is changed
-            - result.attributes.key2 == "new_value2"
+            - result_module is changed
+            - result_module.attributes.key2 == "new_value2"
+            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key2'] == "new_value2"
 
+      # ============================================================
       # Test deleting attributes
+      #
+
+      # Check mode
       - name: Attributes | Test deleting attributes on an existing user in check mode
         mysql_user:
           <<: *mysql_params
           name: '{{ user_name_2 }}'
           host: '%'
           attributes:
-            key2: False
-        register: result
+            key2: null
+        register: result_module
         check_mode: yes
+
+      - name: Attributes | Run query to verify deleted attribute in check mode
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that attribute would have been deleted
         assert:
           that:
-            - result is changed
-            - "'key2' not in result.attributes"
+            - result_module is changed
+            - "'key2' not in result_module.attributes"
+            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key2'] == "new_value2"
 
+      # Real mode
       - name: Attributes | Test deleting attributes on an existing user
         mysql_user:
           <<: *mysql_params
           name: '{{ user_name_2 }}'
           host: '%'
           attributes:
-            key2: False
-        register: result
+            key2: null
+        register: result_module
+
+      - name: Attributes | Run query to verify deleted attribute
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that attribute was deleted
         assert:
           that:
-            - result is changed
-            - "'key2' not in result.attributes"
+            - result_module is changed
+            - "'key2' not in result_module.attributes"
+            - "'key2' not in result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml"
 
-      # Test attribute idempotency
+      # ============================================================
+      # Test attribute idempotency when specifying attributes
+      #
+
+      # Check mode
       - name: Attributes | Test attribute idempotency by trying to change an already correct attribute in check mode
         mysql_user:
           <<: *mysql_params
@@ -187,15 +289,23 @@
           host: '%'
           attributes:
             key1: "value1"
-        register: result
+        register: result_module
         check_mode: yes
+
+      - name: Attributes | Run query to verify idempotency of already correct attribute in check mode
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that attribute would not have been updated
         assert:
           that:
-            - result is not changed
-            - result.attributes.key1 == "value1"
+            - result_module is not changed
+            - result_module.attributes.key1 == "value1"
+            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key1'] == "value1"
 
+      # Real mode
       - name: Attributes | Test attribute idempotency by trying to change an already correct attribute
         mysql_user:
           <<: *mysql_params
@@ -203,42 +313,71 @@
           host: '%'
           attributes:
             key1: "value1"
-        register: result
+        register: result_module
+
+      - name: Attributes | Run query to verify idempotency of already correct attribute
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that attribute was not updated
         assert:
           that:
-            - result is not changed
-            - result.attributes.key1 == "value1"
+            - result_module is not changed
+            - result_module.attributes.key1 == "value1"
+            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key1'] == "value1"
 
+      # ============================================================
+      # Test attribute idempotency when not specifying attribute parameter
+      #
+
+      # Check mode
       - name: Attributes | Test attribute idempotency by not specifying attribute parameter in check mode
         mysql_user:
           <<: *mysql_params
           name: '{{ user_name_2 }}'
           host: '%'
-        register: result
+        register: result_module
         check_mode: yes
+
+      - name: Attributes | Run query to verify idempotency when not specifying attribute parameter in check mode
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that attribute is returned in check mode
         assert:
           that:
-            - result is not changed
-            - result.attributes.key1 == "value1"
+            - result_module is not changed
+            - result_module.attributes.key1 == "value1"
+            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key1'] == "value1"
 
+      # Real mode
       - name: Attributes | Test attribute idempotency by not specifying attribute parameter
         mysql_user:
           <<: *mysql_params
           name: '{{ user_name_2 }}'
           host: '%'
-        register: result
+        register: result_module
+
+      - name: Attributes | Run query to verify idempotency when not specifying attribute parameter
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
 
       - name: Attributes | Assert that attribute is returned
         assert:
           that:
-            - result is not changed
-            - result.attributes.key1 == "value1"
+            - result_module is not changed
+            - result_module.attributes.key1 == "value1"
+            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key1'] == "value1"
 
+      # ============================================================
       # Cleanup
+      #
       - include_tasks: utils/remove_user.yml
         vars:
           user_name: "{{ user_name_2 }}"

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_attributes.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_attributes.yml
@@ -1,0 +1,244 @@
+---
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    - when: db_engine == 'mariadb'
+      block:
+
+      - name: Attributes | Attempt to create user with attributes with mariadb in check mode
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          password: '{{ user_password_2 }}'
+          attributes:
+            key1: "value1"
+        ignore_errors: yes
+        register: result
+        check_mode: yes
+
+      - name: Attributes | Assert that creating user with attributes fails with mariadb
+        assert:
+          that:
+            - result is failed
+
+      - name: Attributes | Attempt to create user with attributes with mariadb
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          password: '{{ user_password_2 }}'
+          attributes:
+            key1: "value1"
+        ignore_errors: yes
+        register: result
+
+      - name: Attributes | Assert that creating user with attributes fails with mariadb
+        assert:
+          that:
+            - result is failed
+
+    - when: db_engine == 'mysql'
+      block:
+
+      # Create user with attributes
+      - name: Attributes | Test creating a user with attributes in check mode
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          password: '{{ user_password_2 }}'
+          attributes:
+            key1: "value1"
+        register: result
+        check_mode: yes
+
+      - name: Attributes | Assert that user would have been created with attributes
+        assert:
+          that:
+            - result is changed
+            - result.attributes.key1 == "value1"
+
+      - name: Attributes | Test creating a user with attributes
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          password: '{{ user_password_2 }}'
+          attributes:
+            key1: "value1"
+        register: result
+
+      - name: Attributes | Assert that user was created with attributes
+        assert:
+          that:
+            - result is changed
+            - result.attributes.key1 == "value1"
+
+      # Append attributes on an existing user
+      - name: Attributes | Test appending attributes to an existing user in check mode
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key2: "value2"
+        register: result
+        check_mode: yes
+
+      - name: Attributes | Assert that attribute would have been appended and existing attribute stays
+        assert:
+          that:
+            - result is changed
+            - result.attributes.key1 == "value1"
+            - result.attributes.key2 == "value2"
+
+      - name: Attributes | Test appending attributes to an existing user
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key2: "value2"
+        register: result
+
+      - name: Attributes | Assert that new attribute was appended and existing attribute stays
+        assert:
+          that:
+            - result is changed
+            - result.attributes.key1 == "value1"
+            - result.attributes.key2 == "value2"
+
+      # Test updating existing attributes
+      - name: Attributes | Test updating attributes on an existing user in check mode
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key2: "new_value2"
+        check_mode: yes
+        register: result
+
+      - name: Attributes | Assert that attribute would have been updated
+        assert:
+          that:
+            - result is changed
+            - result.attributes.key2 == "new_value2"
+
+      - name: Attributes | Test updating attributes on an existing user
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key2: "new_value2"
+        register: result
+
+      - name: Attributes | Assert that attribute was updated
+        assert:
+          that:
+            - result is changed
+            - result.attributes.key2 == "new_value2"
+
+      # Test deleting attributes
+      - name: Attributes | Test deleting attributes on an existing user in check mode
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key2: False
+        register: result
+        check_mode: yes
+
+      - name: Attributes | Assert that attribute would have been deleted
+        assert:
+          that:
+            - result is changed
+            - "'key2' not in result.attributes"
+
+      - name: Attributes | Test deleting attributes on an existing user
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key2: False
+        register: result
+
+      - name: Attributes | Assert that attribute was deleted
+        assert:
+          that:
+            - result is changed
+            - "'key2' not in result.attributes"
+
+      # Test attribute idempotency
+      - name: Attributes | Test attribute idempotency by trying to change an already correct attribute in check mode
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key1: "value1"
+        register: result
+        check_mode: yes
+
+      - name: Attributes | Assert that attribute would not have been updated
+        assert:
+          that:
+            - result is not changed
+            - result.attributes.key1 == "value1"
+
+      - name: Attributes | Test attribute idempotency by trying to change an already correct attribute
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key1: "value1"
+        register: result
+
+      - name: Attributes | Assert that attribute was not updated
+        assert:
+          that:
+            - result is not changed
+            - result.attributes.key1 == "value1"
+
+      - name: Attributes | Test attribute idempotency by not specifying attribute parameter in check mode
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+        register: result
+        check_mode: yes
+
+      - name: Attributes | Assert that attribute is returned in check mode
+        assert:
+          that:
+            - result is not changed
+            - result.attributes.key1 == "value1"
+
+      - name: Attributes | Test attribute idempotency by not specifying attribute parameter
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+        register: result
+
+      - name: Attributes | Assert that attribute is returned
+        assert:
+          that:
+            - result is not changed
+            - result.attributes.key1 == "value1"
+
+      # Cleanup
+      - include_tasks: utils/remove_user.yml
+        vars:
+          user_name: "{{ user_name_2 }}"

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_attributes.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_attributes.yml
@@ -69,6 +69,60 @@
       block:
 
       # ============================================================
+      # Create user with no attributes (test attributes return type)
+      #
+
+      # Check mode
+      - name: Attributes | Test creating a user with no attributes in check mode
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          password: '{{ user_password_2 }}'
+        register: result_module
+        check_mode: yes
+
+      - name: Attributes | Run query to verify user creation with no attributes did not take place in check mode
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT user FROM mysql.user WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
+
+      - name: Attributes | Assert that user would have been created without attributes
+        assert:
+          that:
+            - result_module is changed
+            - result_module.attributes is none
+            - not result_query.query_result[0]
+
+      # Real mode
+      - name: Attributes | Test creating a user with no attributes
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          password: '{{ user_password_2 }}'
+        register: result_module
+
+      - name: Attributes | Run query to verify created user without attributes
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
+
+      - name: Attributes | Assert that user was created without attributes
+        assert:
+          that:
+            - result_module is changed
+            - result_module.attributes is none
+            - result_query.query_result[0][0]['ATTRIBUTE'] is none
+
+      # Clean up user to allow it to be recreated with attributes
+      - include_tasks: utils/remove_user.yml
+        vars:
+          user_name: "{{ user_name_2 }}"
+
+      # ============================================================
       # Create user with attributes
       #
 
@@ -227,57 +281,6 @@
             - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key2'] == "new_value2"
 
       # ============================================================
-      # Test deleting attributes
-      #
-
-      # Check mode
-      - name: Attributes | Test deleting attributes on an existing user in check mode
-        mysql_user:
-          <<: *mysql_params
-          name: '{{ user_name_2 }}'
-          host: '%'
-          attributes:
-            key2: null
-        register: result_module
-        check_mode: yes
-
-      - name: Attributes | Run query to verify deleted attribute in check mode
-        mysql_query:
-          <<: *mysql_params
-          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
-        register: result_query
-
-      - name: Attributes | Assert that attribute would have been deleted
-        assert:
-          that:
-            - result_module is changed
-            - "'key2' not in result_module.attributes"
-            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key2'] == "new_value2"
-
-      # Real mode
-      - name: Attributes | Test deleting attributes on an existing user
-        mysql_user:
-          <<: *mysql_params
-          name: '{{ user_name_2 }}'
-          host: '%'
-          attributes:
-            key2: null
-        register: result_module
-
-      - name: Attributes | Run query to verify deleted attribute
-        mysql_query:
-          <<: *mysql_params
-          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
-        register: result_query
-
-      - name: Attributes | Assert that attribute was deleted
-        assert:
-          that:
-            - result_module is changed
-            - "'key2' not in result_module.attributes"
-            - "'key2' not in result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml"
-
-      # ============================================================
       # Test attribute idempotency when specifying attributes
       #
 
@@ -374,6 +377,94 @@
             - result_module is not changed
             - result_module.attributes.key1 == "value1"
             - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key1'] == "value1"
+
+      # ============================================================
+      # Test deleting attributes
+      #
+
+      # Check mode
+      - name: Attributes | Test deleting attributes on an existing user in check mode
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key2: null
+        register: result_module
+        check_mode: yes
+
+      - name: Attributes | Run query to verify deleted attribute in check mode
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
+
+      - name: Attributes | Assert that attribute would have been deleted
+        assert:
+          that:
+            - result_module is changed
+            - "'key2' not in result_module.attributes"
+            - (result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml)['key2'] == "new_value2"
+
+      # Real mode
+      - name: Attributes | Test deleting attributes on an existing user
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key2: null
+        register: result_module
+
+      - name: Attributes | Run query to verify deleted attribute
+        mysql_query:
+          <<: *mysql_params
+          query: 'SELECT attribute FROM INFORMATION_SCHEMA.USER_ATTRIBUTES WHERE user = "{{ user_name_2 }}" AND host = "%"'
+        register: result_query
+
+      - name: Attributes | Assert that attribute was deleted
+        assert:
+          that:
+            - result_module is changed
+            - "'key2' not in result_module.attributes"
+            - "'key2' not in result_query.query_result[0][0]['ATTRIBUTE'] | from_yaml"
+
+      # ============================================================
+      # Test attribute return value when no attributes exist
+      #
+
+      # Check mode
+      - name: Attributes | Test attributes return value when no attributes exist in check mode
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key1: null
+        register: result_module
+        check_mode: yes
+
+      - name: Attributes | Assert attributes return value when no attributes exist in check mode
+        assert:
+          that:
+            - result_module is changed
+            - result_module.attributes is none
+
+      # Real mode
+      - name: Attributes | Test attributes return value when no attributes exist
+        mysql_user:
+          <<: *mysql_params
+          name: '{{ user_name_2 }}'
+          host: '%'
+          attributes:
+            key1: null
+        register: result_module
+
+      - name: Attributes | Assert attributes return value when no attributes exist
+        assert:
+          that:
+            - result_module is changed
+            - result_module.attributes is none
 
       # ============================================================
       # Cleanup


### PR DESCRIPTION
##### SUMMARY
This PR adds support for [MySQL user attributes](https://dev.mysql.com/doc/refman/8.0/en/information-schema-user-attributes-table.html) (essentially arbitrary comments associated with a user in a key: value format) to the mysql_user module. It adds the ability to add, update, and delete user attributes, and get existing attributes by checking the `attributes` attribute of the `mysql_user` task.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`community.mysql.mysql_user`

##### ADDITIONAL INFORMATION

- Previously, `user_mod` would prematurely return at various points in check mode when changes were detected. IMO, this is not ideal, as the entirety of the module that will execute in non-check mode is not ran in check mode, and it means we have to support returning a specifically-constructed dict in multiple locations. As part of this PR, since I am modifying the return dict of `user_mod`, I removed the premature returns when in check mode in favor of the final return at the end of the function. I can revert this if desired, but I think it makes the code cleaner and safer. It is worth noting that messages from the module are still masked if a later message is registered.
- Return values are not documented yet, so I didn't document the new `attributes` return value, but I could add return value documentation if desired.

##### LOCAL TESTING

###### SERVER SUPPORTS ATTRIBUTES

Creating a new user without attributes:

```
$ ansible -m mysql_user -a '{ "user": "newuser1", "host": "localhost" }' remote
remote | CHANGED => {
    "attributes": {},
    "changed": true,
    "msg": "User added",
    "password_changed": true,
    "user": "newuser1"
}
$ 
```

Creating a new user with attributes:

```
$ ansible -m mysql_user -a '{ "user": "newuser2", "host": "localhost", "attributes": { "key": "value" } }' remote
remote | CHANGED => {
    "attributes": {
        "key": "value"
    },
    "changed": true,
    "msg": "User added",
    "password_changed": true,
    "user": "newuser2"
}
$ 
```

Updating an existing user's attributes:

```
$ ansible -m mysql_user -a '{ "user": "newuser2", "host": "localhost", "attributes": { "key": "value_changed", "new_key": "new_value" } }' remote
remote | CHANGED => {
    "attributes": {
        "key": "value_changed",
        "new_key": "new_value"
    },
    "changed": true,
    "msg": "Attributes updated: key: value_changed, new_key: new_value",
    "password_changed": false,
    "user": "newuser2"
}
$ 
```

No change when existing attributes are already in line with the attributes specified in the `attributes` parameter:

```
$ ansible -m mysql_user -a '{ "user": "newuser2", "host": "localhost", "attributes": { "key": "value_changed", "new_key": "new_value" } }' remote
remote | SUCCESS => {
    "attributes": {
        "key": "value_changed",
        "new_key": "new_value"
    },
    "changed": false,
    "msg": "User unchanged",
    "password_changed": false,
    "user": "newuser2"
}
$ 
```

No change when the `attributes` parameter is not specified:

```
$ ansible -m mysql_user -a '{ "user": "newuser2", "host": "localhost" }' remote
remote | SUCCESS => {
    "attributes": {
        "key": "value_changed",
        "new_key": "new_value"
    },
    "changed": false,
    "msg": "User unchanged",
    "password_changed": false,
    "user": "newuser2"
}
$ 
```

###### SERVER DOES NOT SUPPORT ATTRIBUTES

Creating a new user without attributes:

```
$ ansible -m mysql_user -a '{ "user": "newuser1", "host": "localhost" }' remote
remote | CHANGED => {
    "attributes": {},
    "changed": true,
    "msg": "User added",
    "password_changed": true,
    "user": "newuser1"
}
$ 
```

Reading an existing user:

```
$ ansible -m mysql_user -a '{ "user": "newuser1", "host": "localhost" }' remote
remote | SUCCESS => {
    "attributes": {},
    "changed": false,
    "msg": "User unchanged",
    "password_changed": false,
    "user": "newuser1"
}
$ 
```

Creating a new user with attributes:

```
$ ansible -m mysql_user -a '{ "user": "newuser2", "host": "localhost", "attributes": { "key": "value" } }' remote
remote | FAILED! => {
    "changed": false,
    "msg": "user attributes were specified but the mysql server does not support user attributes"
}
$ 
```

Updating an existing user's attributes:

```
$ ansible -m mysql_user -a '{ "user": "newuser1", "host": "localhost", "attributes": { "key": "value" } }' remote
remote | FAILED! => {
    "changed": false,
    "msg": "user attributes were specified but the mysql server does not support user attributes"
}
$ 
```