### PR TITLE
Add tests for Ansible core 2.17 (devel is 2.18 today) and bump tests dependencies

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -1,6 +1,6 @@
 ---
 name: Plugins CI
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'plugins/**'

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -275,8 +275,8 @@ jobs:
           fi
 
       - name: Set docker_image
-        run: |
-          docker_image_multiline=(" \
+        run: |-
+          docker_image_multiline=("\
           ghcr.io/ansible-collections/community.mysql\
           /test-container-${{ env.db_client }}\
           -py${{ env.python_version_flat }}\

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -27,6 +27,7 @@ jobs:
           - stable-2.17
           - devel
     steps:
+      # https://github.com/ansible-community/ansible-test-gh-action
       - name: Perform sanity testing
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -22,9 +22,9 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
     steps:
       - name: Perform sanity testing
@@ -41,9 +41,9 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
         db_engine_name:
           - mysql
@@ -112,9 +112,6 @@ jobs:
             python: '3.10'
 
           - db_engine_version: 5.7.40
-            ansible: stable-2.14
-
-          - db_engine_version: 5.7.40
             ansible: stable-2.15
 
           - db_engine_version: 5.7.40
@@ -175,13 +172,13 @@ jobs:
             connector_version: 2.0.3
 
           - python: '3.8'
-            ansible: stable-2.14
-
-          - python: '3.8'
             ansible: stable-2.15
 
           - python: '3.8'
             ansible: stable-2.16
+
+          - python: '3.8'
+            ansible: stable-2.17
 
           - python: '3.8'
             ansible: devel
@@ -340,20 +337,20 @@ jobs:
       fail-fast: true
       matrix:
         ansible:
-          - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
         python:
           - 3.8
           - 3.9
         exclude:
           - python: '3.8'
-            ansible: stable-2.14
-          - python: '3.8'
             ansible: stable-2.15
           - python: '3.8'
             ansible: stable-2.16
+          - python: '3.8'
+            ansible: stable-2.17
           - python: '3.8'
             ansible: devel
 

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -283,8 +283,6 @@ jobs:
           -${{ matrix.connector_name }}${{ env.connector_version_flat }}\
           :latest")
 
-      - name: Store docker_image name in GITHUB_ENV
-        run: >-
           echo "docker_image=$(printf '%s' $docker_image_multiline)"
           >> $GITHUB_ENV
 

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   sanity:
     name: "Sanity (Ansible: ${{ matrix.ansible }})"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         ansible:
@@ -36,7 +36,7 @@ jobs:
 
   integration:
     name: "Integration (Python: ${{ matrix.python }}, Ansible: ${{ matrix.ansible }}, DB: ${{ matrix.db_engine_name }} ${{ matrix.db_engine_version }}, connector: ${{ matrix.connector_name }} ${{ matrix.connector_version }})"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -325,7 +325,7 @@ jobs:
           testing-type: integration
 
   units:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Units (Ⓐ${{ matrix.ansible }})
     strategy:
       # As soon as the first unit test fails,

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -283,8 +283,8 @@ jobs:
           -${{ matrix.connector_name }}${{ env.connector_version_flat }}\
           :latest")
 
-      - name: Sore docker_image name in GITHUB_ENV
-        run: >
+      - name: Store docker_image name in GITHUB_ENV
+        run: >-
           echo "docker_image=$(printf '%s' $docker_image_multiline)" \
           >> $GITHUB_ENV
 

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -123,9 +123,6 @@ jobs:
           - db_engine_version: 8.0.31
             python: '3.8'
 
-          - db_engine_version: 8.0.31
-            python: '3.8'
-
           - db_engine_version: 10.4.27
             python: '3.10'
 

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -285,7 +285,7 @@ jobs:
 
       - name: Store docker_image name in GITHUB_ENV
         run: >-
-          echo "docker_image=$(printf '%s' $docker_image_multiline)" \
+          echo "docker_image=$(printf '%s' $docker_image_multiline)"
           >> $GITHUB_ENV
 
       - name: >-

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -169,9 +169,6 @@ jobs:
             connector_version: 2.0.3
 
           - python: '3.8'
-            ansible: stable-2.15
-
-          - python: '3.8'
             ansible: stable-2.16
 
           - python: '3.8'
@@ -181,10 +178,10 @@ jobs:
             ansible: devel
 
           - python: '3.9'
-            ansible: stable-2.15
+            ansible: stable-2.16
 
           - python: '3.9'
-            ansible: stable-2.16
+            ansible: stable-2.17
 
           - python: '3.9'
             ansible: devel

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -276,15 +276,11 @@ jobs:
 
       - name: Set docker_image
         run: |-
-          docker_image_multiline=("\
-          ghcr.io/ansible-collections/community.mysql\
+          echo "docker_image=ghcr.io/ansible-collections/community.mysql\
           /test-container-${{ env.db_client }}\
           -py${{ env.python_version_flat }}\
           -${{ matrix.connector_name }}${{ env.connector_version_flat }}\
-          :latest")
-
-          echo "docker_image=$(printf '%s' $docker_image_multiline)"
-          >> $GITHUB_ENV
+          :latest" >> $GITHUB_ENV
 
       - name: >-
           Perform integration testing against

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -275,15 +275,17 @@ jobs:
           fi
 
       - name: Set docker_image
-        run: >
-          docker_image_multiline=("
+        run: |
+          docker_image_multiline=(" \
           ghcr.io/ansible-collections/community.mysql\
           /test-container-${{ env.db_client }}\
           -py${{ env.python_version_flat }}\
           -${{ matrix.connector_name }}${{ env.connector_version_flat }}\
           :latest")
 
-          echo "docker_image=$(printf '%s' $docker_image_multiline)"
+      - name: Sore docker_image name in GITHUB_ENV
+        run: >
+          echo "docker_image=$(printf '%s' $docker_image_multiline)" \
           >> $GITHUB_ENV
 
       - name: >-

--- a/.github/workflows/ansible-test-roles.yml
+++ b/.github/workflows/ansible-test-roles.yml
@@ -38,12 +38,12 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ansible_collections/community/mysql
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/ansible-test-roles.yml
+++ b/.github/workflows/ansible-test-roles.yml
@@ -1,6 +1,6 @@
 ---
 name: Roles CI
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'roles/**'

--- a/.github/workflows/ansible-test-roles.yml
+++ b/.github/workflows/ansible-test-roles.yml
@@ -29,10 +29,14 @@ jobs:
           - stable-2.15
           - devel
         python:
-          - 3.8
-          - 3.9
+          - '3.8'
+          - '3.9'
+          - '3.10'
         exclude:
           - python: 3.8
+            ansible: devel
+
+          - python: 3.9
             ansible: devel
 
     steps:

--- a/.github/workflows/ansible-test-roles.yml.off
+++ b/.github/workflows/ansible-test-roles.yml.off
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   molecule:
     name: "Molecule (Python: ${{ matrix.python }}, Ansible: ${{ matrix.ansible }}, MySQL: ${{ matrix.mysql }})"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1
@@ -24,15 +24,21 @@ jobs:
         mysql:
           - 2.0.12
         ansible:
-          - stable-2.13
-          - stable-2.14
           - stable-2.15
+          - stable-2.16
+          - stable-2.17
           - devel
         python:
           - '3.8'
           - '3.9'
           - '3.10'
         exclude:
+          - python: 3.8
+            ansible: stable-2.17
+
+          - python: 3.9
+            ansible: stable-2.17
+
           - python: 3.8
             ansible: devel
 

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,7 +1,7 @@
 ---
 name: Build Docker Image for ansible-test
 
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
       registry:

--- a/.github/workflows/docker-image-mariadb-py310-mysqlclient211.yml
+++ b/.github/workflows/docker-image-mariadb-py310-mysqlclient211.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mariadb-py310-mysqlclient211
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mariadb-py310-mysqlclient211/**'

--- a/.github/workflows/docker-image-mariadb-py310-pymysql102.yml
+++ b/.github/workflows/docker-image-mariadb-py310-pymysql102.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mariadb-py310-pymysql102
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mariadb-py310-pymysql102/**'

--- a/.github/workflows/docker-image-mariadb-py38-mysqlclient201.yml
+++ b/.github/workflows/docker-image-mariadb-py38-mysqlclient201.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mariadb-py38-mysqlclient201
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mariadb-py38-mysqlclient201/**'

--- a/.github/workflows/docker-image-mariadb-py38-pymysql093.yml
+++ b/.github/workflows/docker-image-mariadb-py38-pymysql093.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mariadb-py38-pymysql093
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mariadb-py38-pymysql093/**'

--- a/.github/workflows/docker-image-mariadb-py39-mysqlclient203.yml
+++ b/.github/workflows/docker-image-mariadb-py39-mysqlclient203.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mariadb-py39-mysqlclient203
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mariadb-py39-mysqlclient203/**'

--- a/.github/workflows/docker-image-mariadb-py39-pymysql093.yml
+++ b/.github/workflows/docker-image-mariadb-py39-pymysql093.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mariadb-py39-pymysql093
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mariadb-py39-pymysql093/**'

--- a/.github/workflows/docker-image-my57-py38-mysqlclient201.yml
+++ b/.github/workflows/docker-image-my57-py38-mysqlclient201.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI my57-py38-mysqlclient201
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/my57-py38-mysqlclient201/**'

--- a/.github/workflows/docker-image-my57-py38-pymysql0711.yml
+++ b/.github/workflows/docker-image-my57-py38-pymysql0711.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI my57-py38-pymysql0711
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/my57-py38-pymysql0711/**'

--- a/.github/workflows/docker-image-my57-py38-pymysql093.yml
+++ b/.github/workflows/docker-image-my57-py38-pymysql093.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI my57-py38-pymysql093
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/my57-py38-pymysql093/**'

--- a/.github/workflows/docker-image-mysql-py310-mysqlclient211.yml
+++ b/.github/workflows/docker-image-mysql-py310-mysqlclient211.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mysql-py310-mysqlclient211
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mysql-py310-mysqlclient211/**'

--- a/.github/workflows/docker-image-mysql-py310-pymysql102.yml
+++ b/.github/workflows/docker-image-mysql-py310-pymysql102.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mysql-py310-pymysql102
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mysql-py310-pymysql102/**'

--- a/.github/workflows/docker-image-mysql-py38-mysqlclient201.yml
+++ b/.github/workflows/docker-image-mysql-py38-mysqlclient201.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mysql-py38-mysqlclient201
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mysql-py38-mysqlclient201/**'

--- a/.github/workflows/docker-image-mysql-py38-pymysql093.yml
+++ b/.github/workflows/docker-image-mysql-py38-pymysql093.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mysql-py38-pymysql093
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mysql-py38-pymysql093/**'

--- a/.github/workflows/docker-image-mysql-py39-mysqlclient203.yml
+++ b/.github/workflows/docker-image-mysql-py39-mysqlclient203.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mysql-py39-mysqlclient203
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mysql-py39-mysqlclient203/**'

--- a/.github/workflows/docker-image-mysql-py39-pymysql093.yml
+++ b/.github/workflows/docker-image-mysql-py39-pymysql093.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker Image CI mysql-py39-pymysql093
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'test-containers/mysql-py39-pymysql093/*'

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Here is the table for the support timeline:
 
 ### ansible-core
 
-- stable-2.14
 - stable-2.15
 - stable-2.16
+- stable-2.17
 - current development version
 
 ### Databases

--- a/TESTING.md
+++ b/TESTING.md
@@ -49,11 +49,10 @@ The Makefile accept the following options
 - `ansible`
   - Mandatory: true
   - Choices:
-    - "stable-2.12"
-    - "stable-2.13"
     - "stable-2.14"
     - "stable-2.15"
     - "stable-2.16"
+    - "stable-2.17"
     - "devel"
   - Description: Version of ansible to install in a venv to run ansible-test
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -49,7 +49,6 @@ The Makefile accept the following options
 - `ansible`
   - Mandatory: true
   - Choices:
-    - "stable-2.14"
     - "stable-2.15"
     - "stable-2.16"
     - "stable-2.17"

--- a/tests/integration/targets/test_mysql_user/tasks/test_tls_requirements.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_tls_requirements.yml
@@ -76,14 +76,14 @@
           that:
             - "'SSL' in reqs"
         vars:
-          - reqs: "{{((old_result.results[0] is skipped | ternary(new_result, old_result)).results | selectattr('item', 'contains', user_name_1) | first).stdout.split('REQUIRE')[1].split(separator)[0].strip()}}"
+          reqs: "{{ ((old_result.results[0] is skipped | ternary(new_result, old_result)).results | selectattr('item', 'contains', user_name_1) | first).stdout.split('REQUIRE')[1].split(separator)[0].strip() }}"
 
       - name: Tls reqs | Assert user2 TLS requirements
         assert:
           that:
             - "'X509' in reqs"
         vars:
-          - reqs: "{{((old_result.results[0] is skipped | ternary(new_result, old_result)).results | selectattr('item', 'contains', user_name_2) | first).stdout.split('REQUIRE')[1].split(separator)[0].strip()}}"
+          reqs: "{{ ((old_result.results[0] is skipped | ternary(new_result, old_result)).results | selectattr('item', 'contains', user_name_2) | first).stdout.split('REQUIRE')[1].split(separator)[0].strip() }}"
 
       - name: Tls reqs | Assert user3 TLS requirements
         assert:
@@ -92,7 +92,7 @@
             - "'/CN=org/O=MyDom, Inc./C=US/ST=Oregon/L=Portland' in (reqs | select('contains', 'ISSUER') | first)"
             - "'ECDHE-ECDSA-AES256-SHA384' in (reqs | select('contains', 'CIPHER') | first)"
         vars:
-          - reqs: "{{((old_result.results[0] is skipped | ternary(new_result, old_result)).results | selectattr('item', 'contains', user_name_3) | first).stdout.split('REQUIRE')[1].split(separator)[0].replace(\"' \", \"':\").split(\":\")}}"
+          reqs: "{{ ((old_result.results[0] is skipped | ternary(new_result, old_result)).results | selectattr('item', 'contains', user_name_3) | first).stdout.split('REQUIRE')[1].split(separator)[0].replace(\"' \", \"':\").split(\":\") }}"
       # CentOS 6 uses an older version of jinja that does not provide the selectattr filter.
       when: ansible_distribution != 'CentOS' or ansible_distribution_major_version != '6'
 
@@ -129,7 +129,7 @@
       assert:
         that: "'SSL' in reqs"
       vars:
-        - reqs: "{{(old_result is skipped | ternary(new_result, old_result)).stdout.split('REQUIRE')[1].split(separator)[0].strip()}}"
+        reqs: "{{ (old_result is skipped | ternary(new_result, old_result)).stdout.split('REQUIRE')[1].split(separator)[0].strip() }}"
 
     - name: Tls reqs | Modify user with TLS requirements state=present (expect changed=true)
       mysql_user:
@@ -157,7 +157,7 @@
       assert:
         that: "'X509' in reqs"
       vars:
-        - reqs: "{{(old_result is skipped | ternary(new_result, old_result)).stdout.split('REQUIRE')[1].split(separator)[0].strip()}}"
+        reqs: "{{ (old_result is skipped | ternary(new_result, old_result)).stdout.split('REQUIRE')[1].split(separator)[0].strip() }}"
 
     - name: Tls reqs | Remove TLS requirements from user (expect changed=true)
       mysql_user:


### PR DESCRIPTION
##### SUMMARY
fix #622

Drop tests for Ansible-core 2.14 and add 2.17.

I had to upgrade from Ubuntu 20.04 to 22.04 to overcome the error:
```
ERROR: Command "docker run --tmpfs /tmp:exec --tmpfs /run:exec --tmpfs /run/lock --volume /var/run/docker.sock:/var/run/docker.sock --cgroupns host --tmpfs /sys/fs/cgroup --volume /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd:rw -dt --ulimit nofile=10240 --name ansible-test-controller-jP3nWvru --network github_network_aaa99831959740bca775ef73f797b985 '  '" returned exit status 125.
``` 
As a reminder, ubuntu 20.04 was forced because cgroup v2 wasn't supported by ansible 2.10, 2.11 and 2.12 (more info [here](https://github.com/ansible-collections/collection_template/blob/main/.github/workflows/ansible-test.yml#L83-L91). Since we dropped those versions we can now move on to the latest ubuntu.
Also latest ansible-test-gh-action doesn't work with ubuntu 20.04, so the upgrade is necessary.

I also updated some GitHub Action plugins to avoid warnings. But some warnings comes from ansible-community/ansible-test-gh-action@release/v1 which as this PR that will solve them when merged: https://github.com/ansible-community/ansible-test-gh-action/pull/80

Finally, I disabled the role tests because they were out of date and we don't use them anyway.

##### ISSUE TYPE
- Github action - Integration tests

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- Github action - Integration tests
