### PR TITLE
Fix mysql_user on_new_username IndexError

### DIFF
--- a/changelogs/fragments/lie_fix_mysql_user_on_new_username.yml
+++ b/changelogs/fragments/lie_fix_mysql_user_on_new_username.yml
@@ -1,0 +1,6 @@
+---
+
+bugfixes:
+
+  - mysql_user - Fixed an IndexError in the update_password functionality introduced in PR https://github.com/ansible-collections/community.mysql/pull/580 and released in community.mysql 3.8.0. If you used this functionality, please avoid versions 3.8.0 to 3.9.0.
+  - mysql_user - Added a warning to update_password's on_new_username option if multiple accounts with the same username but different passwords exist.

--- a/changelogs/fragments/lie_fix_mysql_user_on_new_username.yml
+++ b/changelogs/fragments/lie_fix_mysql_user_on_new_username.yml
@@ -2,5 +2,5 @@
 
 bugfixes:
 
-  - mysql_user - Fixed an IndexError in the update_password functionality introduced in PR https://github.com/ansible-collections/community.mysql/pull/580 and released in community.mysql 3.8.0. If you used this functionality, please avoid versions 3.8.0 to 3.9.0.
-  - mysql_user - Added a warning to update_password's on_new_username option if multiple accounts with the same username but different passwords exist.
+  - mysql_user - Fixed an IndexError in the update_password functionality introduced in PR https://github.com/ansible-collections/community.mysql/pull/580 and released in community.mysql 3.8.0. If you used this functionality, please avoid versions 3.8.0 to 3.9.0 (https://github.com/ansible-collections/community.mysql/pull/642).
+  - mysql_user - Added a warning to update_password's on_new_username option if multiple accounts with the same username but different passwords exist (https://github.com/ansible-collections/community.mysql/pull/642).

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -139,26 +139,20 @@ def get_existing_authentication(cursor, user, host=None):
     if len(rows) == 0:
         return []
 
-    # Mysql_info use a DictCursor so we must convert back to a list
-    # otherwise we get KeyError 0
-    if isinstance(rows, dict):
-        rows = list(rows.values())
+    # Mysql_info use a DictCursor so we must convert list(dict)
+    # to list(tuple) otherwise we get KeyError 0
+    if isinstance(rows[0], dict):
+        rows = [tuple(row.values()) for row in rows]
 
     existing_auth_list = []
 
     # 'plugin_auth_string' contains the hash string. Must be removed in c.mysql 4.0
     # See https://github.com/ansible-collections/community.mysql/pull/629
     for r in rows:
