### PR TITLE
Enhance support of tls_requires in mysql_user and mysql_info

### DIFF
--- a/changelogs/fragments/mysql_user_tls_requires.yml
+++ b/changelogs/fragments/mysql_user_tls_requires.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - mysql_info - Fix ``tls_requires`` data structure to be compatible with ``mysql_user`` input.
+  - mysql_info - Fix module output variable for hashed password to use ``plugin_hash_string`` instead of ``plugin_auth_string``.
+  - mysql_user - Fix idempotence when using variables from the ``users_info`` filter of ``mysql_info``.
+  - mysql_user - Fix ``tls_requires`` not removing ``SSL`` and ``X509`` when passing an empty value.

--- a/changelogs/fragments/mysql_user_tls_requires.yml
+++ b/changelogs/fragments/mysql_user_tls_requires.yml
@@ -2,6 +2,5 @@
 minor_changes:
   - mysql_info - Add ``tls_requires`` returned value for the ``users_info`` filter (https://github.com/ansible-collections/community.mysql/pull/628).
 bugfixes:
-  - mysql_info - Fix ``users_info`` filter output variable for hashed password to use ``plugin_hash_string`` instead of ``plugin_auth_string`` (https://github.com/ansible-collections/community.mysql/pull/628).
   - mysql_user - Fix idempotence when using variables from the ``users_info`` filter of ``mysql_info`` as an input (https://github.com/ansible-collections/community.mysql/pull/628).
   - mysql_user - Fix ``tls_requires`` not removing ``SSL`` and ``X509`` when sets as empty (https://github.com/ansible-collections/community.mysql/pull/628).

--- a/changelogs/fragments/mysql_user_tls_requires.yml
+++ b/changelogs/fragments/mysql_user_tls_requires.yml
@@ -1,6 +1,6 @@
 ---
 bugfixes:
-  - mysql_info - Fix ``tls_requires`` data structure to be compatible with ``mysql_user`` input.
-  - mysql_info - Fix module output variable for hashed password to use ``plugin_hash_string`` instead of ``plugin_auth_string``.
-  - mysql_user - Fix idempotence when using variables from the ``users_info`` filter of ``mysql_info``.
-  - mysql_user - Fix ``tls_requires`` not removing ``SSL`` and ``X509`` when passing an empty value.
+  - mysql_info - Fix ``tls_requires`` data structure to be compatible with ``mysql_user`` input (https://github.com/ansible-collections/community.mysql/pull/628).
+  - mysql_info - Fix module output variable for hashed password to use ``plugin_hash_string`` instead of ``plugin_auth_string`` (https://github.com/ansible-collections/community.mysql/pull/628).
+  - mysql_user - Fix idempotence when using variables from the ``users_info`` filter of ``mysql_info`` (https://github.com/ansible-collections/community.mysql/pull/628).
+  - mysql_user - Fix ``tls_requires`` not removing ``SSL`` and ``X509`` when passing an empty value (https://github.com/ansible-collections/community.mysql/pull/628).

--- a/changelogs/fragments/mysql_user_tls_requires.yml
+++ b/changelogs/fragments/mysql_user_tls_requires.yml
@@ -1,6 +1,7 @@
 ---
+minor_changes:
+  - mysql_info - Add ``tls_requires`` returned value for the ``users_info`` filter (https://github.com/ansible-collections/community.mysql/pull/628).
 bugfixes:
-  - mysql_info - Fix ``tls_requires`` data structure to be compatible with ``mysql_user`` input (https://github.com/ansible-collections/community.mysql/pull/628).
-  - mysql_info - Fix module output variable for hashed password to use ``plugin_hash_string`` instead of ``plugin_auth_string`` (https://github.com/ansible-collections/community.mysql/pull/628).
-  - mysql_user - Fix idempotence when using variables from the ``users_info`` filter of ``mysql_info`` (https://github.com/ansible-collections/community.mysql/pull/628).
-  - mysql_user - Fix ``tls_requires`` not removing ``SSL`` and ``X509`` when passing an empty value (https://github.com/ansible-collections/community.mysql/pull/628).
+  - mysql_info - Fix ``users_info`` filter output variable for hashed password to use ``plugin_hash_string`` instead of ``plugin_auth_string`` (https://github.com/ansible-collections/community.mysql/pull/628).
+  - mysql_user - Fix idempotence when using variables from the ``users_info`` filter of ``mysql_info`` as an input (https://github.com/ansible-collections/community.mysql/pull/628).
+  - mysql_user - Fix ``tls_requires`` not removing ``SSL`` and ``X509`` when sets as empty (https://github.com/ansible-collections/community.mysql/pull/628).

--- a/plugins/module_utils/implementations/mariadb/user.py
+++ b/plugins/module_utils/implementations/mariadb/user.py
@@ -29,3 +29,47 @@ def server_supports_password_expire(cursor):
     version = get_server_version(cursor)
 
     return LooseVersion(version) >= LooseVersion("10.4.3")
+
+def get_tls_requires(cursor, user, host):
+    """Get user TLS requirements.
+    Reads directly from mysql.user table allowing for a more
+    readable code.
+
+    Args:
+        cursor (cursor): DB driver cursor object.
+        user (str): User name.
+        host (str): User host name.
+
+    Returns: Dictionary containing current TLS required
+    """
+    tls_requires = dict()
+
+    query = ('SELECT ssl_type, ssl_cipher, x509_issuer, x509_subject '
+             'FROM mysql.user WHERE User = %s AND Host = %s')
+    cursor.execute(query, (user, host))
+    res = cursor.fetchone()
+
+    # Mysql_info use a DictCursor so we must convert back to a list
+    # otherwise we get KeyError 0
+    if isinstance(res, dict):
+        res = list(res.values())
+
+    # When user don't require SSL, res value is: ('', '', '', '')
+    if not any(res):
+        return None
+
+    if res[0] == 'ANY':
+        tls_requires['SSL'] = None
+
+    if res[0] == 'X509':
+        tls_requires['X509'] = None
+
+    if res[1]:
+        tls_requires['CIPHER'] = res[1]
+
+    if res[2]:
+        tls_requires['ISSUER'] = res[2]
+
+    if res[3]:
+        tls_requires['SUBJECT'] = res[3]
+    return tls_requires

--- a/plugins/module_utils/implementations/mariadb/user.py
+++ b/plugins/module_utils/implementations/mariadb/user.py
@@ -30,6 +30,7 @@ def server_supports_password_expire(cursor):
 
     return LooseVersion(version) >= LooseVersion("10.4.3")
 
+
 def get_tls_requires(cursor, user, host):
     """Get user TLS requirements.
     Reads directly from mysql.user table allowing for a more

--- a/plugins/module_utils/implementations/mysql/user.py
+++ b/plugins/module_utils/implementations/mysql/user.py
@@ -34,6 +34,7 @@ def server_supports_password_expire(cursor):
 
     return LooseVersion(version) >= LooseVersion("5.7")
 
+
 def get_tls_requires(cursor, user, host):
     """Get user TLS requirements.
     We must use SHOW GRANTS because some tls fileds are encoded.

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -119,10 +119,10 @@ def get_existing_authentication(cursor, user, host):
         rows = list(rows.values())
 
     if isinstance(rows[0], tuple):
-        return {'plugin': rows[0][0], 'plugin_auth_string': rows[0][1]}
+        return {'plugin': rows[0][0], 'plugin_hash_string': rows[0][1]}
 
     if isinstance(rows[0], dict):
-        return {'plugin': rows[0].get('plugin'), 'plugin_auth_string': rows[0].get('auth')}
+        return {'plugin': rows[0].get('plugin'), 'plugin_hash_string': rows[0].get('auth')}
     return None
 
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -119,10 +119,10 @@ def get_existing_authentication(cursor, user, host):
         rows = list(rows.values())
 
     if isinstance(rows[0], tuple):
-        return {'plugin': rows[0][0], 'plugin_hash_string': rows[0][1]}
+        return {'plugin': rows[0][0], 'plugin_auth_string': rows[0][1]}
 
     if isinstance(rows[0], dict):
-        return {'plugin': rows[0].get('plugin'), 'plugin_hash_string': rows[0].get('auth')}
+        return {'plugin': rows[0].get('plugin'), 'plugin_auth_string': rows[0].get('auth')}
     return None
 
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -102,14 +102,15 @@ def get_tls_requires(cursor, user, host):
     if isinstance(res, dict):
         res = list(res.values())
 
-    if not res:
+    # When user don't require SSL, res value is: ('', '', '', '')
+    if not any(res):
         return None
 
     if res[0] == 'ANY':
-        return {'SSL': ''}
+        return 'SSL'
 
     if res[0] == 'X509':
-        return {'X509': ''}
+        return 'X509'
 
     if res[1]:
         tls_requires['CIPHER'] = res[1]

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -240,7 +240,8 @@ users_info:
       "host": "host.com",
       "plugin": "mysql_native_password",
       "priv": "db1.*:SELECT/db2.*:SELECT",
-      "resource_limits": { "MAX_USER_CONNECTIONS": 100 } }
+      "resource_limits": { "MAX_USER_CONNECTIONS": 100 }
+      "tls_requires": {"SSL": null} }
   version_added: '3.8.0'
 engines:
   description: Information about the server's storage engines.

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -240,8 +240,8 @@ users_info:
       "host": "host.com",
       "plugin": "mysql_native_password",
       "priv": "db1.*:SELECT/db2.*:SELECT",
-      "resource_limits": { "MAX_USER_CONNECTIONS": 100 }
-      "tls_requires": {"SSL": null} }
+      "resource_limits": { "MAX_USER_CONNECTIONS": 100 },
+      "tls_requires": { "SSL": null } }
   version_added: '3.8.0'
 engines:
   description: Information about the server's storage engines.

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -230,7 +230,7 @@ users_info:
     - Does not support proxy privileges. If an account has proxy privileges, they won't appear in the output.
     - Causes issues with authentications plugins C(sha256_password) and C(caching_sha2_password).
       If the output is fed to M(community.mysql.mysql_user), the
-      ``plugin_hash_string`` will most likely be unreadable due to non-binary
+      ``plugin_auth_string`` will most likely be unreadable due to non-binary
       characters.
   returned: if not excluded by filter
   type: dict

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -301,6 +301,7 @@ from ansible_collections.community.mysql.plugins.module_utils.user import (
     get_resource_limits,
     get_existing_authentication,
     get_tls_requires,
+    sanitize_requires,
 )
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
@@ -612,7 +613,7 @@ class MySQL_Info(object):
                 'host': host,
                 'priv': '/'.join(priv_string),
                 'resource_limits': copy_ressource_limits,
-                'tls_requires': tls_requires,
+                'tls_requires': sanitize_requires(tls_requires),
             }
 
             # Prevent returning a resource limit if empty

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -300,6 +300,7 @@ from ansible_collections.community.mysql.plugins.module_utils.user import (
     privileges_get,
     get_resource_limits,
     get_existing_authentication,
+    get_tls_requires,
 )
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
@@ -602,13 +603,16 @@ class MySQL_Info(object):
                 priv_string.remove('*.*:USAGE')
 
             resource_limits = get_resource_limits(self.cursor, user, host)
-
             copy_ressource_limits = dict.copy(resource_limits)
+
+            tls_requires = get_tls_requires(self.cursor, user, host)
+
             output_dict = {
                 'name': user,
                 'host': host,
                 'priv': '/'.join(priv_string),
                 'resource_limits': copy_ressource_limits,
+                'tls_requires': tls_requires,
             }
 
             # Prevent returning a resource limit if empty
@@ -618,6 +622,10 @@ class MySQL_Info(object):
                         del output_dict['resource_limits'][key]
                 if len(output_dict['resource_limits']) == 0:
                     del output_dict['resource_limits']
+
+            # Prevent returning tls_require if empty
+            if not tls_requires:
+                del output_dict['tls_requires']
 
             authentications = get_existing_authentication(self.cursor, user, host)
             if authentications:

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -230,7 +230,7 @@ users_info:
     - Does not support proxy privileges. If an account has proxy privileges, they won't appear in the output.
     - Causes issues with authentications plugins C(sha256_password) and C(caching_sha2_password).
       If the output is fed to M(community.mysql.mysql_user), the
-      ``plugin_auth_string`` will most likely be unreadable due to non-binary
+      ``plugin_hash_string`` will most likely be unreadable due to non-binary
       characters.
   returned: if not excluded by filter
   type: dict

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -146,7 +146,7 @@ EXAMPLES = r'''
       plugin: "{{ item.plugin | default(omit) }}"
       plugin_auth_string: "{{ item.plugin_auth_string | default(omit) }}"
       plugin_hash_string: "{{ item.plugin_hash_string | default(omit) }}"
-      tls_require: "{{ item.tls_require | default(omit) }}"
+      tls_requires: "{{ item.tls_requires | default(omit) }}"
       priv: "{{ item.priv | default(omit) }}"
       resource_limits: "{{ item.resource_limits | default(omit) }}"
       column_case_sensitive: true

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -309,7 +309,7 @@ from ansible_collections.community.mysql.plugins.module_utils.mysql import (
 )
 from ansible_collections.community.mysql.plugins.module_utils.user import (
     convert_priv_dict_to_str,
-    get_impl,
+    get_user_implementation,
     get_mode,
     user_mod,
     privileges_grant,
@@ -1054,7 +1054,7 @@ def main():
     # Set defaults
     changed = False
 
-    get_impl(cursor)
+    impl = get_user_implementation(cursor)
 
     if priv is not None:
         try:

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -401,7 +401,6 @@ from ansible_collections.community.mysql.plugins.module_utils.mysql import (
 )
 from ansible_collections.community.mysql.plugins.module_utils.user import (
     convert_priv_dict_to_str,
-    get_impl,
     get_mode,
     InvalidPrivsError,
     limit_resources,
@@ -527,8 +526,6 @@ def main():
 
     if session_vars:
         set_session_vars(module, cursor, session_vars)
-
-    get_impl(cursor)
 
     if priv is not None:
         try:

--- a/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
@@ -47,7 +47,7 @@
         state: import
         target: /root/create_procedure.sql
 
-    # Use a query instead of mysql_user, because we want to caches differences
+    # Use a query instead of mysql_user, because we want to catch differences
     # at the end and a bug in mysql_user would be invisible to this tests
     - name: Mysql_info users_info | Prepare common tests users
       community.mysql.mysql_query:
@@ -147,6 +147,69 @@
             '*CB3326D5279DE7915FE5D743232165EE887883CA'
           - GRANT SELECT ON users_info_db.* TO users_info_multi_hosts@'host2'
 
+          - >-
+            CREATE USER users_info_ssl_off@'host'
+            IDENTIFIED WITH mysql_native_password AS
+            '*CB3326D5279DE7915FE5D743232165EE887883CA' REQUIRE NONE
+          - GRANT SELECT ON users_info_db.* TO users_info_ssl_off@'host'
+
+          - >-
+            CREATE USER users_info_ssl@'host'
+            IDENTIFIED WITH mysql_native_password AS
+            '*CB3326D5279DE7915FE5D743232165EE887883CA' REQUIRE SSL
+          - GRANT SELECT ON users_info_db.* TO users_info_ssl@'host'
+
+          - >-
+            CREATE USER users_info_ssl_cipher@'host'
+            IDENTIFIED WITH mysql_native_password AS
+            '*CB3326D5279DE7915FE5D743232165EE887883CA'
+            REQUIRE CIPHER 'ECDH-RSA-AES256-SHA384'
+          - GRANT SELECT ON users_info_db.* TO users_info_ssl_cipher@'host'
+
+          - >-
+            CREATE USER users_info_x509@'host'
+            IDENTIFIED WITH mysql_native_password AS
+            '*CB3326D5279DE7915FE5D743232165EE887883CA' REQUIRE X509
+          - GRANT SELECT ON users_info_db.* TO users_info_x509@'host'
+
+          - >-
+            CREATE USER users_info_ssl_subject@'host'
+            IDENTIFIED WITH mysql_native_password AS
+            '*CB3326D5279DE7915FE5D743232165EE887883CA'
+            REQUIRE SUBJECT '/CN=Bob/O=MyDom/C=US/ST=Oregon/L=Portland'
+          - GRANT SELECT ON users_info_db.* TO users_info_ssl_subject@'host'
+
+          - >-
+            CREATE USER users_info_ssl_issuer@'host'
+            IDENTIFIED WITH mysql_native_password AS
+            '*CB3326D5279DE7915FE5D743232165EE887883CA'
+            REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/
+            O=CompanyX/CN=Bob/emailAddress=bob@companyx.com'
+          - GRANT SELECT ON users_info_db.* TO users_info_ssl_issuer@'host'
+
+          - >-
+            CREATE USER users_info_subject_ssl_issuer@'host'
+            IDENTIFIED WITH mysql_native_password AS
+            '*CB3326D5279DE7915FE5D743232165EE887883CA'
+            REQUIRE SUBJECT '/CN=Bob/O=MyDom/C=US/ST=Oregon/L=Portland'
+            AND ISSUER '/C=FI/ST=Somewhere/L=City/
+            O=CompanyX/CN=Bob/emailAddress=bob@companyx.com'
+          - >-
+            GRANT SELECT ON users_info_db.*
+            TO users_info_subject_ssl_issuer@'host'
+
+          - >-
+            CREATE USER users_info_ssl_sub_issu_ciph@'host'
+            IDENTIFIED WITH mysql_native_password AS
+            '*CB3326D5279DE7915FE5D743232165EE887883CA'
+            REQUIRE SUBJECT '/CN=Bob/O=MyDom/C=US/ST=Oregon/L=Portland'
+            AND ISSUER '/C=FI/ST=Somewhere/L=City/
+            O=CompanyX/CN=Bob/emailAddress=bob@companyx.com'
+            AND CIPHER 'ECDH-RSA-AES256-SHA384'
+          - >-
+            GRANT SELECT ON users_info_db.*
+            TO users_info_ssl_sub_issu_ciph@'host'
+
     - name: Mysql_info users_info | Prepare tests users for MariaDB
       community.mysql.mysql_user:
         name: "{{ item.name }}"
@@ -237,7 +300,9 @@
         label: "{{ item.name }}@{{ item.host }}"
       register: recreate_users_result
       failed_when:
-        - recreate_users_result is changed
+        - >-
+          recreate_users_result is changed or
+          recreate_users_result.msg != 'User unchanged'
       when:
         - item.name != 'root'
         - item.name != 'mysql'

--- a/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
@@ -148,47 +148,47 @@
           - GRANT SELECT ON users_info_db.* TO users_info_multi_hosts@'host2'
 
           - >-
-            CREATE USER users_info_ssl_off@'host'
+            CREATE USER users_info_tls_none@'host'
             IDENTIFIED WITH mysql_native_password AS
             '*CB3326D5279DE7915FE5D743232165EE887883CA' REQUIRE NONE
-          - GRANT SELECT ON users_info_db.* TO users_info_ssl_off@'host'
+          - GRANT SELECT ON users_info_db.* TO users_info_tls_none@'host'
 
           - >-
-            CREATE USER users_info_ssl@'host'
+            CREATE USER users_info_tls_ssl@'host'
             IDENTIFIED WITH mysql_native_password AS
             '*CB3326D5279DE7915FE5D743232165EE887883CA' REQUIRE SSL
-          - GRANT SELECT ON users_info_db.* TO users_info_ssl@'host'
+          - GRANT SELECT ON users_info_db.* TO users_info_tls_ssl@'host'
 
           - >-
-            CREATE USER users_info_ssl_cipher@'host'
+            CREATE USER users_info_tls_cipher@'host'
             IDENTIFIED WITH mysql_native_password AS
             '*CB3326D5279DE7915FE5D743232165EE887883CA'
             REQUIRE CIPHER 'ECDH-RSA-AES256-SHA384'
-          - GRANT SELECT ON users_info_db.* TO users_info_ssl_cipher@'host'
+          - GRANT SELECT ON users_info_db.* TO users_info_tls_cipher@'host'
 
           - >-
-            CREATE USER users_info_x509@'host'
+            CREATE USER users_info_tls_x509@'host'
             IDENTIFIED WITH mysql_native_password AS
             '*CB3326D5279DE7915FE5D743232165EE887883CA' REQUIRE X509
-          - GRANT SELECT ON users_info_db.* TO users_info_x509@'host'
+          - GRANT SELECT ON users_info_db.* TO users_info_tls_x509@'host'
 
           - >-
-            CREATE USER users_info_ssl_subject@'host'
+            CREATE USER users_info_tls_subject@'host'
             IDENTIFIED WITH mysql_native_password AS
             '*CB3326D5279DE7915FE5D743232165EE887883CA'
             REQUIRE SUBJECT '/CN=Bob/O=MyDom/C=US/ST=Oregon/L=Portland'
-          - GRANT SELECT ON users_info_db.* TO users_info_ssl_subject@'host'
+          - GRANT SELECT ON users_info_db.* TO users_info_tls_subject@'host'
 
           - >-
-            CREATE USER users_info_ssl_issuer@'host'
+            CREATE USER users_info_tls_issuer@'host'
             IDENTIFIED WITH mysql_native_password AS
             '*CB3326D5279DE7915FE5D743232165EE887883CA'
             REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/
             O=CompanyX/CN=Bob/emailAddress=bob@companyx.com'
-          - GRANT SELECT ON users_info_db.* TO users_info_ssl_issuer@'host'
+          - GRANT SELECT ON users_info_db.* TO users_info_tls_issuer@'host'
 
           - >-
-            CREATE USER users_info_subject_ssl_issuer@'host'
+            CREATE USER users_info_tls_subject_issuer@'host'
             IDENTIFIED WITH mysql_native_password AS
             '*CB3326D5279DE7915FE5D743232165EE887883CA'
             REQUIRE SUBJECT '/CN=Bob/O=MyDom/C=US/ST=Oregon/L=Portland'
@@ -196,10 +196,10 @@
             O=CompanyX/CN=Bob/emailAddress=bob@companyx.com'
           - >-
             GRANT SELECT ON users_info_db.*
-            TO users_info_subject_ssl_issuer@'host'
+            TO users_info_tls_subject_issuer@'host'
 
           - >-
-            CREATE USER users_info_ssl_sub_issu_ciph@'host'
+            CREATE USER users_info_tls_sub_issu_ciph@'host'
             IDENTIFIED WITH mysql_native_password AS
             '*CB3326D5279DE7915FE5D743232165EE887883CA'
             REQUIRE SUBJECT '/CN=Bob/O=MyDom/C=US/ST=Oregon/L=Portland'
@@ -208,7 +208,7 @@
             AND CIPHER 'ECDH-RSA-AES256-SHA384'
           - >-
             GRANT SELECT ON users_info_db.*
-            TO users_info_ssl_sub_issu_ciph@'host'
+            TO users_info_tls_sub_issu_ciph@'host'
 
     - name: Mysql_info users_info | Prepare tests users for MariaDB
       community.mysql.mysql_user:

--- a/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
@@ -154,7 +154,7 @@
         plugin: "{{ item.plugin | default(omit) }}"
         plugin_auth_string: "{{ item.plugin_auth_string | default(omit) }}"
         plugin_hash_string: "{{ item.plugin_hash_string | default(omit) }}"
-        tls_require: "{{ item.tls_require | default(omit) }}"
+        tls_requires: "{{ item.tls_requires | default(omit) }}"
         priv: "{{ item.priv }}"
         resource_limits: "{{ item.resource_limits | default(omit) }}"
         column_case_sensitive: true
@@ -174,7 +174,7 @@
         plugin: "{{ item.plugin | default(omit) }}"
         plugin_auth_string: "{{ item.plugin_auth_string | default(omit) }}"
         plugin_hash_string: "{{ item.plugin_hash_string | default(omit) }}"
-        tls_require: "{{ item.tls_require | default(omit) }}"
+        tls_requires: "{{ item.tls_requires | default(omit) }}"
         priv: "{{ item.priv }}"
         resource_limits: "{{ item.resource_limits | default(omit) }}"
         column_case_sensitive: true
@@ -196,7 +196,7 @@
         plugin: "{{ item.plugin | default(omit) }}"
         plugin_auth_string: "{{ item.plugin_auth_string | default(omit) }}"
         plugin_hash_string: "{{ item.plugin_hash_string | default(omit) }}"
-        tls_require: "{{ item.tls_require | default(omit) }}"
+        tls_requires: "{{ item.tls_requires | default(omit) }}"
         priv: "{{ item.priv }}"
         resource_limits: "{{ item.resource_limits | default(omit) }}"
         column_case_sensitive: true
@@ -227,7 +227,7 @@
         plugin: "{{ item.plugin | default(omit) }}"
         plugin_auth_string: "{{ item.plugin_auth_string | default(omit) }}"
         plugin_hash_string: "{{ item.plugin_hash_string | default(omit) }}"
-        tls_require: "{{ item.tls_require | default(omit) }}"
+        tls_requires: "{{ item.tls_requires | default(omit) }}"
         priv: "{{ item.priv | default(omit) }}"
         resource_limits: "{{ item.resource_limits | default(omit) }}"
         column_case_sensitive: true

--- a/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
@@ -330,6 +330,14 @@
         - users_info_usage_only
         - users_info_columns_uppercase
         - users_info_multi_hosts
+        - users_info_tls_none
+        - users_info_tls_ssl
+        - users_info_tls_cipher
+        - users_info_tls_x509
+        - users_info_tls_subject
+        - users_info_tls_issuer
+        - users_info_tls_subject_issuer
+        - users_info_tls_sub_issu_ciph
 
     - name: Mysql_info users_info | Cleanup databases
       community.mysql.mysql_db:

--- a/tests/unit/plugins/modules/test_mysql_info.py
+++ b/tests/unit/plugins/modules/test_mysql_info.py
@@ -16,10 +16,10 @@ from ansible_collections.community.mysql.plugins.modules.mysql_info import MySQL
 @pytest.mark.parametrize(
     'suffix,cursor_output,server_implementation,user_implementation',
     [
-        ('mysql', '5.5.1-mysql', 'mysql','mysql'),
-        ('log', '5.7.31-log', 'mysql','mysql'),
-        ('mariadb', '10.5.0-mariadb', 'mariadb','mariadb'),
-        ('', '8.0.22', 'mysql','mysql'),
+        ('mysql', '5.5.1-mysql', 'mysql', 'mysql'),
+        ('log', '5.7.31-log', 'mysql', 'mysql'),
+        ('mariadb', '10.5.0-mariadb', 'mariadb', 'mariadb'),
+        ('', '8.0.22', 'mysql', 'mysql'),
     ]
 )
 def test_get_info_suffix(suffix, cursor_output, server_implementation, user_implementation):

--- a/tests/unit/plugins/modules/test_mysql_info.py
+++ b/tests/unit/plugins/modules/test_mysql_info.py
@@ -14,15 +14,15 @@ from ansible_collections.community.mysql.plugins.modules.mysql_info import MySQL
 
 
 @pytest.mark.parametrize(
-    'suffix,cursor_output,server_implementation',
+    'suffix,cursor_output,server_implementation,user_implementation',
     [
-        ('mysql', '5.5.1-mysql', 'mysql'),
-        ('log', '5.7.31-log', 'mysql'),
-        ('mariadb', '10.5.0-mariadb', 'mariadb'),
-        ('', '8.0.22', 'mysql'),
+        ('mysql', '5.5.1-mysql', 'mysql','mysql'),
+        ('log', '5.7.31-log', 'mysql','mysql'),
+        ('mariadb', '10.5.0-mariadb', 'mariadb','mariadb'),
+        ('', '8.0.22', 'mysql','mysql'),
     ]
 )
-def test_get_info_suffix(suffix, cursor_output, server_implementation):
+def test_get_info_suffix(suffix, cursor_output, server_implementation, user_implementation):
     def __cursor_return_value(input_parameter):
         if input_parameter == "SHOW GLOBAL VARIABLES":
             cursor.fetchall.return_value = [{"Variable_name": "version", "Value": cursor_output}]
@@ -32,6 +32,6 @@ def test_get_info_suffix(suffix, cursor_output, server_implementation):
     cursor = MagicMock()
     cursor.execute.side_effect = __cursor_return_value
 
-    info = MySQL_Info(MagicMock(), cursor, server_implementation)
+    info = MySQL_Info(MagicMock(), cursor, server_implementation, user_implementation)
 
     assert info.get_info([], [], False)['version']['suffix'] == suffix


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I refactored the `get_tls_requires` method with separate implementations for MySQL and MariaDB.
The solution for MariaDB turned out to be incompatible with MySQL.

I fixed the integration tests for `mysql_info` and added test users with TLS to assert that everything is working correctly.

This chang enable using the output of `mysql_info: {filter: users_info}` and passing it to `mysql_user` to achieve idempotent execution even if the user has TLS options.

I encountered an issue with MySQL 8 refusing to remove SSL and X509 when `tls_requires` was passed an empty value. I'm unsure why this test passed previously. Perhaps it was due to adding a sanitized method during this PR? I admit that I didn't put much effort into MySQL (even though it consumes 80% of my time...). I hope I successfully fixed that too.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_user, mysql_info

##### EXEMPLES
Using `mysql_info` with community.mysql 3.9.0:
```yaml
users_info:
    - host: localhost
      name: user_ssl
      plugin: mysql_native_password
      plugin_auth_string: '*7D2ABFF56C15D67445082FBB4ACD2DCD26C0ED57'
      priv: '*.*:USAGE'
```

Using `mysql_info` with this PR:
```yaml
users_info:
    - host: localhost
      name: user_ssl
      plugin: mysql_native_password
      plugin_auth_string: '*7D2ABFF56C15D67445082FBB4ACD2DCD26C0ED57'
      priv: '*.*:USAGE'
      tls_requires:  # <----------------------------------------- New
        SSL: null       # <----------------------------------------- New

```