### PR TITLE
Add parsec to ed25519 plugin check

### DIFF
--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -232,7 +232,7 @@ def user_add(cursor, user, host, host_all, password, encrypted,
         # Mysql and MariaDB differ in naming pam plugin and Syntax to set it
         if plugin == 'pam':  # Used by MariaDB which requires the USING keyword, not BY
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
-        elif plugin == 'ed25519':  # Used by MariaDB which requires the USING keyword, not BY
+        elif plugin == 'ed25519' or 'parsec':  # Used by MariaDB which requires the USING keyword, not BY
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING PASSWORD(%s)", (user, host, plugin, plugin_auth_string)
         elif salt:
             if plugin in ['caching_sha2_password', 'sha256_password']:

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -232,7 +232,7 @@ def user_add(cursor, user, host, host_all, password, encrypted,
         # Mysql and MariaDB differ in naming pam plugin and Syntax to set it
         if plugin == 'pam':  # Used by MariaDB which requires the USING keyword, not BY
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING %s", (user, host, plugin, plugin_auth_string)
-        elif plugin == 'ed25519' or 'parsec':  # Used by MariaDB which requires the USING keyword, not BY
+        elif plugin in ['ed25519', 'parsec']:  # Used by MariaDB which requires the USING keyword, not BY
             query_with_args = "CREATE USER %s@%s IDENTIFIED WITH %s USING PASSWORD(%s)", (user, host, plugin, plugin_auth_string)
         elif salt:
             if plugin in ['caching_sha2_password', 'sha256_password']:


### PR DESCRIPTION
##### SUMMARY
When creating a new user, and specifying parsec as plugin it will generate the wrong SQL query.
It should be added to the same plugin check as ed25519 so that it generates a query using` USING PASSWORDS(%s)`
instead of `BY %s`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`community.mysql.mysql_user`

##### ADDITIONAL INFORMATION
MariaDB has intended parsec to be the default in future releases. It is avaiable since MariaDB 11.6 the docs for reference:
[ https://mariadb.com/docs/server/reference/plugins/authentication-plugins/authentication-plugin-parsec](https://mariadb.com/docs/server/reference/plugins/authentication-plugins/authentication-plugin-parsec)