### PR TITLE
mysql_info: Add support for source terminology for slave_status filter

### DIFF
--- a/changelogs/fragments/mysql_info_fix_slave_status_for_source_terminology.yaml
+++ b/changelogs/fragments/mysql_info_fix_slave_status_for_source_terminology.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql_info - Fix slave status for source terminology (https://github.com/ansible-collections/community.mysql/issues/682).

--- a/changelogs/fragments/mysql_info_fix_slave_status_for_source_terminology.yaml
+++ b/changelogs/fragments/mysql_info_fix_slave_status_for_source_terminology.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - mysql_info - Fix slave status for source terminology (https://github.com/ansible-collections/community.mysql/issues/682).
+  - mysql_info - Fix slave status for source terminology introduced in MySQL 8.0.23 (https://github.com/ansible-collections/community.mysql/issues/682).

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -531,20 +531,20 @@ class MySQL_Info(object):
         res = self.__exec_sql(query)
         if res:
             for line in res:
-                host = line['Master_Host']
+                host = line.get('Master_Host') or line.get('Source_Host')
                 if host not in self.info['slave_status']:
                     self.info['slave_status'][host] = {}
 
-                port = line['Master_Port']
+                port = line.get('Master_Port') or line.get('Source_Port')
                 if port not in self.info['slave_status'][host]:
                     self.info['slave_status'][host][port] = {}
 
-                user = line['Master_User']
+                user = line.get('Master_User') or line.get('Source_User')
                 if user not in self.info['slave_status'][host][port]:
                     self.info['slave_status'][host][port][user] = {}
 
                 for vname, val in line.items():
-                    if vname not in ('Master_Host', 'Master_Port', 'Master_User'):
+                    if vname not in ('Master_Host', 'Master_Port', 'Master_User', 'Source_Host', 'Source_Port', 'Source_User'):
                         self.info['slave_status'][host][port][user][vname] = self.__convert(val)
 
     def __get_slaves(self):

--- a/tests/integration/targets/test_mysql_info/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_info/defaults/main.yml
@@ -4,6 +4,7 @@ mysql_user: root
 mysql_password: msandbox
 mysql_host: '{{ gateway_addr }}'
 mysql_primary_port: 3307
+mysql_replica1_port: 3308
 
 db_name: data
 

--- a/tests/integration/targets/test_mysql_info/tasks/issue-682.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/issue-682.yml
@@ -1,0 +1,28 @@
+---
+
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_replica1_port }}'
+
+  block:
+
+    - name: Skip non-affected versions
+      meta: end_play
+      when:
+        - db_engine != 'mysql' or db_version is version('8.0.23', '<')
+
+    - name: Test mysql_info with slave_status filter on replica database
+      mysql_info:
+        <<: *mysql_params
+        filter: slave_status
+      register: slave_status_result
+      ignore_errors: yes
+
+    - name: Assert that mysql_info with slave_status returns data
+      assert:
+        that:
+          - slave_status_result is not failed
+        fail_msg: "mysql_info with slave_status filter crashed: {{ slave_status_result.msg | default('Unknown error') }}"

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -141,3 +141,5 @@
     - name: Import tasks file to tests users_info filter
       ansible.builtin.import_tasks:
         file: filter_users_info.yml
+
+    - include_tasks: issue-682.yml


### PR DESCRIPTION
##### SUMMARY
This is a bugfix for the `mysql_info` module when using the `slave_status` filter. For MySQL >= 8.0.23, the command resolver uses `SHOW REPLICA STATUS` instead of `SHOW SLAVE STATUS`, which alters the output structure of the result. Currently, the processing of the result crashes since it expects some keys named `Master_*` to be present, which are renamed to `Source_*` when using the aforementioned `REPLICA` version of the command.

In this PR, I adjusted the processing of the output to support both variants, thus enabling the filter to be used with recent versions of MySQL again.

Fixes: #682 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
mysql_info module

##### ADDITIONAL INFORMATION
This fix focuses specifically on the keys required for proper result processing. While `SHOW REPLICA STATUS` renames many additional keys in the output, I consider mapping all terminology changes of scope for this bugfix. The goal is to restore basic functionality of the `slave_status` filter without introducing breaking changes to the existing output format.