### PR TITLE
Fix ssl verification always enabled for replication even if set to false

### DIFF
--- a/changelogs/fragments/707-source_ssl_verify_server_cert.yml
+++ b/changelogs/fragments/707-source_ssl_verify_server_cert.yml
@@ -1,6 +1,6 @@
 ---
 bugfixes:
-  - mysql_replication - fixed an issue where setting ``primary_ssl_verify_server_cert`` to false had no effect.
+  - mysql_replication - fixed an issue where setting ``primary_ssl_verify_server_cert`` to false had no effect (https://github.com/ansible-collections/community.mysql/issues/689).
 
 minor_changes:
-  - mysql_replication - change default value for ``primary_ssl_verify_server_cert`` from False to None. This should not affect existing playbooks.
+  - mysql_replication - change default value for ``primary_ssl_verify_server_cert`` from False to None. This should not affect existing playbooks (https://github.com/ansible-collections/community.mysql/pull/707).

--- a/changelogs/fragments/707-source_ssl_verify_server_cert.yml
+++ b/changelogs/fragments/707-source_ssl_verify_server_cert.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - mysql_replication - fixed an issue where setting primary_ssl_verify_server_cert to false had no effect.
+  - mysql_replication - fixed an issue where setting ``primary_ssl_verify_server_cert`` to false had no effect.

--- a/changelogs/fragments/707-source_ssl_verify_server_cert.yml
+++ b/changelogs/fragments/707-source_ssl_verify_server_cert.yml
@@ -1,3 +1,6 @@
 ---
 bugfixes:
   - mysql_replication - fixed an issue where setting ``primary_ssl_verify_server_cert`` to false had no effect.
+
+minor_changes:
+  - mysql_replication - change default value for ``primary_ssl_verify_server_cert`` from False to None. This should not affect existing playbooks.

--- a/changelogs/fragments/707-source_ssl_verify_server_cert.yml
+++ b/changelogs/fragments/707-source_ssl_verify_server_cert.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - mysql_replication - fixed an issue where setting primary_ssl_verify_server_cert to false had no effect.

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -643,9 +643,9 @@ def main():
         if primary_ssl_cipher is not None:
             chm.append("%s='%s'" % (command_resolver.resolve_command('MASTER_SSL_CIPHER'), primary_ssl_cipher))
         if primary_ssl_verify_server_cert:
-                chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
-            else:
-                chm.append("%s=0" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
+            chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
+        else:
+            chm.append("%s=0" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
         if primary_auto_position:
             chm.append("%s=1" % command_resolver.resolve_command('MASTER_AUTO_POSITION'))
         if primary_use_gtid is not None:

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -140,6 +140,7 @@ options:
     - Same as C(MASTER_SSL_VERIFY_SERVER_CERT) MySQL/MariaDB variable.
     - The module switch automatically to C(SOURCE_SSL_VERIFY_SERVER_CERT) for MySQL 8.0.23 and later.
     type: bool
+    default: false
     version_added: '3.5.0'
   primary_auto_position:
     description:
@@ -493,7 +494,7 @@ def main():
         primary_ssl_cert=dict(type='str', aliases=['master_ssl_cert']),
         primary_ssl_key=dict(type='str', no_log=False, aliases=['master_ssl_key']),
         primary_ssl_cipher=dict(type='str', aliases=['master_ssl_cipher']),
-        primary_ssl_verify_server_cert=dict(type='bool'),
+        primary_ssl_verify_server_cert=dict(type='bool', default=False),
         primary_use_gtid=dict(type='str', choices=[
             'current_pos', 'replica_pos', 'disabled'], aliases=['master_use_gtid']),
         primary_delay=dict(type='int', aliases=['master_delay']),
@@ -641,8 +642,7 @@ def main():
             chm.append("%s='%s'" % (command_resolver.resolve_command('MASTER_SSL_KEY'), primary_ssl_key))
         if primary_ssl_cipher is not None:
             chm.append("%s='%s'" % (command_resolver.resolve_command('MASTER_SSL_CIPHER'), primary_ssl_cipher))
-        if primary_ssl_verify_server_cert is not None:
-            if primary_ssl_verify_server_cert:
+        if primary_ssl_verify_server_cert:
                 chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
             else:
                 chm.append("%s=0" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
@@ -726,11 +726,10 @@ def main():
             chm.append("SOURCE_SSL_KEY='%s'" % primary_ssl_key)
         if primary_ssl_cipher is not None:
             chm.append("SOURCE_SSL_CIPHER='%s'" % primary_ssl_cipher)
-        if primary_ssl_verify_server_cert is not None:
-            if primary_ssl_verify_server_cert:
-                chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
-            else:
-                chm.append("%s=0" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
+        if primary_ssl_verify_server_cert:
+            chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
+        else:
+            chm.append("%s=0" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
         if primary_auto_position:
             chm.append("SOURCE_AUTO_POSITION=1")
         try:

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -139,7 +139,6 @@ options:
     description:
     - Same as mysql variable.
     type: bool
-    default: false
     version_added: '3.5.0'
   primary_auto_position:
     description:

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -140,7 +140,6 @@ options:
     - Same as C(MASTER_SSL_VERIFY_SERVER_CERT) MySQL/MariaDB variable.
     - The module switch automatically to C(SOURCE_SSL_VERIFY_SERVER_CERT) for MySQL 8.0.23 and later.
     type: bool
-    default: false
     version_added: '3.5.0'
   primary_auto_position:
     description:
@@ -494,7 +493,7 @@ def main():
         primary_ssl_cert=dict(type='str', aliases=['master_ssl_cert']),
         primary_ssl_key=dict(type='str', no_log=False, aliases=['master_ssl_key']),
         primary_ssl_cipher=dict(type='str', aliases=['master_ssl_cipher']),
-        primary_ssl_verify_server_cert=dict(type='bool', default=False),
+        primary_ssl_verify_server_cert=dict(type='bool'),
         primary_use_gtid=dict(type='str', choices=[
             'current_pos', 'replica_pos', 'disabled'], aliases=['master_use_gtid']),
         primary_delay=dict(type='int', aliases=['master_delay']),
@@ -642,10 +641,11 @@ def main():
             chm.append("%s='%s'" % (command_resolver.resolve_command('MASTER_SSL_KEY'), primary_ssl_key))
         if primary_ssl_cipher is not None:
             chm.append("%s='%s'" % (command_resolver.resolve_command('MASTER_SSL_CIPHER'), primary_ssl_cipher))
-        if primary_ssl_verify_server_cert:
-            chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
-        else:
-            chm.append("%s=0" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
+        if primary_ssl_verify_server_cert is not None:
+            if primary_ssl_verify_server_cert:
+                chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
+            else:
+                chm.append("%s=0" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
         if primary_auto_position:
             chm.append("%s=1" % command_resolver.resolve_command('MASTER_AUTO_POSITION'))
         if primary_use_gtid is not None:
@@ -726,10 +726,11 @@ def main():
             chm.append("SOURCE_SSL_KEY='%s'" % primary_ssl_key)
         if primary_ssl_cipher is not None:
             chm.append("SOURCE_SSL_CIPHER='%s'" % primary_ssl_cipher)
-        if primary_ssl_verify_server_cert:
-            chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
-        else:
-            chm.append("%s=0" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
+        if primary_ssl_verify_server_cert is not None:
+            if primary_ssl_verify_server_cert:
+                chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
+            else:
+                chm.append("%s=0" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
         if primary_auto_position:
             chm.append("SOURCE_AUTO_POSITION=1")
         try:

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -493,7 +493,7 @@ def main():
         primary_ssl_cert=dict(type='str', aliases=['master_ssl_cert']),
         primary_ssl_key=dict(type='str', no_log=False, aliases=['master_ssl_key']),
         primary_ssl_cipher=dict(type='str', aliases=['master_ssl_cipher']),
-        primary_ssl_verify_server_cert=dict(type='bool', default=False),
+        primary_ssl_verify_server_cert=dict(type='bool'),
         primary_use_gtid=dict(type='str', choices=[
             'current_pos', 'replica_pos', 'disabled'], aliases=['master_use_gtid']),
         primary_delay=dict(type='int', aliases=['master_delay']),
@@ -641,8 +641,11 @@ def main():
             chm.append("%s='%s'" % (command_resolver.resolve_command('MASTER_SSL_KEY'), primary_ssl_key))
         if primary_ssl_cipher is not None:
             chm.append("%s='%s'" % (command_resolver.resolve_command('MASTER_SSL_CIPHER'), primary_ssl_cipher))
-        if primary_ssl_verify_server_cert:
-            chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
+        if primary_ssl_verify_server_cert is not None:
+            if primary_ssl_verify_server_cert:
+                chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
+            else:
+                chm.append("%s=0" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
         if primary_auto_position:
             chm.append("%s=1" % command_resolver.resolve_command('MASTER_AUTO_POSITION'))
         if primary_use_gtid is not None:
@@ -723,8 +726,11 @@ def main():
             chm.append("SOURCE_SSL_KEY='%s'" % primary_ssl_key)
         if primary_ssl_cipher is not None:
             chm.append("SOURCE_SSL_CIPHER='%s'" % primary_ssl_cipher)
-        if primary_ssl_verify_server_cert:
-            chm.append("SOURCE_SSL_VERIFY_SERVER_CERT=1")
+        if primary_ssl_verify_server_cert is not None:
+            if primary_ssl_verify_server_cert:
+                chm.append("%s=1" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
+            else:
+                chm.append("%s=0" % command_resolver.resolve_command('MASTER_SSL_VERIFY_SERVER_CERT'))
         if primary_auto_position:
             chm.append("SOURCE_AUTO_POSITION=1")
         try:

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -137,7 +137,8 @@ options:
     aliases: [master_ssl_cipher]
   primary_ssl_verify_server_cert:
     description:
-    - Same as mysql variable.
+    - Same as C(MASTER_SSL_VERIFY_SERVER_CERT) MySQL/MariaDB variable.
+    - The module switch automatically to C(SOURCE_SSL_VERIFY_SERVER_CERT) for MySQL 8.0.23 and later.
     type: bool
     version_added: '3.5.0'
   primary_auto_position:

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -139,6 +139,7 @@ options:
     description:
     - Same as C(MASTER_SSL_VERIFY_SERVER_CERT) MySQL/MariaDB variable.
     - The module switch automatically to C(SOURCE_SSL_VERIFY_SERVER_CERT) for MySQL 8.0.23 and later.
+    - Prior to community.mysql 3.14.0 C(false) had no effect.
     type: bool
     version_added: '3.5.0'
   primary_auto_position:

--- a/tests/integration/targets/test_mysql_replication/tasks/issue-689.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/issue-689.yml
@@ -1,0 +1,40 @@
+---
+
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+  block:
+
+    - name: Disable ssl verification
+      community.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        mode: changeprimary
+        primary_ssl_verify_server_cert: false
+      register: result
+
+    - name: Assert that changeprimmary is changed and return expected query for MariaDB and MySQL < 8.0.23
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries == expected_queries
+      when:
+        - >
+          db_engine == 'mariadb' or
+          (db_engine == 'mysql' and db_version is version('8.0.23', '<'))
+      vars:
+        expected_queries: ["CHANGE MASTER TO MASTER_SSL_VERIFY_SERVER_CERT=0"]
+
+    - name: Assert that changeprimmary is changed and return expected query for MySQL > 8.0.23
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries == expected_queries
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('8.0.23', '>=')
+      vars:
+        expected_queries: ["CHANGE REPLICATION SOURCE TO SOURCE_SSL_VERIFY_SERVER_CERT=0"]

--- a/tests/integration/targets/test_mysql_replication/tasks/issue-689.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/issue-689.yml
@@ -38,3 +38,25 @@
         - db_version is version('8.0.23', '>=')
       vars:
         expected_queries: ["CHANGE REPLICATION SOURCE TO SOURCE_SSL_VERIFY_SERVER_CERT=0"]
+
+    - name: Disable ssl verification for MySQL 8.0.23+
+      community.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        mode: changereplication
+        primary_ssl_verify_server_cert: false
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('8.0.23', '>=')
+
+    - name: Assert that changereplication is changed and return expected query for MySQL > 8.0.23
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries == expected_queries
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('8.0.23', '>=')
+      vars:
+        expected_queries: ["CHANGE REPLICATION SOURCE TO SOURCE_SSL_VERIFY_SERVER_CERT=0"]

--- a/tests/integration/targets/test_mysql_replication/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/main.yml
@@ -31,3 +31,6 @@
   when:
     - db_engine == 'mysql'
     - db_version is version('8.0.23', '>=')
+
+# primary_ssl_verify_server_cert
+- import_tasks: issue-689.yml

--- a/tests/integration/targets/test_mysql_replication/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/main.yml
@@ -13,6 +13,10 @@
 # Tests of replication filters and force_context
 - include_tasks: issue-265.yml
 
+# primary_ssl_verify_server_cert
+# Must run before mysql add channels in mysql_replication_channel.yml
+- import_tasks: issue-689.yml
+
 # Tests of primary_delay parameter:
 - import_tasks: mysql_replication_primary_delay.yml
 
@@ -31,6 +35,3 @@
   when:
     - db_engine == 'mysql'
     - db_version is version('8.0.23', '>=')
-
-# primary_ssl_verify_server_cert
-- import_tasks: issue-689.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix #689

The primary_ssl_verify_server_cert was set to false by default. Later, the code test if this variable is true, it must have add `CHANGE MASTER TO MASTER_SSL_VERIFY_SERVER_CERT=1` or `CHANGE REPLICATION SOURCE TO SOURCE_SSL_VERIFY_SERVER_CERT=1` depending on the db engine and its version.

This PR allow to remove this flag if it was set when the replication was started.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_replication

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
