### PR TITLE
Add `session_vars` to `mysql_query`.

### DIFF
--- a/changelogs/fragments/0_mysql_query_session_vars.yml
+++ b/changelogs/fragments/0_mysql_query_session_vars.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - '`mysql_query` - add new `session_vars` argument, similar to ansible-collections/community.mysql#489.'

--- a/tests/integration/targets/test_mysql_query/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/main.yml
@@ -7,3 +7,5 @@
 - import_tasks: mysql_query_initial.yml
 
 - include_tasks: issue-28.yml
+
+- include_tasks: session_vars.yml

--- a/tests/integration/targets/test_mysql_query/tasks/session_vars.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/session_vars.yml
@@ -1,0 +1,29 @@
+---
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+  - name: Select sql_log_bin without session vars
+    mysql_query:
+      <<: *mysql_params
+      query: SELECT @@session.sql_log_bin AS sql_log_bin
+    register: result_without_vars
+
+  - name: Select sql_log_bin with session vars
+    mysql_query:
+      <<: *mysql_params
+      query: SELECT @@session.sql_log_bin AS sql_log_bin
+      session_vars:
+        sql_log_bin: 0
+    register: result_with_vars
+
+  - name: Assert sql_log_bin is set
+    ansible.builtin.assert:
+      that:
+        - 'result_without_vars.query_result[0][0].sql_log_bin == 1'
+        - 'result_with_vars.query_result[0][0].sql_log_bin == 0'


### PR DESCRIPTION
##### SUMMARY

This commit adds a `session_vars` dict to the `mysql_query` plugin, similar to that done in #489. While this could also be done by using a list of queries, having a dictionary allows for a cleaner query, reusability (via merge key), and a more consistent experience when using different plugins (like `mysql_user`, which supports `session_vars`).

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`mysql_user`