### PR TITLE
mysql_info: remove plugin_auth_string field from output

### DIFF
--- a/changelogs/fragments/6-mysql_info.yml
+++ b/changelogs/fragments/6-mysql_info.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - mysql_info - The ``users_info`` filter does not return the ``plugin_auth_string`` field anymore. Use the `plugin_hash_string` return value instead (https://github.com/ansible-collections/community.mysql/pull/629).

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -163,7 +163,8 @@ def get_existing_authentication(cursor, user, host=None):
 
     existing_auth_list = []
 
-    # 'plugin_auth_string' contains the hash string. Must be removed in c.mysql 4.0
+    # 'plugin_auth_string' contains the hash string.
+    # Removed from mysql_info output in c.mysql 4.0.0
     # See https://github.com/ansible-collections/community.mysql/pull/629
     for r in rows:
         existing_auth_list.append({

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -147,7 +147,6 @@ EXAMPLES = r'''
       name: "{{ item.name }}"
       host: "{{ item.host }}"
       plugin: "{{ item.plugin | default(omit) }}"
-      plugin_auth_string: "{{ item.plugin_auth_string | default(omit) }}"
       plugin_hash_string: "{{ item.plugin_hash_string | default(omit) }}"
       tls_requires: "{{ item.tls_requires | default(omit) }}"
       priv: "{{ item.priv | default(omit) }}"
@@ -247,13 +246,13 @@ users_info:
     - Does not support proxy privileges. If an account has proxy privileges, they won't appear in the output.
     - Causes issues with authentications plugins C(sha256_password) and C(caching_sha2_password).
       If the output is fed to M(community.mysql.mysql_user), the
-      ``plugin_auth_string`` will most likely be unreadable due to non-binary
+      ``plugin_hash_string`` will most likely be unreadable due to non-binary
       characters.
     - The "locked" field was aded in ``community.mysql`` 3.13.
   returned: if not excluded by filter
   type: dict
   sample:
-  - { "plugin_auth_string": '*1234567',
+  - { "plugin_hash_string": '*1234567',
       "name": "user1",
       "host": "host.com",
       "plugin": "mysql_native_password",
@@ -659,6 +658,8 @@ class MySQL_Info(object):
             authentications = get_existing_authentication(self.cursor, user, host)
             if authentications:
                 output_dict.update(authentications[0])
+                # https://github.com/ansible-collections/community.mysql/pull/629
+                output_dict.pop('plugin_auth_string', None)
 
             if line.get('is_role') and line['is_role'] == 'N':
                 output_dict['locked'] = user_is_locked(self.cursor, user, host)


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.mysql/issues/633

I proceeded with option 2 from https://github.com/ansible-collections/community.mysql/issues/633