-        if isinstance(r, tuple):
-            existing_auth_list.append({
-                'plugin': r[0],
-                'plugin_auth_string': r[1],
-                'plugin_hash_string': r[1]})
-        elif isinstance(r, dict):
-            existing_auth_list.append({
-                'plugin': r.get('plugin'),
-                'plugin_auth_string': r.get('auth'),
-                'plugin_hash_string': r.get('auth')})
+        existing_auth_list.append({
+            'plugin': r[0],
+            'plugin_auth_string': r[1],
+            'plugin_hash_string': r[1]})
 
     return existing_auth_list
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -189,9 +189,7 @@ def user_add(cursor, user, host, host_all, password, encrypted,
     if reuse_existing_password:
         existing_auth = get_existing_authentication(cursor, user)
         if existing_auth:
-            pass_hashes = [p['plugin_hash_string'] for p in existing_auth]
-            # Use a set to check if all values are the same
-            if len(set(pass_hashes)) != 1:
+            if len(existing_auth) != 1:
                 module.warn("An account with the username %s has a different "
                             "password than the others existing accounts. Thus "
                             "on_new_username can't decide which password to "

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -201,7 +201,7 @@ def user_add(cursor, user, host, host_all, password, encrypted,
                 plugin_hash_string = existing_auth[0]['plugin_hash_string']
                 password = None
                 used_existing_password = True
-            plugin = existing_auth[0]['plugin']  # What if plugin differ?
+                plugin = existing_auth[0]['plugin']  # What if plugin differ?
     if password and encrypted:
         if impl.supports_identified_by_password(cursor):
             query_with_args = "CREATE USER %s@%s IDENTIFIED BY PASSWORD %s", (user, host, password)

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -90,7 +90,11 @@ def get_grants(cursor, user, host):
 
 
 def get_existing_authentication(cursor, user, host):
-    # Return the plugin and auth_string if there is exactly one distinct existing plugin and auth_string.
+    """ Return a list of dict containing the plugin and auth_string for the
+    specified username.
+    If hostname is provided, return only the information about this particular
+    account.
+    """
     cursor.execute("SELECT VERSION()")
     srv_type = cursor.fetchone()
     # Mysql_info use a DictCursor so we must convert back to a list
@@ -114,27 +118,30 @@ def get_existing_authentication(cursor, user, host):
     rows = cursor.fetchall()
 
     if len(rows) == 0:
-        return None
+        return []
 
     # Mysql_info use a DictCursor so we must convert back to a list
     # otherwise we get KeyError 0
     if isinstance(rows, dict):
         rows = list(rows.values())
 
-    # 'plugin_auth_string' contains the hash string. Must be removed in c.mysql 4.0
-    # See https://github.com/ansible-collections/community.mysql/pull/629
-    if isinstance(rows[0], tuple):
-        return {'plugin': rows[0][0],
-                'plugin_auth_string': rows[0][1],
-                'plugin_hash_string': rows[0][1]}
+    existing_auth_list = []
 
     # 'plugin_auth_string' contains the hash string. Must be removed in c.mysql 4.0
     # See https://github.com/ansible-collections/community.mysql/pull/629
-    if isinstance(rows[0], dict):
-        return {'plugin': rows[0].get('plugin'),
-                'plugin_auth_string': rows[0].get('auth'),
-                'plugin_hash_string': rows[0].get('auth')}
-    return None
+    for r in rows:
+        if isinstance(r, tuple):
+            existing_auth_list.append({
+                'plugin': r[0],
+                'plugin_auth_string': r[1],
+                'plugin_hash_string': r[1]})
+        elif isinstance(r, dict):
+            existing_auth_list.append({
+                'plugin': r.get('plugin'),
+                'plugin_auth_string': r.get('auth'),
+                'plugin_hash_string': r.get('auth')})
+
+    return existing_auth_list
 
 
 def user_add(cursor, user, host, host_all, password, encrypted,
@@ -158,14 +165,26 @@ def user_add(cursor, user, host, host_all, password, encrypted,
 
     mogrify = do_not_mogrify_requires if old_user_mgmt else mogrify_requires
 
+    # This is for update_password: on_new_username
     used_existing_password = False
     if reuse_existing_password:
         existing_auth = get_existing_authentication(cursor, user, host)
         if existing_auth:
-            plugin = existing_auth['plugin']
-            plugin_hash_string = existing_auth['plugin_hash_string']
-            password = None
-            used_existing_password = True
+            pass_hashes = [p['plugin_hash_string'] for p in existing_auth]
+            # Use a set to check if all values are the same
+            if len(set(pass_hashes)) != 1:
+                module.warn("An account with the username %s has a different "
+                            "password than the others existing accounts. Thus "
+                            "on_new_username can't decide which password to "
+                            "reuse so it will use your provided password "
+                            "instead. If no password is provided, the account "
+                            "will have an empty password!" % user)
+                used_existing_password = False
+            else:
+                plugin_hash_string = existing_auth[0]['plugin_hash_string']
+                password = None
+                used_existing_password = True
+            plugin = existing_auth[0]['plugin']  # What if plugin differ?
     if password and encrypted:
         if impl.supports_identified_by_password(cursor):
             query_with_args = "CREATE USER %s@%s IDENTIFIED BY PASSWORD %s", (user, host, password)

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -113,6 +113,9 @@ def get_existing_authentication(cursor, user, host):
             group by plugin, authentication_string limit 2""", {'user': user, 'host': host})
     rows = cursor.fetchall()
 
+    if len(rows) == 0:
+        return None
+
     # Mysql_info use a DictCursor so we must convert back to a list
     # otherwise we get KeyError 0
     if isinstance(rows, dict):

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -633,7 +633,7 @@ class MySQL_Info(object):
 
             authentications = get_existing_authentication(self.cursor, user, host)
             if authentications:
-                output_dict.update(authentications)
+                output_dict.update(authentications[0])
 
             # TODO password_option
             # TODO lock_option

--- a/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
@@ -3,7 +3,7 @@
   command: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
   register: result
 - set_fact:
-    tls_enabled: "{{ 'YES' in result.stdout | bool | default('false', true) }}"
+    tls_enabled: "{{ 'YES' in result.stdout }}"
 
 - vars:
     mysql_parameters: &mysql_params

--- a/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
@@ -3,7 +3,7 @@
   command: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
   register: result
 - set_fact:
-    tls_enabled: "{{ 'YES' in result.stdout }}"
+    tls_enabled: "{{ 'YES' in result.stdout | bool | default('false', true) }}"
 
 - vars:
     mysql_parameters: &mysql_params

--- a/tests/integration/targets/test_mysql_user/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/main.yml
@@ -295,3 +295,7 @@
     - name: Mysql_user - test column case sensitive
       ansible.builtin.import_tasks:
         file: test_column_case_sensitive.yml
+
+    - name: Mysql_user - test update_password
+      ansible.builtin.import_tasks:
+        file: test_update_password.yml

--- a/tests/integration/targets/test_mysql_user/tasks/test_update_password.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_update_password.yml
@@ -127,3 +127,25 @@
           update_password: on_create
         - username: test3
           update_password: on_new_username
+
+    # another new user, another new password and multiple existing users with
+    # varying passwords without providing a password
+    - name: update_password | Create account with on_new_username while omit password
+      community.mysql.mysql_user:
+        login_user: '{{ mysql_parameters.login_user }}'
+        login_password: '{{ mysql_parameters.login_password }}'
+        login_host: '{{ mysql_parameters.login_host }}'
+        login_port: '{{ mysql_parameters.login_port }}'
+        state: present
+        name: test3
+        host: '10.10.10.10'
+        update_password: on_new_username
+
+    - name: update_password | Assert create account with on_new_username while omit password produce empty auth string
+      ansible.builtin.command: >-
+        {{ mysql_command }} -BNe "SELECT user, host, plugin, authentication_string
+        FROM mysql.user where user='test3' and host='10.10.10.10'"
+      register: test3_info
+      changed_when: false
+      failed_when:
+        - "'test3\t10.10.10.10\tmysql_native_password\t' != test3_info.stdout"

--- a/tests/integration/targets/test_mysql_user/tasks/test_update_password.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_update_password.yml
@@ -148,4 +148,8 @@
       register: test3_info
       changed_when: false
       failed_when:
+        # MariaDB default plugin is mysql_native_password
         - "'test3\t10.10.10.10\tmysql_native_password\t' != test3_info.stdout"
+
+        # MySQL 8+ default plugin is caching_sha2_password
+        - "'test3\t10.10.10.10\tcaching_sha2_password\t' != test3_info.stdout"

--- a/tests/integration/targets/test_mysql_user/tasks/utils/assert_user_password.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/utils/assert_user_password.yml
@@ -1,6 +1,6 @@
 ---
 - name: Utils | Assert user password | Apply update_password to {{ username }}
-  mysql_user:
+  community.mysql.mysql_user:
     login_user: '{{ mysql_parameters.login_user }}'
     login_password: '{{ mysql_parameters.login_password }}'
     login_host: '{{ mysql_parameters.login_host }}'
@@ -13,16 +13,17 @@
   register: result
 
 - name: Utils | Assert user password | Assert a change occurred
-  assert:
+  ansible.builtin.assert:
     that:
-      - "result.changed | bool == {{ expect_change }} | bool"
-      - "result.password_changed == {{ expect_password_change }}"
+      - result.changed | bool == expect_change | bool
+      - result.password_changed == expect_password_change
 
-- name: Utils | Assert user password | Query user {{ username }}
-  command: "{{ mysql_command }} -BNe \"SELECT plugin, authentication_string FROM mysql.user where user='{{ username }}' and host='{{ host }}'\""
+- name: Utils | Assert user password | Assert expect_hash is in user stdout for {{ username }}
+  ansible.builtin.command: >-
+    {{ mysql_command }} -BNe "SELECT plugin, authentication_string
+    FROM mysql.user where user='{{ username }}' and host='{{ host }}'"
   register: existing_user
-
-- name: Utils | Assert user password | Assert expect_hash is in user stdout
-  assert:
-    that:
-      - "'mysql_native_password\t{{ expect_password_hash }}' in existing_user.stdout_lines"
+  changed_when: false
+  failed_when: pattern not in existing_user.stdout_lines
+  vars:
+    pattern: "mysql_native_password\t{{ expect_password_hash }}"

--- a/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
@@ -6,7 +6,7 @@
 
 - name: Set tls_enabled fact
   ansible.builtin.set_fact:
-    tls_enabled: "{{ 'YES' in result.stdout }}"
+    tls_enabled: "{{ 'YES' in result.stdout | bool | default('false', true) }}"
 
 - vars:
     mysql_parameters: &mysql_params

--- a/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
@@ -1,9 +1,12 @@
 ---
 - name: set fact tls_enabled
-  command: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
+  ansible.builtin.command:
+    cmd: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
   register: result
-- set_fact:
-    tls_enabled: "{{ 'YES' in result.stdout | bool | default('false', true) }}"
+
+- name: Set tls_enabled fact
+  ansible.builtin.set_fact:
+    tls_enabled: "{{ 'YES' in result.stdout }}"
 
 - vars:
     mysql_parameters: &mysql_params
@@ -16,21 +19,21 @@
 
     # ============================================================
     - name: get server certificate
-      copy:
+      ansible.builtin.copy:
         content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
         dest: /tmp/cert.pem
       delegate_to: localhost
 
     - name: Drop mysql user if exists
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ user_name_1 }}'
         host_all: true
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: create user with ssl requirement
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: "{{ user_name_1 }}"
         host: '%'
@@ -40,7 +43,7 @@
           SSL:
 
     - name: attempt connection with newly created user (expect failure)
-      mysql_variables:
+      community.mysql.mysql_variables:
         variable: '{{ set_name }}'
         login_user: '{{ user_name_1 }}'
         login_password: '{{ user_password_1 }}'
@@ -48,22 +51,24 @@
         login_port: '{{ mysql_primary_port }}'
         ca_cert: /tmp/cert.pem
       register: result
-      ignore_errors: yes
+      ignore_errors: true
 
-    - assert:
+    - name: Assert that result is failed for pymysql
+      ansible.builtin.assert:
         that:
           - result is failed
       when:
         - connector_name == 'pymysql'
 
-    - assert:
+    - name: Assert that result is success for mysqlclient
+      ansible.builtin.assert:
         that:
           - result is succeeded
       when:
         - connector_name != 'pymysql'
 
     - name: attempt connection with newly created user ignoring hostname
-      mysql_variables:
+      community.mysql.mysql_variables:
         variable: '{{ set_name }}'
         login_user: '{{ user_name_1 }}'
         login_password: '{{ user_password_1 }}'
@@ -72,14 +77,12 @@
         ca_cert: /tmp/cert.pem
         check_hostname: no
       register: result
-      ignore_errors: yes
-
-    - assert:
-        that:
-          - result is succeeded or 'pymysql >= 0.7.11 is required' in result.msg
+      ignore_errors: true
+      failed_when:
+        - result is failed or 'pymysql >= 0.7.11 is required' not in result.msg
 
     - name: Drop mysql user
-      mysql_user:
+      community.mysql.mysql_user:
         <<: *mysql_params
         name: '{{ user_name_1 }}'
         host_all: true

--- a/tests/integration/targets/test_mysql_variables/tasks/mysql_variables.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/mysql_variables.yml
@@ -47,8 +47,8 @@
     # Verify mysql_variable successfully updates a variable (issue:4568)
     #
     - set_fact:
-         set_name: 'delay_key_write'
-         set_value: 'ON'
+        set_name: 'delay_key_write'
+        set_value: 'ON'
 
     - name: set mysql variable
       mysql_variables:
@@ -74,8 +74,8 @@
     # Verify mysql_variable successfully updates a variable using single quotes
     #
     - set_fact:
-         set_name: 'wait_timeout'
-         set_value: '300'
+        set_name: 'wait_timeout'
+        set_value: '300'
 
     - name: set mysql variable to a temp value
       mysql_variables:
@@ -105,8 +105,8 @@
     # Verify mysql_variable successfully updates a variable using double quotes
     #
     - set_fact:
-         set_name: "wait_timeout"
-         set_value: "400"
+        set_name: "wait_timeout"
+        set_value: "400"
 
     - name: set mysql variable to a temp value
       mysql_variables:
@@ -132,8 +132,8 @@
     # Verify mysql_variable successfully updates a variable using no quotes
     #
     - set_fact:
-         set_name: wait_timeout
-         set_value: 500
+        set_name: wait_timeout
+        set_value: 500
 
     - name: set mysql variable to a temp value
       mysql_variables:
@@ -251,8 +251,8 @@
     # Verify mysql_variable works with the login_user and login_password parameters
     #
     - set_fact:
-         set_name: wait_timeout
-         set_value: 77
+        set_name: wait_timeout
+        set_value: 77
 
     - name: query mysql_variable using login_user and password_password
       mysql_variables:
@@ -291,8 +291,8 @@
     # Verify mysql_variable fails with an incorrect login_password parameter
     #
     - set_fact:
-         set_name: connect_timeout
-         set_value: 10
+        set_name: connect_timeout
+        set_value: 10
 
     - name: query mysql_variable using incorrect login_password
       mysql_variables:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
  - mysql_user - Fixed an IndexError in the update_password functionality introduced in PR https://github.com/ansible-collections/community.mysql/pull/580 and released in community.mysql 3.8.0. If you used this functionality, please avoid versions 3.8.0 to 3.9.0.
  - mysql_user - Added a warning to update_password's on_new_username option if multiple accounts with the same username but different passwords exist.
- Enable the integration tests for the `update_password` functionality of `mysql_user`. Weirdly, they were never included in the `main.yml` fail.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #641

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- module_utils
- mysql_user
- mysql_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
