### PR TITLE
mysql_role: add sql_log_bin support (#742)

### DIFF
--- a/changelogs/fragments/742-mysql_role-sql_log_bin.yml
+++ b/changelogs/fragments/742-mysql_role-sql_log_bin.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - mysql_role - add ``sql_log_bin`` option to disable binary logging for the connection (https://github.com/ansible-collections/community.mysql/issues/742).

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -138,7 +138,7 @@ options:
       - Whether binary logging should be enabled or disabled for the connection.
     type: bool
     default: true
-    version_added: '4.0.0'
+    version_added: '4.1.0'
 
 notes:
   - Roles are supported since MySQL 8.0.0 and MariaDB 10.0.5.

--- a/tests/integration/targets/test_mysql_role/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/main.yml
@@ -25,6 +25,7 @@
 
 # Test sql_log_bin parameter
 # (https://github.com/ansible-collections/community.mysql/issues/742)
-- include_tasks: test_sql_log_bin.yml
+- name: Test sql_log_bin parameter
+  ansible.builtin.include_tasks: test_sql_log_bin.yml
   when:
     - db_engine == 'mysql'

--- a/tests/integration/targets/test_mysql_role/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/main.yml
@@ -22,3 +22,9 @@
 - name: Test column case sensitive
   ansible.builtin.import_tasks:
     file: test_column_case_sensitive.yml
+
+# Test sql_log_bin parameter
+# (https://github.com/ansible-collections/community.mysql/issues/742)
+- include_tasks: test_sql_log_bin.yml
+  when:
+    - db_engine == 'mysql'

--- a/tests/integration/targets/test_mysql_role/tasks/test_sql_log_bin.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/test_sql_log_bin.yml
@@ -3,7 +3,7 @@
 # https://github.com/ansible-collections/community.mysql/issues/742
 
 - name: Sql_log_bin | Set show_master_status variable
-  set_fact:
+  ansible.builtin.set_fact:
     show_master_status: >-
       {% if db_engine == 'mysql' and db_version is version('8.4', '>=') %}
         SHOW BINARY LOG STATUS
@@ -15,11 +15,11 @@
 # Test sql_log_bin: true (default behavior - binlog events should be written)
 # ============================================================
 - name: Sql_log_bin | Capture binlog position before creating role with sql_log_bin enabled
-  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  ansible.builtin.command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
   register: bin_log_position_1
 
 - name: Sql_log_bin | Create role with sql_log_bin enabled
-  mysql_role:
+  community.mysql.mysql_role:
     login_user: '{{ mysql_user }}'
     login_password: '{{ mysql_password }}'
     login_host: '{{ mysql_host }}'
@@ -29,16 +29,12 @@
     state: present
 
 - name: Sql_log_bin | Capture binlog position after creating role with sql_log_bin enabled
-  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  ansible.builtin.command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
   register: bin_log_position_2
-
-- name: Sql_log_bin | Assert binlog events were written when sql_log_bin is true
-  assert:
-    that:
-      - bin_log_position_1.stdout_lines[2] != bin_log_position_2.stdout_lines[2]
+  failed_when: bin_log_position_1.stdout_lines[2] == bin_log_position_2.stdout_lines[2]
 
 - name: Sql_log_bin | Remove role with sql_log_bin enabled
-  mysql_role:
+  community.mysql.mysql_role:
     login_user: '{{ mysql_user }}'
     login_password: '{{ mysql_password }}'
     login_host: '{{ mysql_host }}'
@@ -48,23 +44,19 @@
     state: absent
 
 - name: Sql_log_bin | Capture binlog position after removing role with sql_log_bin enabled
-  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  ansible.builtin.command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
   register: bin_log_position_3
-
-- name: Sql_log_bin | Assert binlog events were written when removing role with sql_log_bin true
-  assert:
-    that:
-      - bin_log_position_2.stdout_lines[2] != bin_log_position_3.stdout_lines[2]
+  failed_when: bin_log_position_2.stdout_lines[2] == bin_log_position_3.stdout_lines[2]
 
 # ============================================================
 # Test sql_log_bin: false (binlog events should NOT be written)
 # ============================================================
 - name: Sql_log_bin | Capture binlog position before creating role with sql_log_bin disabled
-  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  ansible.builtin.command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
   register: bin_log_position_4
 
 - name: Sql_log_bin | Create role with sql_log_bin disabled
-  mysql_role:
+  community.mysql.mysql_role:
     login_user: '{{ mysql_user }}'
     login_password: '{{ mysql_password }}'
     login_host: '{{ mysql_host }}'
@@ -74,16 +66,12 @@
     state: present
 
 - name: Sql_log_bin | Capture binlog position after creating role with sql_log_bin disabled
-  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  ansible.builtin.command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
   register: bin_log_position_5
-
-- name: Sql_log_bin | Assert binlog events were not written when sql_log_bin is false
-  assert:
-    that:
-      - bin_log_position_4.stdout_lines[2] == bin_log_position_5.stdout_lines[2]
+  failed_when: bin_log_position_4.stdout_lines[2] != bin_log_position_5.stdout_lines[2]
 
 - name: Sql_log_bin | Remove role with sql_log_bin disabled
-  mysql_role:
+  community.mysql.mysql_role:
     login_user: '{{ mysql_user }}'
     login_password: '{{ mysql_password }}'
     login_host: '{{ mysql_host }}'
@@ -93,10 +81,6 @@
     state: absent
 
 - name: Sql_log_bin | Capture binlog position after removing role with sql_log_bin disabled
-  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  ansible.builtin.command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
   register: bin_log_position_6
-
-- name: Sql_log_bin | Assert binlog events were not written when removing role with sql_log_bin false
-  assert:
-    that:
-      - bin_log_position_5.stdout_lines[2] == bin_log_position_6.stdout_lines[2]
+  failed_when: bin_log_position_5.stdout_lines[2] != bin_log_position_6.stdout_lines[2]

--- a/tests/integration/targets/test_mysql_role/tasks/test_sql_log_bin.yml
+++ b/tests/integration/targets/test_mysql_role/tasks/test_sql_log_bin.yml
@@ -1,0 +1,102 @@
+---
+# Test sql_log_bin parameter for mysql_role module
+# https://github.com/ansible-collections/community.mysql/issues/742
+
+- name: Sql_log_bin | Set show_master_status variable
+  set_fact:
+    show_master_status: >-
+      {% if db_engine == 'mysql' and db_version is version('8.4', '>=') %}
+        SHOW BINARY LOG STATUS
+      {% else %}
+        SHOW MASTER STATUS
+      {% endif %}
+
+# ============================================================
+# Test sql_log_bin: true (default behavior - binlog events should be written)
+# ============================================================
+- name: Sql_log_bin | Capture binlog position before creating role with sql_log_bin enabled
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_1
+
+- name: Sql_log_bin | Create role with sql_log_bin enabled
+  mysql_role:
+    login_user: '{{ mysql_user }}'
+    login_password: '{{ mysql_password }}'
+    login_host: '{{ mysql_host }}'
+    login_port: '{{ mysql_primary_port }}'
+    name: 'test_role_bin_on'
+    sql_log_bin: true
+    state: present
+
+- name: Sql_log_bin | Capture binlog position after creating role with sql_log_bin enabled
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_2
+
+- name: Sql_log_bin | Assert binlog events were written when sql_log_bin is true
+  assert:
+    that:
+      - bin_log_position_1.stdout_lines[2] != bin_log_position_2.stdout_lines[2]
+
+- name: Sql_log_bin | Remove role with sql_log_bin enabled
+  mysql_role:
+    login_user: '{{ mysql_user }}'
+    login_password: '{{ mysql_password }}'
+    login_host: '{{ mysql_host }}'
+    login_port: '{{ mysql_primary_port }}'
+    name: 'test_role_bin_on'
+    sql_log_bin: true
+    state: absent
+
+- name: Sql_log_bin | Capture binlog position after removing role with sql_log_bin enabled
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_3
+
+- name: Sql_log_bin | Assert binlog events were written when removing role with sql_log_bin true
+  assert:
+    that:
+      - bin_log_position_2.stdout_lines[2] != bin_log_position_3.stdout_lines[2]
+
+# ============================================================
+# Test sql_log_bin: false (binlog events should NOT be written)
+# ============================================================
+- name: Sql_log_bin | Capture binlog position before creating role with sql_log_bin disabled
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_4
+
+- name: Sql_log_bin | Create role with sql_log_bin disabled
+  mysql_role:
+    login_user: '{{ mysql_user }}'
+    login_password: '{{ mysql_password }}'
+    login_host: '{{ mysql_host }}'
+    login_port: '{{ mysql_primary_port }}'
+    name: 'test_role_bin_off'
+    sql_log_bin: false
+    state: present
+
+- name: Sql_log_bin | Capture binlog position after creating role with sql_log_bin disabled
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_5
+
+- name: Sql_log_bin | Assert binlog events were not written when sql_log_bin is false
+  assert:
+    that:
+      - bin_log_position_4.stdout_lines[2] == bin_log_position_5.stdout_lines[2]
+
+- name: Sql_log_bin | Remove role with sql_log_bin disabled
+  mysql_role:
+    login_user: '{{ mysql_user }}'
+    login_password: '{{ mysql_password }}'
+    login_host: '{{ mysql_host }}'
+    login_port: '{{ mysql_primary_port }}'
+    name: 'test_role_bin_off'
+    sql_log_bin: false
+    state: absent
+
+- name: Sql_log_bin | Capture binlog position after removing role with sql_log_bin disabled
+  command: "{{ mysql_command }} -e \"{{ show_master_status }}\\G\""
+  register: bin_log_position_6
+
+- name: Sql_log_bin | Assert binlog events were not written when removing role with sql_log_bin false
+  assert:
+    that:
+      - bin_log_position_5.stdout_lines[2] == bin_log_position_6.stdout_lines[2]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add `sql_log_bin` option to disable binary logging for the connection similar to the mysql_user module
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #742 
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mysql_role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Create role without binary logging
  community.mysql.mysql_role:
    name: readers
    state: present
    priv: 'fiction.*:SELECT'
    sql_log_bin: false
```
