### PR TITLE
ci: add ingore.txt entry to avoid failures with core 2.21

### DIFF
--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,3 +1,3 @@
-plugins/modules/mysql_db.py validate-modules:use-run-command-not-popen
+plugins/modules/mysql_db.py pylint:ansible-bad-function
 plugins/module_utils/mysql.py pylint:unused-import
 plugins/module_utils/version.py pylint:unused-import


### PR DESCRIPTION
##### SUMMARY
ci: add ingore.txt entry to avoid failures with core 2.21

i investigated a lot: we can't use run_command instead of Popen because it doesn't provide a pipe that will transmit data from a dump to stdin of mysql