### PR TITLE
mysql_info: add server_engine return value

### DIFF
--- a/changelogs/fragments/1-mysql_info.yml
+++ b/changelogs/fragments/1-mysql_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_info - return a database server engine used (https://github.com/ansible-collections/community.mysql/issues/644).

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -162,6 +162,12 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
+server_engine:
+  description: Database server engine.
+  returned: if not excluded by filter
+  type: str
+  sample: 'mariadb'
+  version_added: '3.10.0'
 version:
   description: Database server version.
   returned: if not excluded by filter
@@ -765,6 +771,7 @@ def main():
     mysql = MySQL_Info(module, cursor, server_implementation, user_implementation)
 
     module.exit_json(changed=False,
+                     server_engine=server_implementation,
                      connector_name=connector_name,
                      connector_version=connector_version,
                      **mysql.get_info(filter_, exclude_fields, return_empty_dbs))

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -166,7 +166,7 @@ server_engine:
   description: Database server engine.
   returned: if not excluded by filter
   type: str
-  sample: 'mariadb'
+  sample: 'MariaDB'
   version_added: '3.10.0'
 version:
   description: Database server version.
@@ -771,7 +771,7 @@ def main():
     mysql = MySQL_Info(module, cursor, server_implementation, user_implementation)
 
     module.exit_json(changed=False,
-                     server_engine=server_implementation,
+                     server_engine='MariaDB' if server_implementation == 'mariadb' else 'MySQL',
                      connector_name=connector_name,
                      connector_version=connector_version,
                      **mysql.get_info(filter_, exclude_fields, return_empty_dbs))

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -56,7 +56,7 @@
           - result.databases != {}
           - result.engines != {}
           - result.users != {}
-          - result.server_engine == 'mysql' or result.server_engine == 'mariadb'
+          - result.server_engine == 'MariaDB' or result.server_engine == 'MySQL'
 
     - name: mysql_info - Test connector informations display
       ansible.builtin.import_tasks:

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -56,6 +56,7 @@
           - result.databases != {}
           - result.engines != {}
           - result.users != {}
+          - result.server_engine == 'mysql' or result.server_engine == 'mariadb'
 
     - name: mysql_info - Test connector informations display
       ansible.builtin.import_tasks:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.mysql/issues/644

To me it seems OK as is but I'm not sure 100% if
- it's OK now
- or we should choose another name for a key instead of `server_engine`
- or/and if we should properly capitalize the returned values, i.e. mysql -> MySQL and mariadb -> MariaDB

Thoughts? If you're OK, just approve the PR