### PR TITLE
Add query to find command between python and python3

### DIFF
--- a/tests/integration/targets/setup_controller/tasks/verify.yml
+++ b/tests/integration/targets/setup_controller/tasks/verify.yml
@@ -42,8 +42,8 @@
         - connector_name == 'mysqlclient'
 
     - name: Get the python version in use
-      ansible.builtin.command:
-        cmd: python -V
+      ansible.builtin.shell:
+        cmd: echo $( $(command -v python || command -v python3) -V )
       changed_when: false
       failed_when: false
       register: python_version_in_use
@@ -52,7 +52,7 @@
       ansible.builtin.debug:
         msg: >
           Python in use inside the test container:
-          ${{ python_version_in_use }}
+          ${{ python_version_in_use.stdout }}
       when:
         - python_version_in_use is defined
 

--- a/tests/integration/targets/setup_controller/tasks/verify.yml
+++ b/tests/integration/targets/setup_controller/tasks/verify.yml
@@ -52,7 +52,7 @@
       ansible.builtin.debug:
         msg: >
           Python in use inside the test container:
-          ${{ python_version_in_use.stdout }}
+          {{ python_version_in_use.stdout }}
       when:
         - python_version_in_use is defined
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I noticed that the command `python -V` fails in integrations tests. Python is installed by https://github.com/ansible-community/ansible-test-gh-action so the test suite from `community.mysql` doesn't control what version is installed and if an alias from `python` to `python3` is added.

So this PR fix the check that verify what version of Python is present inside the test container/VM.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
CI

