### PR TITLE
mysql_role: column_case_sensitive default is set to true

### DIFF
--- a/changelogs/fragments/5-case_sensitive2.yml
+++ b/changelogs/fragments/5-case_sensitive2.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- mysql_role - the ``column_case_sensitive`` argument's default value has been changed to ``true``. If your playbook expected the column to be automatically uppercased for your users privileges, you should set this to ``false`` explicitly (https://github.com/ansible-collections/community.mysql/issues/578).

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -128,6 +128,7 @@ options:
       - When C(false), the field names will be upper-cased. This was the default before this
         feature was introduced but since MySQL/MariaDB is case sensitive you should set this
         to C(true) in most cases.
+      - The default changed from C(false) to C(true) in v4.0.0
     type: bool
     default: true
     version_added: '3.8.0'

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -123,12 +123,13 @@ options:
 
   column_case_sensitive:
     description:
-      - The default is C(false).
+      - The default is C(true).
       - When C(true), the module will not uppercase the field in the privileges.
       - When C(false), the field names will be upper-cased. This was the default before this
         feature was introduced but since MySQL/MariaDB is case sensitive you should set this
         to C(true) in most cases.
     type: bool
+    default: true
     version_added: '3.8.0'
 
 notes:
@@ -973,7 +974,7 @@ def main():
         check_implicit_admin=dict(type='bool', default=False),
         set_default_role_all=dict(type='bool', default=True),
         members_must_exist=dict(type='bool', default=True),
-        column_case_sensitive=dict(type='bool', default=None),  # TODO 4.0.0 add default=True
+        column_case_sensitive=dict(type='bool', default=True),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -1020,13 +1021,6 @@ def main():
 
     if mysql_driver is None:
         module.fail_json(msg=mysql_driver_fail_msg)
-
-    # TODO Release 4.0.0 : Remove this test and variable assignation
-    if column_case_sensitive is None:
-        column_case_sensitive = False
-        module.warn("Option column_case_sensitive is not provided. "
-                    "The default is now false, so the column's name will be uppercased. "
-                    "The default will be changed to true in community.mysql 4.0.0.")
 
     cursor = None
     try:

--- a/tests/integration/targets/test_mysql_role/tasks/test_column_case_sensitive.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/test_column_case_sensitive.yml
@@ -29,6 +29,7 @@
         name: column_case_sensitive
         host: '%'
         password: 'msandbox'
+        column_case_sensitive: false
 
     # ================= Reproduce failure =====================================
 
@@ -41,6 +42,7 @@
           - 'column_case_sensitive@%'
         priv:
           'mysql_role_column_case.t1': 'SELECT(a, B, cC, Dd)'
+        column_case_sensitive: false
 
     - name: Mysql_role Column case sensitive | Assert role privileges are all caps
       community.mysql.mysql_query:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.mysql/issues/578