### PR TITLE
mysql_db: Add support for sql_log_bin option

### DIFF
--- a/changelogs/fragments/723-myqsl_db_supports_sql_log_bin.yaml
+++ b/changelogs/fragments/723-myqsl_db_supports_sql_log_bin.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - mysql_db - Add support for ``sql_log_bin`` option (https://github.com/ansible-collections/community.mysql/issues/700).

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -165,6 +165,11 @@ options:
     type: bool
     default: false
     version_added: '3.4.0'
+  sql_log_bin:
+    description:
+      - Whether binary logging should be enabled or disabled for the connection.
+    type: bool
+    default: true
 
 seealso:
 - module: community.mysql.mysql_info
@@ -633,6 +638,7 @@ def main():
         config_overrides_defaults=dict(type='bool', default=False),
         chdir=dict(type='path'),
         pipefail=dict(type='bool', default=False),
+        sql_log_bin=dict(type='bool', default=True),
     )
 
     module = AnsibleModule(
@@ -683,6 +689,7 @@ def main():
     config_overrides_defaults = module.params['config_overrides_defaults']
     chdir = module.params['chdir']
     pipefail = module.params['pipefail']
+    sql_log_bin = module.params["sql_log_bin"]
 
     if chdir:
         try:
@@ -724,6 +731,9 @@ def main():
                                  "Exception message: %s" % (config_file, to_native(e)))
         else:
             module.fail_json(msg="unable to find %s. Exception message: %s" % (config_file, to_native(e)))
+
+    if state in ['absent', 'present'] and not sql_log_bin:
+        cursor.execute("SET SQL_LOG_BIN=0;")
 
     server_implementation = get_server_implementation(cursor)
     server_version = get_server_version(cursor)

--- a/tests/integration/targets/test_mysql_db/tasks/state_present_absent.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/state_present_absent.yml
@@ -310,3 +310,99 @@
   assert:
     that:
       - db_user1 not in result.stdout
+
+# ============================================================
+- set_fact:
+    show_master_status: >-
+      {% if db_engine == 'mariadb' and db_version is version('10.5.2', '>=') %}
+        SHOW BINLOG STATUS
+      {% elif db_engine == 'mysql' and db_version is version('8.4', '>=') %}
+        SHOW BINARY LOG STATUS
+      {% else %}
+        SHOW MASTER STATUS
+      {% endif %}
+
+- name: State Present Absent | Capture binlog position
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_1
+
+- name: State Present Absent | Create database with sql_log_bin enabled
+  mysql_db:
+    login_user: '{{ mysql_user }}'
+    login_password: '{{ mysql_password }}'
+    login_host: '{{ mysql_host }}'
+    login_port: '{{ mysql_primary_port }}'
+    name: 'sql_bin_on_{{ db_name }}'
+    sql_log_bin: true
+    state: present
+
+- name: State Present Absent | Capture binlog position
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_2
+
+- name: State Present Absent | Assert binlog events were written
+  assert:
+    that:
+      - bin_log_position_1.stdout_lines[2] != bin_log_position_2.stdout_lines[2]
+
+- name: State Present Absent | Remove database with sql_log_bin enabled
+  mysql_db:
+    login_user: '{{ mysql_user }}'
+    login_password: '{{ mysql_password }}'
+    login_host: '{{ mysql_host }}'
+    login_port: '{{ mysql_primary_port }}'
+    name: 'sql_bin_on_{{ db_name }}'
+    sql_log_bin: true
+    state: absent
+
+- name: State Present Absent | Capture binlog position
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_3
+
+- name: State Present Absent | Assert Binlog events were written
+  assert:
+    that:
+      - bin_log_position_2.stdout_lines[2] != bin_log_position_3.stdout_lines[2]
+
+# ============================================================
+- name: State Present Absent | Capture binlog position
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_4
+
+- name: State Present Absent | Create database with sql_log_bin disabled
+  mysql_db:
+    login_user: '{{ mysql_user }}'
+    login_password: '{{ mysql_password }}'
+    login_host: '{{ mysql_host }}'
+    login_port: '{{ mysql_primary_port }}'
+    name: 'sql_bin_off_{{ db_name }}'
+    sql_log_bin: false
+    state: present
+
+- name: State Present Absent | Capture binlog position
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_5
+
+- name: State Present Absent | Assert binlog events were not written
+  assert:
+    that:
+      - bin_log_position_4.stdout_lines[2] == bin_log_position_5.stdout_lines[2]
+
+- name: State Present Absent | Remove database with sql_log_bin disabled
+  mysql_db:
+    login_user: '{{ mysql_user }}'
+    login_password: '{{ mysql_password }}'
+    login_host: '{{ mysql_host }}'
+    login_port: '{{ mysql_primary_port }}'
+    name: 'sql_bin_off_{{ db_name }}'
+    sql_log_bin: false
+    state: absent
+
+- name: State Present Absent | Capture binlog position
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_6
+
+- name: State Present Absent | Assert Binlog events were not written
+  assert:
+    that:
+      - bin_log_position_5.stdout_lines[2] == bin_log_position_6.stdout_lines[2]


### PR DESCRIPTION
##### SUMMARY

The mysql_db module supports creating and deleting databases without writing to the binary log.

Fix https://github.com/ansible-collections/community.mysql/issues/700

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mysql_db

##### ADDITIONAL INFORMATION

Creation foo database without writing to binary logs
```yaml
  mysql_db:
    name: foo
    sql_log_bin: false
    state: present
```
