### PR TITLE
Improve get replica/primary status

### DIFF
--- a/changelogs/fragments/improve_get_replica_primary_status.yml
+++ b/changelogs/fragments/improve_get_replica_primary_status.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+
+  - mysql_replication - Improve detection of IsReplica and IsPrimary by inspecting the dictionary returned from the SQL query instead of relying on variable types. This ensures compatibility with changes in the connector or the output of SHOW REPLICA STATUS and SHOW MASTER STATUS, allowing for easier maintenance if these change in the future.

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -560,10 +560,10 @@ def main():
 
     elif mode == "getreplica":
         status = get_replica_status(cursor, connection_name, channel, replica_term)
-        if not isinstance(status, dict):
-            status = dict(Is_Replica=False, msg="Server is not configured as mysql replica")
-        else:
+        if status and "Slave_IO_Running" in status and "Slave_SQL_Running" in status:
             status['Is_Replica'] = True
+        else:
+            status = dict(Is_Replica=False, msg="Server is not configured as mysql replica")
 
         module.exit_json(queries=executed_queries, **status)
 

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -550,11 +550,13 @@ def main():
 
     if mode == 'getprimary':
         status = get_primary_status(cursor)
-        if not isinstance(status, dict):
-            status = dict(Is_Primary=False,
-                          msg="Server is not configured as mysql primary")
-        else:
+        if status and "File" in status and "Position" in status:
             status['Is_Primary'] = True
+        else:
+            status = dict(
+                Is_Primary=False,
+                msg="Server is not configured as mysql primary. "
+                    "Meaning: Binary logs are disabled")
 
         module.exit_json(queries=executed_queries, **status)
 

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -560,7 +560,11 @@ def main():
 
     elif mode == "getreplica":
         status = get_replica_status(cursor, connection_name, channel, replica_term)
-        if status and "Slave_IO_Running" in status and "Slave_SQL_Running" in status:
+        # MySQL 8.0 uses Replica_...
+        # MariaDB 10.6 uses Slave_...
+        if status and (
+                "Slave_IO_Running" in status or
+                "Replica_IO_Running" in status):
             status['Is_Replica'] = True
         else:
             status = dict(Is_Replica=False, msg="Server is not configured as mysql replica")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Getting the Replica/Primary status rely on testing that `cursor.fetchone()` returned a dict. To prevent case were fetchone returns a dict also in case of failure, I added tests for keys inside the dictionary.

For **getreplica**, since MariaDB and MySQL doesn't have the same variables, I searched for both Slave_IO_Running and Replica_IO_Running.

for **getprimary**, the output would be the same on a primary or a replica with binary log enabled. This is confusing with the term `is_primary` so I added "Meaning: Binary logs are disabled" to the returned message.
I searched for "file" and "Position" in the output that is luckily the same for MariaDB and MySQL:
```
mysql> show master status\G
*************************** 1. row ***************************
             File: binlog.000003
         Position: 157
     Binlog_Do_DB: 
 Binlog_Ignore_DB: 
Executed_Gtid_Set: 
1 row in set (0.00 sec)
```

This PR changes nothing and may even break in the future is MySQL or MariaDB changes the term used in the output of the command `show replica status` or `show master status`. But this will makes us aware of the change.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_replication

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
