### PR TITLE
[CI] Add 2024 versions to tests

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -275,9 +275,9 @@ jobs:
             repl1_conf='[mysqld]\\nserver-id=2\\nlog-bin=/var/lib/mysql/replica1-bin'
             repl2_conf='[mysqld]\\nserver-id=3\\nlog-bin=/var/lib/mysql/replica2-bin'
           fi
-          docker exec ${{ job.services.db_primary.id }} bash -c 'echo -e $prima_conf > /etc/mysql/conf.d/replication.cnf'
-          docker exec ${{ job.services.db_replica1.id }} bash -c 'echo -e $repl1_conf > /etc/mysql/conf.d/replication.cnf'
-          docker exec ${{ job.services.db_replica2.id }} bash -c 'echo -e $repl2_conf > /etc/mysql/conf.d/replication.cnf'
+          docker exec -e cnf=$prima_conf ${{ job.services.db_primary.id }} bash -c 'echo -e $cnf > /etc/mysql/conf.d/replication.cnf'
+          docker exec -e cnf=$repl1_conf ${{ job.services.db_replica1.id }} bash -c 'echo -e $cnf > /etc/mysql/conf.d/replication.cnf'
+          docker exec -e cnf=$repl2_conf ${{ job.services.db_replica2.id }} bash -c 'echo -e $cnf > /etc/mysql/conf.d/replication.cnf'
           docker restart -t 30 ${{ job.services.db_primary.id }}
           docker restart -t 30 ${{ job.services.db_replica1.id }}
           docker restart -t 30 ${{ job.services.db_replica2.id }}

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -275,9 +275,9 @@ jobs:
             repl1_conf='[mysqld]\\nserver-id=2\\nlog-bin=/var/lib/mysql/replica1-bin'
             repl2_conf='[mysqld]\\nserver-id=3\\nlog-bin=/var/lib/mysql/replica2-bin'
           fi
-          docker exec -e cnf=$prima_conf ${{ job.services.db_primary.id }} bash -c 'echo -e $cnf > /etc/mysql/conf.d/replication.cnf'
-          docker exec -e cnf=$repl1_conf ${{ job.services.db_replica1.id }} bash -c 'echo -e $cnf > /etc/mysql/conf.d/replication.cnf'
-          docker exec -e cnf=$repl2_conf ${{ job.services.db_replica2.id }} bash -c 'echo -e $cnf > /etc/mysql/conf.d/replication.cnf'
+          docker exec -e cnf=$prima_conf ${{ job.services.db_primary.id }} bash -c 'echo -e ${cnf//\\n/\n} > /etc/mysql/conf.d/replication.cnf'
+          docker exec -e cnf=$repl1_conf ${{ job.services.db_replica1.id }} bash -c 'echo -e ${cnf//\\n/\n} > /etc/mysql/conf.d/replication.cnf'
+          docker exec -e cnf=$repl2_conf ${{ job.services.db_replica2.id }} bash -c 'echo -e ${cnf//\\n/\n} > /etc/mysql/conf.d/replication.cnf'
           docker restart -t 30 ${{ job.services.db_primary.id }}
           docker restart -t 30 ${{ job.services.db_replica1.id }}
           docker restart -t 30 ${{ job.services.db_replica2.id }}

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -271,6 +271,7 @@ jobs:
             echo -n "${{ matrix.ansible }}"
             > tests/integration/ansible
           testing-type: integration
+          integration-retry-on-error: false
 
   units:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -63,7 +63,6 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
-          - '3.12'
         connector_name:
           - pymysql
           - mysqlclient
@@ -136,9 +135,6 @@ jobs:
             python: '3.11'
 
           - db_engine_version: '10.4.34'
-            python: '3.12'
-
-          - db_engine_version: '10.4.34'
             ansible: devel
 
           - db_engine_version: '10.6.18'
@@ -184,18 +180,6 @@ jobs:
             connector_version: '2.0.1'
 
           - python: '3.11'
-            connector_version: '2.0.3'
-
-          - python: '3.12'
-            connector_version: '0.9.3'
-
-          - python: '3.12'
-            connector_version: '1.0.2'
-
-          - python: '3.12'
-            connector_version: '2.0.1'
-
-          - python: '3.12'
             connector_version: '2.0.3'
 
           - python: '3.8'
@@ -347,7 +331,6 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
-          - '3.12'
         exclude:
           - python: '3.8'
             ansible: stable-2.16
@@ -377,12 +360,6 @@ jobs:
             ansible: stable-2.15
 
           - python: '3.11'
-            ansible: stable-2.16
-
-          - python: '3.12'
-            ansible: stable-2.15
-
-          - python: '3.12'
             ansible: stable-2.16
 
     steps:

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -53,16 +53,11 @@ jobs:
           - mariadb
         db_engine_version:
           - '8.0.38'
-          # - '8.4.1'  # Unable to install mysql-client on Ubuntu 20.04 default container used by ansible-test
+          - '8.4.1'
           - '10.4.34'
           - '10.5.25'
           - '10.6.18'
           - '10.11.8'
-        python:
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
         connector_name:
           - pymysql
           - mysqlclient
@@ -78,7 +73,6 @@ jobs:
           # RHEL8 context
           - connector_name: pymysql
             connector_version: '0.10.1'
-            python: '3.6'
             ansible: stable-2.16
             db_engine_name: mariadb
             db_engine_version: '10.11.8'
@@ -86,7 +80,6 @@ jobs:
           # RHEL9 context
           - connector_name: pymysql
             connector_version: '1.1.1'
-            python: '3.9'
             ansible: stable-2.17
             db_engine_name: mariadb
             db_engine_version: '10.11.8'
@@ -125,79 +118,7 @@ jobs:
           - connector_name: mysqlclient
             connector_version: '1.0.2'
 
-          - db_engine_version: '8.4.1'
-            python: '3.8'
-
           - db_engine_version: '10.4.34'
-            python: '3.10'
-
-          - db_engine_version: '10.4.34'
-            python: '3.11'
-
-          - db_engine_version: '10.4.34'
-            ansible: devel
-
-          - db_engine_version: '10.6.18'
-            python: '3.8'
-
-          - db_engine_version: '10.6.18'
-            python: '3.9'
-
-          - python: '3.8'
-            connector_version: '1.0.2'
-
-          - python: '3.8'
-            connector_version: '2.0.3'
-
-          - python: '3.8'
-            connector_version: '2.1.1'
-
-          - python: '3.9'
-            connector_version: '1.0.2'
-
-          - python: '3.9'
-            connector_version: '2.0.1'
-
-          - python: '3.9'
-            connector_version: '2.1.1'
-
-          - python: '3.10'
-            connector_version: '0.9.3'
-
-          - python: '3.10'
-            connector_version: '2.0.1'
-
-          - python: '3.10'
-            connector_version: '2.0.3'
-
-          - python: '3.11'
-            connector_version: '0.9.3'
-
-          - python: '3.11'
-            connector_version: '1.0.2'
-
-          - python: '3.11'
-            connector_version: '2.0.1'
-
-          - python: '3.11'
-            connector_version: '2.0.3'
-
-          - python: '3.8'
-            ansible: stable-2.16
-
-          - python: '3.8'
-            ansible: stable-2.17
-
-          - python: '3.8'
-            ansible: devel
-
-          - python: '3.9'
-            ansible: stable-2.16
-
-          - python: '3.9'
-            ansible: stable-2.17
-
-          - python: '3.9'
             ansible: devel
 
     services:
