### PR TITLE
Fix hashed passwords being returned by get_existing_authentication() via the plugin_auth_string variable instead of plugin_hash_string

### DIFF
--- a/changelogs/fragments/lie_fix_plugin_hash_string_return.yml
+++ b/changelogs/fragments/lie_fix_plugin_hash_string_return.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - mysql_info - Fix ``users_info`` filter output variable for hashed password to use ``plugin_hash_string`` instead of ``plugin_auth_string`` (https://github.com/ansible-collections/community.mysql/pull/629).

--- a/changelogs/fragments/lie_fix_plugin_hash_string_return.yml
+++ b/changelogs/fragments/lie_fix_plugin_hash_string_return.yml
@@ -1,3 +1,6 @@
 ---
 bugfixes:
   - mysql_info - Add ``plugin_hash_string`` to ``users_info`` filter's output. The existing ``plugin_auth_string`` contained the hashed password and thus is missleading, it will be removed from community.mysql 4.0.0. (https://github.com/ansible-collections/community.mysql/pull/629).
+
+breaking_changes:
+  - mysql_info - The ``users_info`` filter returned variable ``plugin_auth_string`` contains the hashed password and it's misleading, it will be removed from community.mysql 4.0.0. Use the `plugin_hash_string` return value instead (https://github.com/ansible-collections/community.mysql/pull/629).

--- a/changelogs/fragments/lie_fix_plugin_hash_string_return.yml
+++ b/changelogs/fragments/lie_fix_plugin_hash_string_return.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - mysql_info - Fix ``users_info`` filter output variable for hashed password to use ``plugin_hash_string`` instead of ``plugin_auth_string`` (https://github.com/ansible-collections/community.mysql/pull/629).
+  - mysql_info - Add ``plugin_hash_string`` to ``users_info`` filter's output. The existing ``plugin_auth_string`` contained the hashed password and thus is missleading, it will be removed from community.mysql 4.0.0. (https://github.com/ansible-collections/community.mysql/pull/629).

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -118,11 +118,21 @@ def get_existing_authentication(cursor, user, host):
     if isinstance(rows, dict):
         rows = list(rows.values())
 
+    # 'plugin_auth_string' contains the hash string. Must be removed in c.mysql 4.0
+    # See https://github.com/ansible-collections/community.mysql/pull/629
     if isinstance(rows[0], tuple):
-        return {'plugin': rows[0][0], 'plugin_hash_string': rows[0][1]}
+        return {'plugin': rows[0][0],
+                'plugin_auth_string': rows[0][1],
+                'plugin_hash_string': rows[0][1]
+        }
 
+    # 'plugin_auth_string' contains the hash string. Must be removed in c.mysql 4.0
+    # See https://github.com/ansible-collections/community.mysql/pull/629
     if isinstance(rows[0], dict):
-        return {'plugin': rows[0].get('plugin'), 'plugin_hash_string': rows[0].get('auth')}
+        return {'plugin': rows[0].get('plugin'),
+                'plugin_auth_string': rows[0].get('auth'),
+                'plugin_hash_string': rows[0].get('auth')
+        }
     return None
 
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -123,16 +123,14 @@ def get_existing_authentication(cursor, user, host):
     if isinstance(rows[0], tuple):
         return {'plugin': rows[0][0],
                 'plugin_auth_string': rows[0][1],
-                'plugin_hash_string': rows[0][1]
-        }
+                'plugin_hash_string': rows[0][1]}
 
     # 'plugin_auth_string' contains the hash string. Must be removed in c.mysql 4.0
     # See https://github.com/ansible-collections/community.mysql/pull/629
     if isinstance(rows[0], dict):
         return {'plugin': rows[0].get('plugin'),
                 'plugin_auth_string': rows[0].get('auth'),
-                'plugin_hash_string': rows[0].get('auth')
-        }
+                'plugin_hash_string': rows[0].get('auth')}
     return None
 
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -162,7 +162,7 @@ def user_add(cursor, user, host, host_all, password, encrypted,
         existing_auth = get_existing_authentication(cursor, user, host)
         if existing_auth:
             plugin = existing_auth['plugin']
-            plugin_hash_string = existing_auth['auth_string']
+            plugin_hash_string = existing_auth['plugin_hash_string']
             password = None
             used_existing_password = True
     if password and encrypted:

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -143,10 +143,10 @@ def get_existing_authentication(cursor, user, host):
         rows = list(rows.values())
 
     if isinstance(rows[0], tuple):
-        return {'plugin': rows[0][0], 'plugin_auth_string': rows[0][1]}
+        return {'plugin': rows[0][0], 'plugin_hash_string': rows[0][1]}
 
     if isinstance(rows[0], dict):
-        return {'plugin': rows[0].get('plugin'), 'plugin_auth_string': rows[0].get('auth')}
+        return {'plugin': rows[0].get('plugin'), 'plugin_hash_string': rows[0].get('auth')}
     return None
 
 

--- a/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
@@ -186,7 +186,7 @@
           - users_info
       register: result
 
-    - name: Recreate users from mysql_info users_info result
+    - name: Mysql_info users_info | Recreate users from mysql_info result
       community.mysql.mysql_user:
         name: "{{ item.name }}"
         host: "{{ item.host }}"

--- a/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/filter_users_info.yml
@@ -148,66 +148,32 @@
           - GRANT SELECT ON users_info_db.* TO users_info_multi_hosts@'host2'
 
     - name: Mysql_info users_info | Prepare tests users for MariaDB
-      community.mysql.mysql_user:
-        name: "{{ item.name }}"
-        host: "users_info.com"
-        plugin: "{{ item.plugin | default(omit) }}"
-        plugin_auth_string: "{{ item.plugin_auth_string | default(omit) }}"
-        plugin_hash_string: "{{ item.plugin_hash_string | default(omit) }}"
-        tls_require: "{{ item.tls_require | default(omit) }}"
-        priv: "{{ item.priv }}"
-        resource_limits: "{{ item.resource_limits | default(omit) }}"
-        column_case_sensitive: true
-        state: present
-      loop:
-        - name: users_info_socket  # Only for MariaDB
-          priv:
-            '*.*': 'ALL'
-          plugin: 'unix_socket'
+      community.mysql.mysql_query:
+        query:
+          - >-
+            CREATE USER users_info_socket@'users_info.com' IDENTIFIED WITH
+            unix_socket
+          - GRANT ALL ON *.* to users_info_socket@'users_info.com'
       when:
         - db_engine == 'mariadb'
 
     - name: Mysql_info users_info | Prepare tests users for MySQL
-      community.mysql.mysql_user:
-        name: "{{ item.name }}"
-        host: "users_info.com"
-        plugin: "{{ item.plugin | default(omit) }}"
-        plugin_auth_string: "{{ item.plugin_auth_string | default(omit) }}"
-        plugin_hash_string: "{{ item.plugin_hash_string | default(omit) }}"
-        tls_require: "{{ item.tls_require | default(omit) }}"
-        priv: "{{ item.priv }}"
-        resource_limits: "{{ item.resource_limits | default(omit) }}"
-        column_case_sensitive: true
-        state: present
-      loop:
-        - name: users_info_sha256  # Only for MySQL
-          priv:
-            '*.*': 'ALL'
-          plugin_auth_string:
-            '$5$/<w*D`L4\"F$WQiI1Pev.7atAh8udYs3wqlzgdfV8LXoy7rqSEC7NF2'
-          plugin: 'sha256_password'
+      community.mysql.mysql_query:
+        query:
+          - >-
+            CREATE USER users_info_sha256@'users_info.com' IDENTIFIED WITH
+            sha256_password BY 'msandbox'
+          - GRANT ALL ON *.* to users_info_sha256@'users_info.com'
       when:
         - db_engine == 'mysql'
 
     - name: Mysql_info users_info | Prepare tests users for MySQL 8+
-      community.mysql.mysql_user:
-        name: "{{ item.name }}"
-        host: "users_info.com"
-        plugin: "{{ item.plugin | default(omit) }}"
-        plugin_auth_string: "{{ item.plugin_auth_string | default(omit) }}"
-        plugin_hash_string: "{{ item.plugin_hash_string | default(omit) }}"
-        tls_require: "{{ item.tls_require | default(omit) }}"
-        priv: "{{ item.priv }}"
-        resource_limits: "{{ item.resource_limits | default(omit) }}"
-        column_case_sensitive: true
-        state: present
-      loop:
-        - name: users_info_caching_sha2  # Only for MySQL 8+
-          priv:
-            '*.*': 'ALL'
-          plugin_auth_string:
-            '$A$005$61j/uF%Qb4-=O2xkeO82u2HNkF.lxDq0liO4U3xqi7bDUCbWM6HayRXWn1'
-          plugin: 'caching_sha2_password'
+      community.mysql.mysql_query:
+        query:
+          - >-
+            CREATE USER users_info_caching_sha2@'users_info.com' IDENTIFIED WITH
+            caching_sha2_password BY 'msandbox'
+          - GRANT ALL ON *.* to users_info_caching_sha2@'users_info.com'
       when:
         - db_engine == 'mysql'
         - db_version is version('8.0', '>=')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix hashed passwords being returned by `get_existing_authentication()` via the `plugin_auth_string` variable instead of `plugin_hash_string`. This method is used in `user_add()`, which doesn't seem appropriate. I would have expected to find it in `user_mod()` instead. I hope it is never used and doesn't require to treat this PR as a major_change.
The only other place where `get_existing_authentication()` is used is in `mysql_info` while utilizing the `users_info` filter introduced in 3.8.0 (#580). Since this feature is relatively new, I don't expect it to have widespread usage yet.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This doesn't f-i-x #621 but the issue was reported there. It makes more sense to use the right variable anyway.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_user, mysql_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Using `mysql_info` with community.mysql 3.9.0:
```yaml
users_info:
    - host: localhost
      name: root
      plugin: mysql_native_password
      plugin_auth_string: '*7D2ABFF56C15D67445082FBB4ACD2DCD26C0ED57'
      priv: '*.*:ALL,GRANT'
```

Using `mysql_info` with this PR:
```yaml
users_info:
    - host: localhost
      name: root
      plugin: mysql_native_password
      plugin_hash_string: '*7D2ABFF56C15D67445082FBB4ACD2DCD26C0ED57'  # <------ Fixed
      priv: '*.*:ALL,GRANT'

```
