### PR TITLE
Update user.py

### DIFF
--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -402,7 +402,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     # Mysql and MariaDB differ in naming pam plugin and syntax to set it
                     if plugin == 'pam': 
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
-                    elif plugin in ('ed25519'):                                                
+                    elif plugin == 'ed25519':                                                
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING PASSWORD(%s)", (user, host, plugin, plugin_auth_string)
                     elif salt:
                         if plugin in ['caching_sha2_password', 'sha256_password']:

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -212,8 +212,10 @@ def user_add(cursor, user, host, host_all, password, encrypted,
         query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
     elif plugin and plugin_auth_string:
         # Mysql and MariaDB differ in naming pam plugin and Syntax to set it
-        if plugin in ('pam', 'ed25519'):  # Used by MariaDB which requires the USING keyword, not BY
+        if plugin in ('pam'):  # Used by MariaDB which requires the USING keyword, not BY
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
+        elif plugin in ('ed25519'):  # Used by MariaDB which requires the USING keyword, not BY
+            query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING PASSWORD(%s)", (user, host, plugin, plugin_auth_string)
         elif salt:
             if plugin in ['caching_sha2_password', 'sha256_password']:
                 generated_hash_string = mysql_sha256_password_hash_hex(password=plugin_auth_string, salt=salt)
@@ -398,8 +400,10 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
                 elif plugin_auth_string:
                     # Mysql and MariaDB differ in naming pam plugin and syntax to set it
-                    if plugin in ('pam', 'ed25519'):
+                    if plugin in ('pam'):                                                
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
+                    elif plugin in ('ed25519'):                                                
+                        query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING PASSWORD(%s)", (user, host, plugin, plugin_auth_string)
                     elif salt:
                         if plugin in ['caching_sha2_password', 'sha256_password']:
                             generated_hash_string = mysql_sha256_password_hash_hex(password=plugin_auth_string, salt=salt)

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -214,7 +214,7 @@ def user_add(cursor, user, host, host_all, password, encrypted,
         # Mysql and MariaDB differ in naming pam plugin and Syntax to set it
         if plugin == 'pam':  # Used by MariaDB which requires the USING keyword, not BY
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
-        elif plugin in ('ed25519'):  # Used by MariaDB which requires the USING keyword, not BY
+        elif plugin == 'ed25519':  # Used by MariaDB which requires the USING keyword, not BY
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING PASSWORD(%s)", (user, host, plugin, plugin_auth_string)
         elif salt:
             if plugin in ['caching_sha2_password', 'sha256_password']:

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -212,7 +212,7 @@ def user_add(cursor, user, host, host_all, password, encrypted,
         query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
     elif plugin and plugin_auth_string:
         # Mysql and MariaDB differ in naming pam plugin and Syntax to set it
-        if plugin in ('pam'):  # Used by MariaDB which requires the USING keyword, not BY
+        if plugin == 'pam':  # Used by MariaDB which requires the USING keyword, not BY
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
         elif plugin in ('ed25519'):  # Used by MariaDB which requires the USING keyword, not BY
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING PASSWORD(%s)", (user, host, plugin, plugin_auth_string)

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -402,7 +402,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     # Mysql and MariaDB differ in naming pam plugin and syntax to set it
                     if plugin == 'pam':
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
-                    elif plugin == 'ed25519':                                                
+                    elif plugin == 'ed25519':
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING PASSWORD(%s)", (user, host, plugin, plugin_auth_string)
                     elif salt:
                         if plugin in ['caching_sha2_password', 'sha256_password']:

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -400,7 +400,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
                 elif plugin_auth_string:
                     # Mysql and MariaDB differ in naming pam plugin and syntax to set it
-                    if plugin == 'pam': 
+                    if plugin == 'pam':
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
                     elif plugin == 'ed25519':                                                
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING PASSWORD(%s)", (user, host, plugin, plugin_auth_string)

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -400,7 +400,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s AS %s", (user, host, plugin, plugin_hash_string)
                 elif plugin_auth_string:
                     # Mysql and MariaDB differ in naming pam plugin and syntax to set it
-                    if plugin in ('pam'):                                                
+                    if plugin == 'pam': 
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
                     elif plugin in ('ed25519'):                                                
                         query_with_args = "ALTER USER %s@%s IDENTIFIED WITH %s USING PASSWORD(%s)", (user, host, plugin, plugin_auth_string)


### PR DESCRIPTION
Added correct syntax to ed25519 password plugin.
on create user
on update user
This only accepts cleartext passwords (PASSWORD(%s)) not pregenerated ed25519 hashes.

##### SUMMARY
MariaDB uses ed25519 for stronger password hashes, the plugin needs the PASSWORD(%s) call if cleartext password is given in plugin_auth_string.
Hopefully fixes #672

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
mysql_user
##### ADDITIONAL INFORMATION
MariaDB accepts either a clear text password in ... USING PASSWORD('password') or a pregenerated hash in ... USING 'hash'
my changes only accept a cleartext password in "plugin_auth_string", so a generated hash will taken as the cleartext password and used in the PASSWORD(%s) call.  