@@ -281,10 +202,10 @@ jobs:
       - name: >-
           Perform integration testing against
           Ansible version ${{ matrix.ansible }}
-          under Python ${{ matrix.python }}
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
           ansible-core-version: ${{ matrix.ansible }}
+          docker-image: ubuntu2204
           pre-test-cmd: >-
             echo Setting db_engine_name to "${{ matrix.db_engine_name }}"...;
             echo -n "${{ matrix.db_engine_name }}"
@@ -303,14 +224,9 @@ jobs:
             echo -n "${{ matrix.connector_version }}"
             > tests/integration/connector_version;
 
-            echo Setting Python version to "${{ matrix.python }}"...;
-            echo -n "${{ matrix.python }}"
-            > tests/integration/python;
-
             echo Setting Ansible version to "${{ matrix.ansible }}"...;
             echo -n "${{ matrix.ansible }}"
             > tests/integration/ansible
-          target-python-version: ${{ matrix.python }}
           testing-type: integration
 
   units:

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -17,7 +17,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   sanity:
-    name: "Sanity (Ansible: ${{ matrix.ansible }})"
+    name: "Sanity (Ⓐ${{ matrix.ansible }})"
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -38,7 +38,7 @@ jobs:
   # Use this to chose which version of Python vs Ansible to test:
   # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-control-node-python-support
   integration:
-    name: "Integration (Ansible: ${{ matrix.ansible }}, DB: ${{ matrix.db_engine_name }} ${{ matrix.db_engine_version }}, connector: ${{ matrix.connector_name }} ${{ matrix.connector_version }})"
+    name: "Integration (Ⓐ${{ matrix.ansible }}, DB: ${{ matrix.db_engine_name }} ${{ matrix.db_engine_version }}, connector: ${{ matrix.connector_name }} ${{ matrix.connector_version }})"
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -275,7 +275,7 @@ jobs:
 
   units:
     runs-on: ubuntu-22.04
-    name: Units (Ⓐ${{ matrix.ansible }})
+    name: Units (Ⓐ${{ matrix.ansible }}, Python${{ matrix.python }})
     strategy:
       # As soon as the first unit test fails,
       # cancel the others to free up the CI queue

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -35,6 +35,8 @@ jobs:
           testing-type: sanity
           pull-request-change-detection: true
 
+  # Use this to chose which version of Python vs Ansible to test:
+  # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-control-node-python-support
   integration:
     name: "Integration (Python: ${{ matrix.python }}, Ansible: ${{ matrix.ansible }}, DB: ${{ matrix.db_engine_name }} ${{ matrix.db_engine_version }}, connector: ${{ matrix.connector_name }} ${{ matrix.connector_version }})"
     runs-on: ubuntu-22.04
@@ -50,124 +52,147 @@ jobs:
           - mysql
           - mariadb
         db_engine_version:
-          - 5.7.40
-          - 8.0.31
-          - 10.4.27
-          - 10.5.18
-          - 10.6.11
+          - '8.0.38'
+          # - '8.4.1'  # Unable to install mysql-client on Ubuntu 20.04 default container used by ansible-test
+          - '10.4.34'
+          - '10.5.25'
+          - '10.6.18'
+          - '10.11.8'
         python:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
+          - '3.12'
         connector_name:
           - pymysql
           - mysqlclient
         connector_version:
-          - 0.7.11
-          - 0.9.3
-          - 1.0.2
-          - 2.0.1
-          - 2.0.3
-          - 2.1.1
-        exclude:
-          - db_engine_name: mysql
-            db_engine_version: 10.4.27
+          - '0.9.3'
+          - '1.0.2'
+          - '2.0.1'
+          - '2.0.3'
+          - '2.1.1'
 
-          - db_engine_name: mysql
-            db_engine_version: 10.5.18
+        include:
 
-          - db_engine_name: mysql
-            db_engine_version: 10.6.11
-
-          - db_engine_name: mariadb
-            db_engine_version: 5.7.40
-
-          - db_engine_name: mariadb
-            db_engine_version: 8.0.31
-
+          # RHEL8 context
           - connector_name: pymysql
-            connector_version: 2.0.1
-
-          - connector_name: pymysql
-            connector_version: 2.0.3
-
-          - connector_name: pymysql
-            connector_version: 2.1.1
-
-          - connector_name: mysqlclient
-            connector_version: 0.7.11
-
-          - connector_name: mysqlclient
-            connector_version: 0.9.3
-
-          - connector_name: mysqlclient
-            connector_version: 1.0.2
-
-          - db_engine_name: mariadb
-            connector_version: 0.7.11
-
-          - db_engine_version: 5.7.40
-            python: '3.9'
-
-          - db_engine_version: 5.7.40
-            python: '3.10'
-
-          - db_engine_version: 5.7.40
-            ansible: stable-2.15
-
-          - db_engine_version: 5.7.40
+            connector_version: '0.10.1'
+            python: '3.6'
             ansible: stable-2.16
 
-          - db_engine_version: 5.7.40
-            ansible: devel
+          # RHEL9 context
+          - connector_name: pymysql
+            connector_version: '1.1.1'
+            python: '3.9'
+            ansible: stable-2.17
 
-          - db_engine_version: 8.0.31
+        exclude:
+          - db_engine_name: mysql
+            db_engine_version: '10.4.34'
+
+          - db_engine_name: mysql
+            db_engine_version: '10.5.25'
+
+          - db_engine_name: mysql
+            db_engine_version: '10.6.18'
+
+          - db_engine_name: mysql
+            db_engine_version: '10.11.8'
+
+          - db_engine_name: mariadb
+            db_engine_version: '8.0.38'
+
+          - db_engine_name: mariadb
+            db_engine_version: '8.4.1'
+
+          - connector_name: pymysql
+            connector_version: '2.0.1'
+
+          - connector_name: pymysql
+            connector_version: '2.0.3'
+
+          - connector_name: pymysql
+            connector_version: '2.1.1'
+
+          - connector_name: mysqlclient
+            connector_version: '0.9.3'
+
+          - connector_name: mysqlclient
+            connector_version: '1.0.2'
+
+          - db_engine_version: '8.4.1'
             python: '3.8'
 
