### PR TITLE
Fix deprecated imports

### DIFF
--- a/changelogs/fragments/fix_deprecated_imports.yaml
+++ b/changelogs/fragments/fix_deprecated_imports.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - Update imports from ansible.module_utils._text to use ansible.module_utils.common.text.converters
+breaking_changes:
+  - Update imports from ansible.module_utils.six to use their python3 equivalent. This change will make this collection incompatible for managed hosts on python2.7.

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -14,9 +14,9 @@ from functools import reduce
 __metaclass__ = type
 
 import os
+import configparser
 
-from ansible.module_utils.six.moves import configparser
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     import pymysql as mysql_driver

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -347,6 +347,7 @@ executed_commands:
 import os
 import subprocess
 import traceback
+import shlex
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.mysql.plugins.module_utils.database import mysql_quote_identifier
@@ -359,8 +360,7 @@ from ansible_collections.community.mysql.plugins.module_utils.mysql import (
     get_server_version,
 )
 from ansible_collections.community.mysql.plugins.module_utils.version import LooseVersion
-from ansible.module_utils.six.moves import shlex_quote
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 executed_commands = []
 
@@ -405,46 +405,46 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
     # If defined, mysqldump demands --defaults-extra-file be the first option
     if config_file:
         if restrict_config_file:
-            cmd.append("--defaults-file=%s" % shlex_quote(config_file))
+            cmd.append("--defaults-file=%s" % shlex.quote(config_file))
         else:
-            cmd.append("--defaults-extra-file=%s" % shlex_quote(config_file))
+            cmd.append("--defaults-extra-file=%s" % shlex.quote(config_file))
 
     if check_implicit_admin:
         cmd.append("--user=root --password=''")
     else:
         if user is not None:
-            cmd.append("--user=%s" % shlex_quote(user))
+            cmd.append("--user=%s" % shlex.quote(user))
 
         if password is not None:
             if not unsafe_password:
-                cmd.append("--password=%s" % shlex_quote(password))
+                cmd.append("--password=%s" % shlex.quote(password))
             else:
                 cmd.append("--password=%s" % password)
 
     if ssl_cert is not None:
-        cmd.append("--ssl-cert=%s" % shlex_quote(ssl_cert))
+        cmd.append("--ssl-cert=%s" % shlex.quote(ssl_cert))
     if ssl_key is not None:
-        cmd.append("--ssl-key=%s" % shlex_quote(ssl_key))
+        cmd.append("--ssl-key=%s" % shlex.quote(ssl_key))
     if ssl_ca is not None:
-        cmd.append("--ssl-ca=%s" % shlex_quote(ssl_ca))
+        cmd.append("--ssl-ca=%s" % shlex.quote(ssl_ca))
     if force:
         cmd.append("--force")
     if socket is not None:
-        cmd.append("--socket=%s" % shlex_quote(socket))
+        cmd.append("--socket=%s" % shlex.quote(socket))
     else:
-        cmd.append("--host=%s --port=%i" % (shlex_quote(host), port))
+        cmd.append("--host=%s --port=%i" % (shlex.quote(host), port))
 
     if all_databases:
         cmd.append("--all-databases")
     elif len(db_name) > 1:
         cmd.append("--databases {0}".format(' '.join(db_name)))
     else:
-        cmd.append("%s" % shlex_quote(' '.join(db_name)))
+        cmd.append("%s" % shlex.quote(' '.join(db_name)))
 
     if skip_lock_tables:
         cmd.append("--skip-lock-tables")
     if (encoding is not None) and (encoding != ""):
-        cmd.append("--default-character-set=%s" % shlex_quote(encoding))
+        cmd.append("--default-character-set=%s" % shlex.quote(encoding))
     if single_transaction:
         cmd.append("--single-transaction=true")
     if quick:
@@ -476,11 +476,11 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
     cmd = ' '.join(cmd)
 
     if path:
-        cmd = '%s | %s > %s' % (cmd, path, shlex_quote(target))
+        cmd = '%s | %s > %s' % (cmd, path, shlex.quote(target))
         if pipefail:
             cmd = 'set -o pipefail && ' + cmd
     else:
-        cmd += " > %s" % shlex_quote(target)
+        cmd += " > %s" % shlex.quote(target)
 
     executed_commands.append(cmd)
 
@@ -511,40 +511,40 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
     # --defaults-file must go first, or errors out
     if config_file:
         if restrict_config_file:
-            cmd.append("--defaults-file=%s" % shlex_quote(config_file))
+            cmd.append("--defaults-file=%s" % shlex.quote(config_file))
         else:
