### PR TITLE
mysql_db: added `zstd` support

### DIFF
--- a/changelogs/fragments/696-mysql-db-add-zstd-support.yml
+++ b/changelogs/fragments/696-mysql-db-add-zstd-support.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- mysql_db - added ``zstd`` (de)compression support for ``import``/``dump`` states
+  (https://github.com/ansible-collections/community.mysql/issues/696).

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -46,8 +46,8 @@ options:
   target:
     description:
     - Location, on the remote host, of the dump file to read from or write to.
-    - Uncompressed SQL files (C(.sql)) as well as bzip2 (C(.bz2)), gzip (C(.gz)) and
-      xz (Added in 2.0) compressed files are supported.
+    - Uncompressed SQL files (C(.sql)) as well as bzip2 (C(.bz2)), gzip (C(.gz)),
+      xz (Added in 2.0) and zstd (C(.zst)) (Added in 3.12.0) compressed files are supported.
     type: path
   single_transaction:
     description:
@@ -455,6 +455,8 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
         path = module.get_bin_path('bzip2', True)
     elif os.path.splitext(target)[-1] == '.xz':
         path = module.get_bin_path('xz', True)
+    elif os.path.splitext(target)[-1] == '.zst':
+        path = module.get_bin_path('zstd', True)
 
     if path:
         cmd = '%s | %s > %s' % (cmd, path, shlex_quote(target))
@@ -526,6 +528,8 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
         comp_prog_path = module.get_bin_path('bzip2', required=True)
     elif os.path.splitext(target)[-1] == '.xz':
         comp_prog_path = module.get_bin_path('xz', required=True)
+    elif os.path.splitext(target)[-1] == '.zst':
+        comp_prog_path = module.get_bin_path('zstd', required=True)
     if comp_prog_path:
         # The line below is for returned data only:
         executed_commands.append('%s -dc %s | %s' % (comp_prog_path, target, cmd))


### PR DESCRIPTION
##### SUMMARY

Closes https://github.com/ansible-collections/community.mysql/issues/594

<!--- Describe the change below, including rationale and design decisions -->
Added support for zstd compressed dumps (`.zst` file extension), which can be faster and more efficient than the currently supported gzip/bz2/xz formats.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_db

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
