### PR TITLE
[stable-3] mysql_info: Add support for source terminology for slave_status filter (#747)

### DIFF
--- a/changelogs/fragments/mysql_info_fix_slave_status_for_source_terminology.yaml
+++ b/changelogs/fragments/mysql_info_fix_slave_status_for_source_terminology.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql_info - Fix slave status for source terminology introduced in MySQL 8.0.23 (https://github.com/ansible-collections/community.mysql/issues/682).

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -533,20 +533,20 @@ class MySQL_Info(object):
         res = self.__exec_sql(query)
         if res:
             for line in res:
-                host = line['Master_Host']
+                host = line.get('Master_Host') or line.get('Source_Host')
                 if host not in self.info['slave_status']:
                     self.info['slave_status'][host] = {}
 
-                port = line['Master_Port']
+                port = line.get('Master_Port') or line.get('Source_Port')
                 if port not in self.info['slave_status'][host]:
                     self.info['slave_status'][host][port] = {}
 
-                user = line['Master_User']
+                user = line.get('Master_User') or line.get('Source_User')
                 if user not in self.info['slave_status'][host][port]:
                     self.info['slave_status'][host][port][user] = {}
 
                 for vname, val in iteritems(line):
-                    if vname not in ('Master_Host', 'Master_Port', 'Master_User'):
+                    if vname not in ('Master_Host', 'Master_Port', 'Master_User', 'Source_Host', 'Source_Port', 'Source_User'):
                         self.info['slave_status'][host][port][user][vname] = self.__convert(val)
 
     def __get_slaves(self):

--- a/tests/integration/targets/test_mysql_info/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_info/defaults/main.yml
@@ -4,6 +4,7 @@ mysql_user: root
 mysql_password: msandbox
 mysql_host: '{{ gateway_addr }}'
 mysql_primary_port: 3307
+mysql_replica1_port: 3308
 
 db_name: data
 

--- a/tests/integration/targets/test_mysql_info/tasks/issue-682.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/issue-682.yml
@@ -1,0 +1,28 @@
+---
+
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_replica1_port }}'
+
+  block:
+
+    - name: Skip non-affected versions
+      meta: end_play
+      when:
+        - db_engine != 'mysql' or db_version is version('8.0.23', '<')
+
+    - name: Test mysql_info with slave_status filter on replica database
+      mysql_info:
+        <<: *mysql_params
+        filter: slave_status
+      register: slave_status_result
+      ignore_errors: yes
+
+    - name: Assert that mysql_info with slave_status returns data
+      assert:
+        that:
+          - slave_status_result is not failed
+        fail_msg: "mysql_info with slave_status filter crashed: {{ slave_status_result.msg | default('Unknown error') }}"

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -141,3 +141,5 @@
     - name: Import tasks file to tests users_info filter
       ansible.builtin.import_tasks:
         file: filter_users_info.yml
+
+    - include_tasks: issue-682.yml


### PR DESCRIPTION
* mysql_info: Add support for source terminology for slave_status filter

* Update changelogs/fragments/mysql_info_fix_slave_status_for_source_terminology.yaml

---------



(cherry picked from commit fad6bc7564952f541058ea585cfdeb4792a99cca)

##### SUMMARY
Backport for https://github.com/ansible-collections/community.mysql/pull/747