-          - db_engine_version: 10.4.27
+          - db_engine_version: '10.4.34'
             python: '3.10'
 
-          - db_engine_version: 10.4.27
+          - db_engine_version: '10.4.34'
+            python: '3.11'
+
+          - db_engine_version: '10.4.34'
+            python: '3.12'
+
+          - db_engine_version: '10.4.34'
             ansible: devel
 
-          - db_engine_version: 10.6.11
+          - db_engine_version: '10.6.18'
             python: '3.8'
 
-          - db_engine_version: 10.6.11
+          - db_engine_version: '10.6.18'
             python: '3.9'
 
           - python: '3.8'
-            connector_version: 1.0.2
+            connector_version: '1.0.2'
 
           - python: '3.8'
-            connector_version: 2.0.3
+            connector_version: '2.0.3'
 
           - python: '3.8'
-            connector_version: 2.1.1
+            connector_version: '2.1.1'
 
           - python: '3.9'
-            connector_version: 0.7.11
+            connector_version: '1.0.2'
 
           - python: '3.9'
-            connector_version: 1.0.2
+            connector_version: '2.0.1'
 
           - python: '3.9'
-            connector_version: 2.0.1
-
-          - python: '3.9'
-            connector_version: 2.1.1
+            connector_version: '2.1.1'
 
           - python: '3.10'
-            connector_version: 0.7.11
+            connector_version: '0.9.3'
 
           - python: '3.10'
-            connector_version: 0.9.3
+            connector_version: '2.0.1'
 
           - python: '3.10'
-            connector_version: 2.0.1
+            connector_version: '2.0.3'
 
-          - python: '3.10'
-            connector_version: 2.0.3
+          - python: '3.11'
+            connector_version: '0.9.3'
+
+          - python: '3.11'
+            connector_version: '1.0.2'
+
+          - python: '3.11'
+            connector_version: '2.0.1'
+
+          - python: '3.11'
+            connector_version: '2.0.3'
+
+          - python: '3.12'
+            connector_version: '0.9.3'
+
+          - python: '3.12'
+            connector_version: '1.0.2'
+
+          - python: '3.12'
+            connector_version: '2.0.1'
+
+          - python: '3.12'
+            connector_version: '2.0.3'
 
           - python: '3.8'
             ansible: stable-2.16
@@ -301,17 +326,47 @@ jobs:
           - stable-2.17
           - devel
         python:
-          - 3.8
-          - 3.9
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
         exclude:
           - python: '3.8'
-            ansible: stable-2.15
-          - python: '3.8'
             ansible: stable-2.16
+
           - python: '3.8'
             ansible: stable-2.17
+
           - python: '3.8'
             ansible: devel
+
+          - python: '3.9'
+            ansible: stable-2.15
+
+          - python: '3.9'
+            ansible: stable-2.17
+
+          - python: '3.9'
+            ansible: devel
+
+          - python: '3.10'
+            ansible: stable-2.15
+
+          - python: '3.10'
+            ansible: stable-2.16
+
+          - python: '3.11'
+            ansible: stable-2.15
+
+          - python: '3.11'
+            ansible: stable-2.16
+
+          - python: '3.12'
+            ansible: stable-2.15
+
+          - python: '3.12'
+            ansible: stable-2.16
 
     steps:
       - name: >-

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -54,7 +54,6 @@ jobs:
         db_engine_version:
           - '8.0.38'
           - '8.4.1'
-          - '10.4.34'
           - '10.5.25'
           - '10.6.18'
           - '10.11.8'
@@ -85,8 +84,6 @@ jobs:
             db_engine_version: '10.11.8'
 
         exclude:
-          - db_engine_name: mysql
-            db_engine_version: '10.4.34'
 
           - db_engine_name: mysql
             db_engine_version: '10.5.25'
@@ -118,7 +115,7 @@ jobs:
           - connector_name: mysqlclient
             connector_version: '1.0.2'
 
-          - db_engine_version: '10.4.34'
+          - db_engine_version: '10.5.25'
             ansible: devel
 
     services:

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -55,7 +55,6 @@ jobs:
           - '8.0.38'
           - '8.4.1'
           - '10.5.25'
-          - '10.6.18'
           - '10.11.8'
         connector_name:
           - pymysql
@@ -89,9 +88,6 @@ jobs:
 
           - db_engine_name: mysql
             db_engine_version: '10.5.25'
-
-          - db_engine_name: mysql
-            db_engine_version: '10.6.18'
 
           - db_engine_name: mysql
             db_engine_version: '10.11.8'
@@ -129,9 +125,6 @@ jobs:
           - db_engine_version: '10.5.25'
             ansible: devel
 
-          - db_engine_version: '10.6.18'
-            ansible: devel
-
           - db_engine_version: '8.4.1'
             connector_version: '0.9.3'
 
@@ -167,9 +160,6 @@ jobs:
 
           - connector_version: '1.1.1'
             db_engine_version: '10.5.25'
-
-          - connector_version: '1.1.1'
-            db_engine_version: '10.6.18'
 
     services:
       db_primary:

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -263,9 +263,21 @@ jobs:
 
       - name: Restart MySQL server with settings for replication
         run: |
-          docker exec ${{ job.services.db_primary.id }} bash -c 'echo -e [mysqld]\\nserver-id=1\\nlog-bin=/var/lib/mysql/primary-bin > /etc/mysql/conf.d/replication.cnf'
-          docker exec ${{ job.services.db_replica1.id }} bash -c 'echo -e [mysqld]\\nserver-id=2\\nlog-bin=/var/lib/mysql/replica1-bin > /etc/mysql/conf.d/replication.cnf'
-          docker exec ${{ job.services.db_replica2.id }} bash -c 'echo -e [mysqld]\\nserver-id=3\\nlog-bin=/var/lib/mysql/replica2-bin > /etc/mysql/conf.d/replication.cnf'
+          maj="${$(matrix.db_engine_version)%.*.*}"
+          maj_min="${$(matrix.db_engine_version)%.*}"
+          min="${maj_min#*.}"
+          if [[ "${{ matrix.db_engine_name }}" == "mysql" && "$maj" == 8 && "$min" >= 2  ]]; then
+            prima_conf='[mysqld]\\nserver-id=1\\nlog-bin=/var/lib/mysql/primary-bin\\nmysql-native-password=1'
+            repl1_conf='[mysqld]\\nserver-id=2\\nlog-bin=/var/lib/mysql/replica1-bin\\nmysql-native-password=1'
+            repl2_conf='[mysqld]\\nserver-id=3\\nlog-bin=/var/lib/mysql/replica2-bin\\nmysql-native-password=1'
+          else
+            prima_conf='[mysqld]\\nserver-id=1\\nlog-bin=/var/lib/mysql/primary-bin'
+            repl1_conf='[mysqld]\\nserver-id=2\\nlog-bin=/var/lib/mysql/replica1-bin'
+            repl2_conf='[mysqld]\\nserver-id=3\\nlog-bin=/var/lib/mysql/replica2-bin'
+          fi
+          docker exec ${{ job.services.db_primary.id }} bash -c 'echo -e $prima_conf > /etc/mysql/conf.d/replication.cnf'
+          docker exec ${{ job.services.db_replica1.id }} bash -c 'echo -e $repl1_conf > /etc/mysql/conf.d/replication.cnf'
+          docker exec ${{ job.services.db_replica2.id }} bash -c 'echo -e $repl2_conf > /etc/mysql/conf.d/replication.cnf'
           docker restart -t 30 ${{ job.services.db_primary.id }}
           docker restart -t 30 ${{ job.services.db_replica1.id }}
           docker restart -t 30 ${{ job.services.db_replica2.id }}

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -271,7 +271,7 @@ jobs:
           maj="${db_ver%.*.*}"
           maj_min="${db_ver%.*}"
           min="${maj_min#*.}"
