### PR TITLE
Fix python2 compatibility of execution_time_ms

### DIFF
--- a/changelogs/fragments/fix_python2_compatibility.yml
+++ b/changelogs/fragments/fix_python2_compatibility.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "mysql_query - fix a Python 2 compatibility issue caused by the addition of ``execution_time_ms`` in version 3.12 (see https://github.com/ansible-collections/community.mysql/issues/716)."

--- a/plugins/modules/mysql_query.py
+++ b/plugins/modules/mysql_query.py
@@ -148,15 +148,23 @@ DDL_QUERY_KEYWORDS = ('CREATE', 'DROP', 'ALTER', 'RENAME', 'TRUNCATE')
 # Module execution.
 #
 
+def get_time():
+    try:
+        time_taken = time.perf_counter()
+    except AttributeError:
+        # For Python 2 compatibility, fallback to time.time()
+        time_taken = time.time()
+    return time_taken
+
 
 def execute_and_return_time(cursor, query, args):
     # Measure query execution time in milliseconds
-    start_time = time.perf_counter()
+    start_time = get_time()
 
     cursor.execute(query, args)
 
     # Calculate the execution time rounding it to 4 decimal places
-    exec_time_ms = round((time.perf_counter() - start_time) * 1000, 4)
+    exec_time_ms = round((get_time() - start_time) * 1000, 4)
     return cursor, exec_time_ms
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes "Restore Python 2 support broken with execution_time_ms" #716 
It still uses time.perf_counter if possible, if not it falls back to time.time

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql_query

