### PR TITLE
Add OceanBase support for creating user and setting password

### DIFF
--- a/plugins/module_utils/implementations/mysql/user.py
+++ b/plugins/module_utils/implementations/mysql/user.py
@@ -17,7 +17,10 @@ def use_old_user_mgmt(cursor):
 
     return LooseVersion(version) < LooseVersion("5.7")
 
-
+def use_oceanbase(cursor):
+    version = get_server_version(cursor)
+    return 'oceanbase' in version.lower()
+    
 def supports_identified_by_password(cursor):
     version = get_server_version(cursor)
     return LooseVersion(version) < LooseVersion("8")


### PR DESCRIPTION
##### SUMMARY
Oceanbase is compatible with most of the MySQL syntax, but there are a few that are not. In order to make community.mysql able to create users and set passwords in OceanBase, the incompatible parts of OceanBase have been specially handled.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Involves creating users and changing passwords