-          if [[ "${{ matrix.db_engine_name }}" == "mysql" && "$maj" == 8 && "$min" >= 2  ]]; then
+          if [[ "${{ matrix.db_engine_name }}" == "mysql" && "$maj" -eq 8 && "$min" -ge 2 ]]; then
             prima_conf='[mysqld]\\nserver-id=1\\nlog-bin=/var/lib/mysql/primary-bin\\nmysql-native-password=1'
             repl1_conf='[mysqld]\\nserver-id=2\\nlog-bin=/var/lib/mysql/replica1-bin\\nmysql-native-password=1'
             repl2_conf='[mysqld]\\nserver-id=3\\nlog-bin=/var/lib/mysql/replica2-bin\\nmysql-native-password=1'

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -63,6 +63,7 @@ jobs:
         connector_version:
           - '0.9.3'
           - '1.0.2'
+          - '1.1.1'
           - '2.0.1'
           - '2.0.3'
           - '2.1.1'
@@ -76,12 +77,13 @@ jobs:
             db_engine_name: mariadb
             db_engine_version: '10.11.8'
 
-          # RHEL9 context
-          - connector_name: pymysql
-            connector_version: '1.1.1'
-            ansible: stable-2.17
-            db_engine_name: mariadb
-            db_engine_version: '10.11.8'
+            # RHEL9 context
+            # - connector_name: pymysql
+            #   connector_version: '1.1.1'
+            #   ansible: stable-2.17
+            #   db_engine_name: mariadb
+            #   db_engine_version: '10.11.8'
+            # This tests is already included in the matrix, no need repeating
 
         exclude:
 
@@ -115,8 +117,59 @@ jobs:
           - connector_name: mysqlclient
             connector_version: '1.0.2'
 
+          - db_engine_version: '8.0.38'
+            ansible: stable-2.17
+
+          - db_engine_version: '10.5.25'
+            ansible: stable-2.17
+
+          - db_engine_version: '8.0.38'
+            ansible: devel
+
           - db_engine_version: '10.5.25'
             ansible: devel
+
+          - db_engine_version: '10.6.18'
+            ansible: devel
+
+          - db_engine_version: '8.4.1'
+            connector_version: '0.9.3'
+
+          - db_engine_version: '8.4.1'
+            connector_version: '1.0.2'
+
+          - db_engine_version: '8.4.1'
+            connector_version: '2.0.1'
+
+          - db_engine_version: '8.4.1'
+            connector_version: '2.0.3'
+
+          - db_engine_version: '10.11.8'
+            connector_version: '0.9.3'
+
+          - db_engine_version: '10.11.8'
+            connector_version: '1.0.2'
+
+          - db_engine_version: '10.11.8'
+            connector_version: '2.0.1'
+
+          - db_engine_version: '10.11.8'
+            connector_version: '2.0.1'
+
+          - db_engine_version: '10.11.8'
+            ansible: stable-2.15
+
+          - db_engine_version: '8.4.1'
+            ansible: stable-2.15
+
+          - connector_version: '1.1.1'
+            db_engine_version: '8.0.38'
+
+          - connector_version: '1.1.1'
+            db_engine_version: '10.5.25'
+
+          - connector_version: '1.1.1'
+            db_engine_version: '10.6.18'
 
     services:
       db_primary:

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -81,12 +81,16 @@ jobs:
             connector_version: '0.10.1'
             python: '3.6'
             ansible: stable-2.16
+            db_engine_name: mariadb
+            db_engine_version: '10.11.8'
 
           # RHEL9 context
           - connector_name: pymysql
             connector_version: '1.1.1'
             python: '3.9'
             ansible: stable-2.17
+            db_engine_name: mariadb
+            db_engine_version: '10.11.8'
 
         exclude:
           - db_engine_name: mysql

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -113,6 +113,9 @@ jobs:
           - connector_name: mysqlclient
             connector_version: '1.0.2'
 
+          - connector_name: mysqlclient
+            connector_version: '1.1.1'
+
           - db_engine_version: '8.0.38'
             ansible: stable-2.17
 

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -325,7 +325,8 @@ jobs:
     steps:
       - name: >-
           Perform unit testing against
-          Ansible version ${{ matrix.ansible }}
+          Ansible version ${{ matrix.ansible }} and
+          python version ${{ matrix.python }}
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
           ansible-core-version: ${{ matrix.ansible }}

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -38,7 +38,7 @@ jobs:
   # Use this to chose which version of Python vs Ansible to test:
   # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-control-node-python-support
   integration:
-    name: "Integration (Python: ${{ matrix.python }}, Ansible: ${{ matrix.ansible }}, DB: ${{ matrix.db_engine_name }} ${{ matrix.db_engine_version }}, connector: ${{ matrix.connector_name }} ${{ matrix.connector_version }})"
+    name: "Integration (Ansible: ${{ matrix.ansible }}, DB: ${{ matrix.db_engine_name }} ${{ matrix.db_engine_version }}, connector: ${{ matrix.connector_name }} ${{ matrix.connector_version }})"
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -267,8 +267,9 @@ jobs:
 
       - name: Restart MySQL server with settings for replication
         run: |
-          maj="${${{ matrix.db_engine_version }}%.*.*}"
-          maj_min="${${{ matrix.db_engine_version }}%.*}"
+          db_ver="${{ matrix.db_engine_version }}"
+          maj="${db_ver%.*.*}"
+          maj_min="${db_ver%.*}"
           min="${maj_min#*.}"
           if [[ "${{ matrix.db_engine_name }}" == "mysql" && "$maj" == 8 && "$min" >= 2  ]]; then
             prima_conf='[mysqld]\\nserver-id=1\\nlog-bin=/var/lib/mysql/primary-bin\\nmysql-native-password=1'

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -267,8 +267,8 @@ jobs:
 
       - name: Restart MySQL server with settings for replication
         run: |
