### PR TITLE
Adds support for `CHANGE REPLICATION SOURCE TO` statement

### DIFF
--- a/changelogs/fragments/supports_mysql_change_replication_source_to.yml
+++ b/changelogs/fragments/supports_mysql_change_replication_source_to.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - mysql_replication - Adds support for `CHANGE REPLICATION SOURCE TO` statement (https://github.com/ansible-collections/community.mysql/issues/635).

--- a/tests/integration/targets/test_mysql_replication/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/main.yml
@@ -25,3 +25,8 @@
 - import_tasks: mysql_replication_resetprimary_mode.yml
 
 - include_tasks: issue-28.yml
+
+# Tests of changereplication mode:
+- import_tasks: mysql_replication_changereplication_mode.yml
+  when:
+    - db_engine == 'mysql'

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_changereplication_mode.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_changereplication_mode.yml
@@ -1,0 +1,65 @@
+---
+
+- vars:
+    mysql_params: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+
+  block:
+    # Get primary log file and log pos:
+    - name: Get primary status
+      mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_primary_port }}'
+        mode: getprimary
+      register: mysql_primary_status
+
+    # Test changereplication mode:
+    - name: Run replication
+      mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        mode: changereplication
+        primary_host: '{{ mysql_host }}'
+        primary_port: '{{ mysql_primary_port }}'
+        primary_user: '{{ replication_user }}'
+        primary_password: '{{ replication_pass }}'
+        primary_log_file: '{{ mysql_primary_status.File }}'
+        primary_log_pos: '{{ mysql_primary_status.Position }}'
+        primary_ssl_ca: ''
+        primary_ssl: no
+      register: result
+
+    - name: Assert that changereplication is changed and return expected query
+      assert:
+        that:
+          - result is changed
+          - result.queries == expected_queries
+      vars:
+        expected_queries: ["CHANGE REPLICATION SOURCE TO SOURCE_HOST='{{ mysql_host }}',\
+          SOURCE_USER='{{ replication_user }}',SOURCE_PASSWORD='********',\
+          SOURCE_PORT={{ mysql_primary_port }},SOURCE_LOG_FILE=\
+          '{{ mysql_primary_status.File }}',SOURCE_LOG_POS=\
+          {{ mysql_primary_status.Position }},SOURCE_SSL=0,SOURCE_SSL_CA=''"]
+
+    # Test changereplication mode with channel:
+    - name: Run replication
+      mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        mode: changereplication
+        primary_user: '{{ replication_user }}'
+        primary_password: '{{ replication_pass }}'
+        channel: '{{ test_channel }}'
+        
+      register: with_channel_result_queries
+
+    - name: Assert that changereplication is changed and is called correctly with channel
+      assert:
+        that:
+          - with_channel_result_queries is changed
+          - with_channel_result_queries.queries == expected_queries
+      vars:
+        expected_queries: ["CHANGE REPLICATION SOURCE TO SOURCE_USER='{{ replication_user }}',\
+          SOURCE_PASSWORD='********' FOR CHANNEL '{{ test_channel }}'"]

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -318,5 +318,5 @@
     - name: Assert that stopslave returns expected error message
       assert:
         that:
-          - result.msg == "value of mode must be one of{{ ":" }} getprimary, getreplica, changeprimary, stopreplica, startreplica, resetprimary, resetreplica, resetreplicaall, got{{ ":" }} stopslave"
+          - result.msg == "value of mode must be one of{{ ":" }} getprimary, getreplica, changeprimary, stopreplica, startreplica, resetprimary, resetreplica, resetreplicaall, changereplication, got{{ ":" }} stopslave"
           - result is failed


### PR DESCRIPTION
##### SUMMARY
Adds new mode for `community.mysql.mysql_replication` module.

This new mode adds support for MySQL `CHANGE SOURCE REPLICATION TO` statement.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`mysql_replication`

##### ADDITIONAL INFORMATION
MySQL `CHANGE MASTER TO` statement was deprecated. [Doc](https://dev.mysql.com/doc/refman/8.0/en/change-replication-source-to.html)

I didn´t found a respective statement for MariaDB that replaces `CHANGE MASTER TO`. [List of MariaDB commands](https://mariadb.com/kb/en/replication-commands/)

Resolves #635