### PR TITLE
mysql_user: deprecate alias user for name argument

### DIFF
--- a/changelogs/fragments/0-mysql_user.yml
+++ b/changelogs/fragments/0-mysql_user.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- mysql_user - the ``user`` alias of the ``name`` argument has been deprecated and will be removed in collection version 5.0.0. Use the ``name`` argument instead.

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -439,7 +439,13 @@ from ansible.module_utils._text import to_native
 def main():
     argument_spec = mysql_common_argument_spec()
     argument_spec.update(
-        user=dict(type='str', required=True, aliases=['name']),
+        name=dict(type='str', required=True, aliases=['user'], deprecated_aliases=[
+            {
+                'name': 'user',
+                'version': '5.0.0',
+                'collection_name': 'community.mysql',
+            }],
+        ),
         password=dict(type='str', no_log=True),
         encrypted=dict(type='bool', default=False),
         host=dict(type='str', default='localhost'),

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -477,7 +477,7 @@ def main():
     )
     login_user = module.params["login_user"]
     login_password = module.params["login_password"]
-    user = module.params["user"]
+    user = module.params["name"]
     password = module.params["password"]
     encrypted = module.boolean(module.params["encrypted"])
     host = module.params["host"].lower()

--- a/tests/integration/targets/test_mysql_user/tasks/issue-265.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-265.yml
@@ -64,7 +64,7 @@
     - name: Issue-265 | Remove blank mysql user with hosts=all (expect changed)
       mysql_user:
         <<: *mysql_params
-        user: ""
+        name: ""
         host_all: true
         state: absent
         force_context: yes
@@ -78,7 +78,7 @@
     - name: Issue-265 | Remove blank mysql user with hosts=all (expect ok)
       mysql_user:
         <<: *mysql_params
-        user: ""
+        name: ""
         host_all: true
         force_context: yes
         state: absent
@@ -151,7 +151,7 @@
     - name: Issue-265 | Remove blank mysql user with hosts=all (expect changed)
       mysql_user:
         <<: *mysql_params
-        user: ""
+        name: ""
         host_all: true
         state: absent
         force_context: no
@@ -165,7 +165,7 @@
     - name: Issue-265 | Remove blank mysql user with hosts=all (expect ok)
       mysql_user:
         <<: *mysql_params
-        user: ""
+        name: ""
         host_all: true
         force_context: no
         state: absent

--- a/tests/integration/targets/test_mysql_user/tasks/test_idempotency.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_idempotency.yml
@@ -66,7 +66,7 @@
     - name: Idempotency | Remove blank  user with hosts=all (expect changed)
       mysql_user:
         <<: *mysql_params
-        user: ""
+        name: ""
         host_all: true
         state: absent
       register: result
@@ -79,7 +79,7 @@
     - name: Idempotency | Remove blank user with hosts=all (expect ok)
       mysql_user:
         <<: *mysql_params
-        user: ""
+        name: ""
         host_all: true
         state: absent
       register: result


### PR DESCRIPTION
##### SUMMARY
Relates to https://github.com/ansible-collections/community.mysql/issues/669.
It wasn't even documented, the failures are addressed in https://github.com/ansible-collections/community.mysql/pull/668