### PR TITLE
Add action group containing all modules

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,11 @@
 ---
 requires_ansible: '>=2.9.10'
+action_groups:
+  all:
+    - mysql_db
+    - mysql_info
+    - mysql_query
+    - mysql_replication
+    - mysql_role
+    - mysql_user
+    - mysql_variables


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Helpful for setting module defaults. For example, when using the same credentials across multiple tasks while only declaring them once. This change creates the group `community.mysql.all` for that purpose.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- N/A

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
- Similar to [community.postgresql#091993f7](https://github.com/ansible-collections/community.postgresql/commit/091993f7fd4ea7d29cf178d9a947ac8ad7781e23).
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->