-          maj="${$(matrix.db_engine_version)%.*.*}"
-          maj_min="${$(matrix.db_engine_version)%.*}"
+          maj="${${{ matrix.db_engine_version }}%.*.*}"
+          maj_min="${${{ matrix.db_engine_version }}%.*}"
           min="${maj_min#*.}"
           if [[ "${{ matrix.db_engine_name }}" == "mysql" && "$maj" == 8 && "$min" >= 2  ]]; then
             prima_conf='[mysqld]\\nserver-id=1\\nlog-bin=/var/lib/mysql/primary-bin\\nmysql-native-password=1'

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 
 # This match what GitHub Action will do. Disabled by default.
 ifdef continue_on_errors
-	_continue_on_errors = --retry-on-error --continue-on-error
+	_continue_on_errors = --continue-on-error
 endif
 
 .PHONY: test-integration

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ test-integration:
 	@echo -n $(db_engine_version) > tests/integration/db_engine_version
 	@echo -n $(connector_name) > tests/integration/connector_name
 	@echo -n $(connector_version) > tests/integration/connector_version
-	@echo -n $(python) > tests/integration/python
 	@echo -n $(ansible) > tests/integration/ansible
 
 	# Create podman network for systems missing it. Error can be ignored
@@ -90,7 +89,7 @@ test-integration:
 	https://github.com/ansible/ansible/archive/$(ansible).tar.gz; \
 	set -x; \
 	ansible-test integration $(target) -v --color --coverage --diff \
-	--docker --python $(python) \
+	--docker ubuntu2204 \
 	--docker-network podman $(_continue_on_errors) $(_keep_containers_alive); \
 	set +x
 	# End of venv
@@ -99,7 +98,6 @@ test-integration:
 	rm tests/integration/db_engine_version
 	rm tests/integration/connector_name
 	rm tests/integration/connector_version
-	rm tests/integration/python
 	rm tests/integration/ansible
 ifndef keep_containers_alive
 	podman stop --time 0 --ignore primary replica1 replica2

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,9 @@ test-integration:
 		repl1_conf='[mysqld]\\nserver-id=2\\nlog-bin=/var/lib/mysql/replica1-bin'; \
 		repl2_conf='[mysqld]\\nserver-id=3\\nlog-bin=/var/lib/mysql/replica2-bin'; \
 	fi; \
-	podman exec -e cnf="$$prima_conf" primary bash -c 'echo -e "$$cnf" > /etc/mysql/conf.d/replication.cnf'; \
-	podman exec -e cnf="$$repl1_conf" replica1 bash -c 'echo -e "$$cnf" > /etc/mysql/conf.d/replication.cnf'; \
-	podman exec -e cnf="$$repl2_conf" replica2 bash -c 'echo -e "$$cnf" > /etc/mysql/conf.d/replication.cnf'
+	podman exec -e cnf="$$prima_conf" primary bash -c 'echo -e "$${cnf//\\n/\n}" > /etc/mysql/conf.d/replication.cnf'; \
+	podman exec -e cnf="$$repl1_conf" replica1 bash -c 'echo -e "$${cnf//\\n/\n}" > /etc/mysql/conf.d/replication.cnf'; \
+	podman exec -e cnf="$$repl2_conf" replica2 bash -c 'echo -e "$${cnf//\\n/\n}" > /etc/mysql/conf.d/replication.cnf'
 	# Don't restart a container unless it is healthy
 	while ! podman healthcheck run primary && [[ "$$SECONDS" -lt 120 ]]; do sleep 1; done
 	podman restart -t 30 primary

--- a/README.md
+++ b/README.md
@@ -106,17 +106,18 @@ Here is the table for the support timeline:
 
 ### Python
 
-- 3.8
-- 3.9
-- 3.10
-- 3.11 (collection version >= 3.10.0)
+- 3.8 (Unit tests only)
+- 3.9 (Unit tests only)
+- 3.10 (Sanity, Units and integrations tests)
+- 3.11 (Unit tests only, collection version >= 3.10.0)
 
 ### Databases
 
 For MariaDB, only Long Term releases are tested.
 
 - mysql 5.7.40 (collection version < 3.10.0)
-- mysql 8.0.31  (collection version < 3.10.0)
+- mysql 8.0.31 (collection version < 3.10.0)
+- mysql 8.4.1 (collection version >= 3.10.0) !!! FAILING, no support yet !!!
 - mariadb:10.3.34 (collection version < 3.5.1)
 - mariadb:10.4.24 (collection version >= 3.5.2, < 3.10.0)
 - mariadb:10.4.34 (collection version >= 3.10.0)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ For MariaDB, only Long Term releases are tested.
 - mysql 8.4.1 (collection version >= 3.10.0) !!! FAILING, no support yet !!!
 - mariadb:10.3.34 (collection version < 3.5.1)
 - mariadb:10.4.24 (collection version >= 3.5.2, < 3.10.0)
-- mariadb:10.4.34 (collection version >= 3.10.0)
 - mariadb:10.5.18 (collection version >= 3.5.2, < 3.10.0)
 - mariadb:10.5.25 (collection version >= 3.10.0)
 - mariadb:10.6.11 (collection version >= 3.5.2, < 3.10.0)

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For MariaDB, only Long Term releases are tested.
 - pymysql 0.9.3
 - pymysql 0.10.1 (for RHEL8 context)
 - pymysql 1.0.2 (collection version >= 3.6.1)
-- pymysql 1.1.1 (for RHEL9 context)
+- pymysql 1.1.1 (collection version >= 3.10.0)
 
 ## External requirements
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here is the table for the support timeline:
 
 ### Databases
 
-For MariaDB, only Long Term releases are tested.
+For MariaDB, only Long Term releases are tested. When multiple LTS are available, we test the oldest and the newest only. Usually breaking changes introduced in the versions in between are also present in the latest version.
 
 - mysql 5.7.40 (collection version < 3.10.0)
 - mysql 8.0.31 (collection version < 3.10.0)
@@ -123,7 +123,6 @@ For MariaDB, only Long Term releases are tested.
 - mariadb:10.5.18 (collection version >= 3.5.2, < 3.10.0)
 - mariadb:10.5.25 (collection version >= 3.10.0)
 - mariadb:10.6.11 (collection version >= 3.5.2, < 3.10.0)
-- mariadb:10.6.18 (collection version >= 3.10.0)
 - mariadb:10.11.8 (collection version >= 3.10.0)
 
 

--- a/README.md
+++ b/README.md
@@ -104,24 +104,37 @@ Here is the table for the support timeline:
 - stable-2.17
 - current development version
 
