### PR TITLE
[mysql_db] Fix wrong documentation about pipefail

### DIFF
--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -159,7 +159,7 @@ options:
   pipefail:
     description:
     - Use C(bash) instead of C(sh) and add C(-o pipefail) to catch errors from the
-      mysql_dump command when I(state=import) and compression is used.
+      mysql_dump command when I(state=dump) and compression is used.
     - The default is C(no) to prevent issues on systems without bash as a default interpreter.
     - The default will change to C(yes) in community.mysql 4.0.0.
     type: bool


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
pipefail currently only works with mysqldump (`state=dump`), not while importing a dump. I know this because it's me that added that feature.

I'm wondering if a corrupted dump could also yield no errors when importing it using `mysql_db`. What do you guys think? Should I implement this option also for `state=import`?

I'm hesitant because I don't understand those lines: https://github.com/ansible-collections/community.mysql/blob/main/plugins/modules/mysql_db.py#L533-L553

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- mysql_db

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