-            cmd.append("--defaults-extra-file=%s" % shlex_quote(config_file))
+            cmd.append("--defaults-extra-file=%s" % shlex.quote(config_file))
 
     if check_implicit_admin:
         cmd.append("--user=root --password=''")
     else:
         if user:
-            cmd.append("--user=%s" % shlex_quote(user))
+            cmd.append("--user=%s" % shlex.quote(user))
 
         if password:
             if not unsafe_password:
-                cmd.append("--password=%s" % shlex_quote(password))
+                cmd.append("--password=%s" % shlex.quote(password))
             else:
                 cmd.append("--password=%s" % password)
 
     if ssl_cert is not None:
-        cmd.append("--ssl-cert=%s" % shlex_quote(ssl_cert))
+        cmd.append("--ssl-cert=%s" % shlex.quote(ssl_cert))
     if ssl_key is not None:
-        cmd.append("--ssl-key=%s" % shlex_quote(ssl_key))
+        cmd.append("--ssl-key=%s" % shlex.quote(ssl_key))
     if ssl_ca is not None:
-        cmd.append("--ssl-ca=%s" % shlex_quote(ssl_ca))
+        cmd.append("--ssl-ca=%s" % shlex.quote(ssl_ca))
     if force:
         cmd.append("-f")
     if socket is not None:
-        cmd.append("--socket=%s" % shlex_quote(socket))
+        cmd.append("--socket=%s" % shlex.quote(socket))
     else:
-        cmd.append("--host=%s" % shlex_quote(host))
+        cmd.append("--host=%s" % shlex.quote(host))
         cmd.append("--port=%i" % port)
     if (encoding is not None) and (encoding != ""):
-        cmd.append("--default-character-set=%s" % shlex_quote(encoding))
+        cmd.append("--default-character-set=%s" % shlex.quote(encoding))
     if not all_databases:
         cmd.append("--one-database")
-        cmd.append(shlex_quote(''.join(db_name)))
+        cmd.append(shlex.quote(''.join(db_name)))
 
     comp_prog_path = None
     if os.path.splitext(target)[-1] == '.gz':
@@ -577,13 +577,13 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
             # FYI: passing the `shell=True` argument to p2 = subprocess.Popen()
             # doesn't solve the problem.
             cmd = " ".join(cmd)
-            cmd = "%s -dc %s | %s" % (comp_prog_path, shlex_quote(target), cmd)
+            cmd = "%s -dc %s | %s" % (comp_prog_path, shlex.quote(target), cmd)
             rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
             return rc, stdout, stderr
 
     else:
         cmd = ' '.join(cmd)
-        cmd += " < %s" % shlex_quote(target)
+        cmd += " < %s" % shlex.quote(target)
         executed_commands.append(cmd)
         rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
         return rc, stdout, stderr

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -327,7 +327,7 @@ from ansible_collections.community.mysql.plugins.module_utils.user import (
     get_user_implementation,
     user_is_locked,
 )
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 # ===========================================

--- a/plugins/modules/mysql_query.py
+++ b/plugins/modules/mysql_query.py
@@ -146,7 +146,7 @@ from ansible_collections.community.mysql.plugins.module_utils.mysql import (
     mysql_driver_fail_msg,
     set_session_vars,
 )
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 DML_QUERY_KEYWORDS = ('INSERT', 'UPDATE', 'DELETE', 'REPLACE')
 # TRUNCATE is not DDL query but it also returns 0 rows affected:

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -315,7 +315,7 @@ from ansible_collections.community.mysql.plugins.module_utils.mysql import (
     mysql_driver_fail_msg,
     mysql_common_argument_spec,
 )
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 executed_queries = []
 

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -334,7 +334,7 @@ from ansible_collections.community.mysql.plugins.module_utils.user import (
     privileges_grant,
     privileges_unpack,
 )
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def normalize_users(module, users, is_mariadb=False):

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -450,7 +450,7 @@ from ansible_collections.community.mysql.plugins.module_utils.user import (
     user_exists,
     user_mod,
 )
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 # ===========================================

--- a/plugins/modules/mysql_variables.py
+++ b/plugins/modules/mysql_variables.py
@@ -103,7 +103,7 @@ from re import match
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.mysql.plugins.module_utils.database import SQLParseError, mysql_quote_identifier
 from ansible_collections.community.mysql.plugins.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg, mysql_common_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 executed_queries = []
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updates imports to resolve #771 and address deprecation of ansible.module_utils.six.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Module imports
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This change will make this collection incompatible with managed hosts running Python 2.7.
<!--- Paste verbatim command output below, e.g. before and after your change -->