+### Python
+
+- 3.8
+- 3.9
+- 3.10
+- 3.11 (collection version >= 3.10.0)
+- 3.12 (collection version >= 3.10.0)
+
 ### Databases
 
 For MariaDB, only Long Term releases are tested.
 
-- mysql 5.7.40
-- mysql 8.0.31
-- mariadb:10.3.34 (only collection version <= 3.5.1)
-- mariadb:10.4.24 (only collection version >= 3.5.2)
-- mariadb:10.5.18 (only collection version >= 3.5.2)
-- mariadb:10.6.11 (only collection version >= 3.5.2)
-- mariadb:10.11.?? (waiting for release)
+- mysql 5.7.40 (collection version < 3.10.0)
+- mysql 8.0.31  (collection version < 3.10.0)
+- mariadb:10.3.34 (collection version < 3.5.1)
+- mariadb:10.4.24 (collection version >= 3.5.2, < 3.10.0)
+- mariadb:10.4.34 (collection version >= 3.10.0)
+- mariadb:10.5.18 (collection version >= 3.5.2, < 3.10.0)
+- mariadb:10.5.25 (collection version >= 3.10.0)
+- mariadb:10.6.11 (collection version >= 3.5.2, < 3.10.0)
+- mariadb:10.6.18 (collection version >= 3.10.0)
+- mariadb:10.11.8 (collection version >= 3.10.0)
 
 
 ### Database connectors
 
-- pymysql 0.7.11 (Only tested with MySQL 5.7)
+- pymysql 0.7.11 (collection version < 3.10 and MySQL 5.7)
 - pymysql 0.9.3
-- pymysql 1.0.2 (only collection version >= 3.6.1)
+- pymysql 0.10.1 (for RHEL8 context)
+- pymysql 1.0.2 (collection version >= 3.6.1)
+- pymysql 1.1.1 (for RHEL9 context)
 
 ## External requirements
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Here is the table for the support timeline:
 - 3.9
 - 3.10
 - 3.11 (collection version >= 3.10.0)
-- 3.12 (collection version >= 3.10.0)
 
 ### Databases
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -66,7 +66,6 @@ The Makefile accept the following options
     - "8.0.38" <- mysql
     - "8.4.1" <- mysql (NOT WORKING YET, ansible-test uses Ubuntu 20.04 which is too old to install mysql-community-client 8.4)
     - "10.5.25" <- mariadb
