### PR TITLE
Adds support for show binary log status statement

### DIFF
--- a/changelogs/fragments/get_primary_show_binary_log_status.yml
+++ b/changelogs/fragments/get_primary_show_binary_log_status.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
 
-  - mysql_replication - Adds support for `SHOW BINARY LOG STATUS` on getprimary mode.
+  - mysql_replication - Adds support for `SHOW BINARY LOG STATUS` and `SHOW BINLOG STATUS` on getprimary mode.

--- a/changelogs/fragments/get_primary_show_binary_log_status.yml
+++ b/changelogs/fragments/get_primary_show_binary_log_status.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+
+  - mysql_replication - Adds support for `SHOW BINARY LOG STATUS` on getprimary mode.

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -316,8 +316,12 @@ def get_primary_status(cursor):
     term = "MASTER"
 
     version = get_server_version(cursor)
-    if get_server_implementation(cursor) == "mysql" and LooseVersion(version) >= LooseVersion("8.2.0"):
+    server_implementation = get_server_implementation(cursor)
+    if server_implementation == "mysql" and LooseVersion(version) >= LooseVersion("8.2.0"):
         term = "BINARY LOG"
+
+    if server_implementation == "mariadb" and LooseVersion(version) >= LooseVersion("10.5.2"):
+        term = "BINLOG"
 
     cursor.execute("SHOW %s STATUS" % term)
 

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -297,8 +297,11 @@ queries:
 import os
 import warnings
 
+from ansible_collections.community.mysql.plugins.module_utils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.mysql.plugins.module_utils.mysql import (
+    get_server_version,
+    get_server_implementation,
     mysql_connect,
     mysql_driver,
     mysql_driver_fail_msg,
@@ -310,10 +313,14 @@ executed_queries = []
 
 
 def get_primary_status(cursor):
-    # TODO: when it's available to change on MySQL's side,
-    # change MASTER to PRIMARY using the approach from
-    # get_replica_status() function. Same for other functions.
-    cursor.execute("SHOW MASTER STATUS")
+    term = "MASTER"
+
+    version = get_server_version(cursor)
+    if get_server_implementation(cursor) == "mysql" and LooseVersion(version) >= LooseVersion("8.2.0"):
+        term = "BINARY LOG"
+
+    cursor.execute("SHOW %s STATUS" % term)
+
     primarystatus = cursor.fetchone()
     return primarystatus
 


### PR DESCRIPTION
##### SUMMARY
Adds support for show binary log status statement.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`mysql_replication`

##### ADDITIONAL INFORMATION
`SHOW MASTER STATUS` was replaced by `SHOW BINARY LOG STATUS`. [Doc](https://dev.mysql.com/doc/refman/8.3/en/show-binary-log-status.html)