-    - "10.6.18" <- mariadb
     - "10.11.8" <- mariadb
   - Description: The tag of the container to use for the service containers that will host a primary database and two replicas. Do not use short version, like `mysql:8` (don't do that) because our tests expect a full version to filter tests precisely. For instance: `when: db_version is version ('8.0.22', '>')`. You can use any tag available on [hub.docker.com/_/mysql](https://hub.docker.com/_/mysql) and [hub.docker.com/_/mariadb](https://hub.docker.com/_/mariadb) but GitHub Action will only use the versions listed above.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -42,7 +42,6 @@ The Makefile accept the following options
     - "3.9"
     - "3.10"
     - "3.11" (for stable-2.15+)
-    - "3.12" (for stable-2.16+)
   - Description: If `Python -V` shows an unsupported version, use this option to select a compatible Python version available on your system. Use `ls /usr/bin/python3*|grep -v config` to list the available versions (You may have to install one). Unsupported versions are those that are too recent for the Ansible version you are using. In such cases, you will see an error message similar to: 'This version of ansible-test cannot be executed with Python version 3.12.3. Supported Python versions are: 3.9, 3.10, 3.11'.
 
 - `ansible`

--- a/TESTING.md
+++ b/TESTING.md
@@ -19,7 +19,7 @@ For now, the makefile only supports Podman.
 
 ### Requirements
 
-- python >= 3.8 and <= 3.10
+- python >= 3.8
 - make
 - podman
 - Minimum 15GB of free space on the device storing containers images and volumes. You can use this command to check: `podman system info --format='{{.Store.GraphRoot}}'|xargs findmnt --noheadings --nofsroot --output SOURCE --target|xargs df -h --output=size,used,avail,pcent,target`
@@ -41,7 +41,9 @@ The Makefile accept the following options
     - "3.8"
     - "3.9"
     - "3.10"
-  - Description: If `Python -V` shows an unsupported version, use this option and choose one of the version available on your system. Use `ls /usr/bin/python3*|grep -v config` to list them.
+    - "3.11" (for stable-2.15+)
+    - "3.12" (for stable-2.16+)
+  - Description: If `Python -V` shows an unsupported version, use this option to select a compatible Python version available on your system. Use `ls /usr/bin/python3*|grep -v config` to list the available versions (You may have to install one). Unsupported versions are those that are too recent for the Ansible version you are using. In such cases, you will see an error message similar to: 'This version of ansible-test cannot be executed with Python version 3.12.3. Supported Python versions are: 3.9, 3.10, 3.11'.
 
 - `ansible`
   - Mandatory: true
@@ -62,11 +64,12 @@ The Makefile accept the following options
 - `db_engine_version`
   - Mandatory: true
   - Choices:
-    - "5.7.40" <- mysql
-    - "8.0.31" <- mysql
-    - "10.4.24" <- mariadb
-    - "10.5.18" <- mariadb
-    - "10.6.11" <- mariadb
+    - "8.0.38" <- mysql
+    - "8.4.1" <- mysql (NOT WORKING YET, ansible-test uses Ubuntu 20.04 which is too old to install mysql-community-client 8.4)
+    - "10.4.34" <- mariadb
+    - "10.5.25" <- mariadb
+    - "10.6.18" <- mariadb
+    - "10.11.8" <- mariadb
   - Description: The tag of the container to use for the service containers that will host a primary database and two replicas. Do not use short version, like `mysql:8` (don't do that) because our tests expect a full version to filter tests precisely. For instance: `when: db_version is version ('8.0.22', '>')`. You can use any tag available on [hub.docker.com/_/mysql](https://hub.docker.com/_/mysql) and [hub.docker.com/_/mariadb](https://hub.docker.com/_/mariadb) but GitHub Action will only use the versions listed above.
 
 - `connector_name`
@@ -79,7 +82,6 @@ The Makefile accept the following options
 - `connector_version`
   - Mandatory: true
   - Choices:
-    - "0.7.11" <- pymysql (Only for MySQL 5.7)
     - "0.9.3" <- pymysql
     - "1.0.2" <- pymysql
     - "2.0.1" <- mysqlclient
@@ -93,6 +95,8 @@ The Makefile accept the following options
     - "3.8"
     - "3.9"
     - "3.10"
+    - "3.11"
+    - "3.12"
   - Description: The python version to use in the controller (ansible-test container).
 
 - `target`
@@ -121,17 +125,17 @@ tests will overwrite the 3 databases containers so no need to kill them in advan
 
 ```sh
 # Run all targets
-make ansible="stable-2.12" db_engine_name="mysql" db_engine_version="5.7.40" python="3.8" connector_name="pymysql" connector_version="0.7.11"
+make ansible="stable-2.16" db_engine_name="mysql" db_engine_version="8.0.31" python="3.10" connector_name="pymysql" connector_version="1.0.2"
 
 # A single target
-make ansible="stable-2.14" db_engine_name="mysql" db_engine_version="5.7.40" python="3.8" connector_name="pymysql" connector_version="0.7.11" target="test_mysql_info"
+make ansible="stable-2.16" db_engine_name="mysql" db_engine_version="8.0.31" python="3.10" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
 
 # Keep databases and ansible tests containers alives
 # A single target and continue on errors
-make ansible="stable-2.14" db_engine_name="mysql" db_engine_version="8.0.31" python="3.9" connector_name="mysqlclient" connector_version="2.0.3" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.31" python="3.11" connector_name="mysqlclient" connector_version="2.0.3" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
 
 # If your system has an usupported version of Python:
-make local_python_version="3.8" ansible="stable-2.14" db_engine_name="mariadb" db_engine_version="10.6.11" python="3.9" connector_name="pymysql" connector_version="0.9.3"
+make local_python_version="3.10" ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="10.6.11" python="3.11" connector_name="pymysql" connector_version="1.0.2"
 ```
 
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -104,7 +104,7 @@ tests will overwrite the 3 databases containers so no need to kill them in advan
 
 - `continue_on_errors`
   - Mandatory: false
-  - Description: Tells ansible-test to retry on errors and also continue on errors. This is the way the GitHub Action's workflow runs the tests. This can be used to catch all errors in a single run, but you'll need to scroll up to find them. Add any value to activate this option: `continue_on_errors=1`
+  - Description: Tells ansible-test to continue on errors. This is the way the GitHub Action's workflow runs the tests. This can be used to catch all errors in a single run, but you'll need to scroll up to find them. Add any value to activate this option: `continue_on_errors=1`
 
 
 #### Makefile usage examples:

--- a/TESTING.md
+++ b/TESTING.md
@@ -83,10 +83,9 @@ The Makefile accept the following options
   - Mandatory: true
   - Choices:
     - "0.9.3" <- pymysql
+    - "0.10.1" <- pymysql
     - "1.0.2" <- pymysql
-    - "2.0.1" <- mysqlclient
-    - "2.0.3" <- mysqlclient
-    - "2.1.1" <- mysqlclient
+    - "1.1.1" <- pymysql
   - Description: The version of the python package of the connector to use. This value is used to filter tests meant for other connectors.
 
 - `python`

--- a/TESTING.md
+++ b/TESTING.md
@@ -65,7 +65,6 @@ The Makefile accept the following options
   - Choices:
     - "8.0.38" <- mysql
     - "8.4.1" <- mysql (NOT WORKING YET, ansible-test uses Ubuntu 20.04 which is too old to install mysql-community-client 8.4)
-    - "10.4.34" <- mariadb
     - "10.5.25" <- mariadb
     - "10.6.18" <- mariadb
     - "10.11.8" <- mariadb

--- a/TESTING.md
+++ b/TESTING.md
@@ -87,16 +87,6 @@ The Makefile accept the following options
     - "1.1.1" <- pymysql
   - Description: The version of the python package of the connector to use. This value is used to filter tests meant for other connectors.
 
-- `python`
-  - Mandatory: true
-  - Choices:
-    - "3.8"
-    - "3.9"
-    - "3.10"
-    - "3.11"
-    - "3.12"
-  - Description: The python version to use in the controller (ansible-test container).
-
 - `target`
   - Mandatory: false
   - Choices:
@@ -123,23 +113,23 @@ tests will overwrite the 3 databases containers so no need to kill them in advan
 
 ```sh
 # Run all targets
-make ansible="stable-2.16" db_engine_name="mysql" db_engine_version="8.0.31" python="3.10" connector_name="pymysql" connector_version="1.0.2"
+make ansible="stable-2.16" db_engine_name="mysql" db_engine_version="8.0.31" connector_name="pymysql" connector_version="1.0.2"
 
 # A single target
-make ansible="stable-2.16" db_engine_name="mysql" db_engine_version="8.0.31" python="3.10" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
+make ansible="stable-2.16" db_engine_name="mysql" db_engine_version="8.0.31" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
 
 # Keep databases and ansible tests containers alives
 # A single target and continue on errors
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.31" python="3.11" connector_name="mysqlclient" connector_version="2.0.3" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.31" connector_name="mysqlclient" connector_version="2.0.3" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
 
 # If your system has an usupported version of Python:
-make local_python_version="3.10" ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="10.6.11" python="3.11" connector_name="pymysql" connector_version="1.0.2"
+make local_python_version="3.10" ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="10.6.11" connector_name="pymysql" connector_version="1.0.2"
 ```
 
 
 ### Run all tests
 
-GitHub Action offer a test matrix that run every combination of Python, MySQL, MariaDB and Connector against each other. To reproduce this, this repo provides a script called *run_all_tests.py*.
+GitHub Action offer a test matrix that run every combination of MySQL, MariaDB and Connector against each other. To reproduce this, this repo provides a script called *run_all_tests.py*.
 
 Examples:
 
@@ -148,8 +138,8 @@ python run_all_tests.py
 ```
 
 
-### Add a new Python, Connector or Database version
+### Add a new Connector or Database version
 
 New components version should be added to this file: [.github/workflows/ansible-test-plugins.yml](https://github.com/ansible-collections/community.mysql/tree/main/.github/workflows)
 
-Be careful to not add too much tests. When adding a new version of Python, for instance, only test it agains the latest versions of Ansible and MySQL/MariaDB. When tests are run, you can see that we already start 40 virtual machines!
+Be careful to not add too much tests. The matrix creates an exponential number of virtual machines!

--- a/tests/integration/targets/setup_controller/tasks/requirements.yml
+++ b/tests/integration/targets/setup_controller/tasks/requirements.yml
@@ -1,5 +1,15 @@
 ---
 
+# (A) Ubuntu 20.04 has been updated on July 10th 2024 and now required
+# additionnal packages to connect to MySQL 8+. I think it was because of a
+# security issues discovered in mysql-client and/or PyMySQL. The error was:
+# unable to connect to database using pymysql 1.0.2, check login_user and
+# login_password are correct or /root/.my.cnf has the credentials. Exception
+# message: 'cryptography' package is required for sha256_password or
+# caching_sha2_password auth method
+# Ubuntu 20.04 is chosen by ansible-test default image. So any change in
+# ansible-test or Ubuntu can break our tests anytime without us knowing why.
+
 - name: "{{ role_name }} | Requirements | Install Linux packages"
   ansible.builtin.package:
     name:
@@ -11,10 +21,12 @@
       # different name between Ubuntu 20.04 and 22.04. Luckily, libmysql++ is
       # available on both.
       - "{{ 'libmysql++-dev' if db_engine == 'mysql' else 'libmariadb-dev' }}"
+      - python3-cryptography  # (A)
     state: present
 
 - name: "{{ role_name }} | Requirements | Install Python packages"
   ansible.builtin.pip:
     name:
+      - cffi  # (A)
       - "{{ connector_name }}=={{ connector_version }}"
     state: present

--- a/tests/integration/targets/setup_controller/tasks/requirements.yml
+++ b/tests/integration/targets/setup_controller/tasks/requirements.yml
@@ -1,14 +1,6 @@
 ---
 
-# (A) Ubuntu 20.04 has been updated on July 10th 2024 and now required
-# additionnal packages to connect to MySQL 8+. I think it was because of a
-# security issues discovered in mysql-client and/or PyMySQL. The error was:
-# unable to connect to database using pymysql 1.0.2, check login_user and
-# login_password are correct or /root/.my.cnf has the credentials. Exception
-# message: 'cryptography' package is required for sha256_password or
-# caching_sha2_password auth method
-# Ubuntu 20.04 is chosen by ansible-test default image. So any change in
-# ansible-test or Ubuntu can break our tests anytime without us knowing why.
+# We use the ubuntu2204 image provided by ansible-test.
 
 - name: "{{ role_name }} | Requirements | Install Linux packages"
   ansible.builtin.package:
@@ -21,12 +13,10 @@
       # different name between Ubuntu 20.04 and 22.04. Luckily, libmysql++ is
       # available on both.
       - "{{ 'libmysql++-dev' if db_engine == 'mysql' else 'libmariadb-dev' }}"
-      - python3-cryptography  # (A)
     state: present
 
 - name: "{{ role_name }} | Requirements | Install Python packages"
   ansible.builtin.pip:
     name:
-      - cffi  # (A)
       - "{{ connector_name }}=={{ connector_version }}"
     state: present

--- a/tests/integration/targets/setup_controller/tasks/setvars.yml
+++ b/tests/integration/targets/setup_controller/tasks/setvars.yml
@@ -32,11 +32,6 @@
         'file',
         '/root/ansible_collections/community/mysql/tests/integration/db_engine_version'
       ) }}
-    python_version_lookup: >-
-      {{ lookup(
-        'file',
-        '/root/ansible_collections/community/mysql/tests/integration/python'
-      ) }}
     ansible_version_lookup: >-
       {{ lookup(
         'file',
@@ -49,7 +44,6 @@
     connector_version: "{{ connector_version_lookup.strip() }}"
     db_engine: "{{ db_engine_name_lookup.strip() }}"
     db_version: "{{ db_engine_version_lookup.strip() }}"
-    python_version: "{{ python_version_lookup.strip() }}"
     test_ansible_version: >-
       {%- if ansible_version_lookup == 'devel' -%}
       {{ ansible_version_lookup }}
@@ -77,7 +71,6 @@
       connector_version: {{ connector_version }}
       db_engine: {{ db_engine }}
       db_version: {{ db_version }}
-      python_version: {{ python_version }}
       test_ansible_version: {{ test_ansible_version }}
   ansible.builtin.debug:
     msg: "{{ msg.split('\n') }}"

--- a/tests/integration/targets/setup_controller/tasks/verify.yml
+++ b/tests/integration/targets/setup_controller/tasks/verify.yml
@@ -41,10 +41,20 @@
       when:
         - connector_name == 'mysqlclient'
 
-    - name: Display the python version in use
-      command:
+    - name: Get the python version in use
+      ansible.builtin.command:
         cmd: python -V
       changed_when: false
+      failed_when: false
+      register: python_version_in_use
+
+    - name: Display the python version in use
+      ansible.builtin.debug:
+        msg: >
+          Python in use inside the test container:
+          ${{ python_version_in_use }}
+      when:
+        - python_version_in_use is defined
 
     - name: Assert that we run the expected ansible version
       assert:

--- a/tests/integration/targets/setup_controller/tasks/verify.yml
+++ b/tests/integration/targets/setup_controller/tasks/verify.yml
@@ -43,14 +43,8 @@
 
     - name: Display the python version in use
       command:
-        cmd: python{{ python_version }} -V
+        cmd: python -V
       changed_when: false
-      register: python_in_use
-
-    - name: Assert that expected Python is installed
-      assert:
-        that:
-          - python_in_use.stdout is search(python_version)
 
     - name: Assert that we run the expected ansible version
       assert:


### PR DESCRIPTION
## SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

fixes #624
fixes #625

### Removes tests for specific version of Python
why:
- Bug for a specific version of Python are rare in Integration tests
- This allow us to use ubuntu2204 instead of unbun2004. This is a limitation of ansible-test. The alternative would have been to use custom container, but we removes ours 3 weeks ago because it was too much maintenance.
- Ubuntu 22.04 can connect to MySQL 8.4. This is not the case for ubuntu 20.04.
- Reduce the number of tests
- It means we only use Python 3.10 (until ansible-test update its images).
- Fix CI for MySQL 8.0 that occured due to an update in ubuntu 20.04 last week (see bellow)

### Remove tests for
- MySQL 5.7.40 that is EoL
- MariaDB 10.4.27 that is EoL
- MariaDB 10.6.11, reason being that usually breaking changes introduced in the versions in between are also present in the latest version.
- PyMySQL 0.7.11 (it is very very old and we can't have too many tests)

### Add tests for
- RHEL8 context: pymysql:0.10.1, ansible:2.16
- MariaDB 10.11.8
- PyMySQL 1.1.1

### Update tests
- MySQL 8.0.31 -> 8.0.38
- MariaDB 10.5.18 -> 10.5.25

### Number of VM
- Before this PR; integration tests used 34 VMs.
- After this PR; integration tests use 36 VMs.

### Note for MySQL 8.4
Since MySQL 8.2, the mysql_native_plugin is absent. I modified the Makefile and GHA workflow to add the option to enable it back. Otherwise our tests fails to connect to the database.

Other tests are now failing due to deprecated option between 8.0 and 8.4 but I intend to let the tests red here and open a new PR to fix issues with MySQL 8.4 later.

### Note for MySQL 8.0
One week ago, our CI stopped working. This is because Ubuntu 20.04 got updated for security reasons and now mysql-client complains that 'cryptography' package is missing. The upgrade to ubuntu 22.04 fix that.

### Note for MySQL 9 and MariaDB 11
None of the latest db engine have a LTS release. So we will wait a little longer before testing those versions.

## ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Tests

## COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- CI
