### PR TITLE
Release 5.0.0 commit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,21 @@ Community MySQL and MariaDB Collection Release Notes
 
 This changelog describes changes after version 2.0.0.
 
+v5.0.0
+======
+
+Release Summary
+---------------
+
+This is a major release of the ``ansible.mysql`` collection.
+Since this version, ``ansible.mysql`` superseds the ``community.mysql`` collection.
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- The collection supports ansible-core version ``>= 2.16.0``.
+- mysql_user - the deprecated ``user`` alias of the ``name`` argument has been removed. Use the ``name`` argument instead.
+
 v4.2.1
 ======
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,9 @@ Here is the table for the support timeline:
 
 - 1.x.y: released 2020-08-17, EOL
 - 2.x.y: released 2021-04-15, EOL
-- 3.x.y: released 2021-12-01, EOL 2027-09-30
-- 4.x.y: released 2025-09-15, current
-- 5.x.y: To be released
-
+- 3.x.y: released 2021-12-01, EOL
+- 4.x.y: released 2025-09-15, EOL 2028-05-05
+- 5.x.y: released 2026-05-05, current
 
 ## Tested with
 
@@ -161,10 +160,20 @@ ansible-galaxy collection install ansible.mysql --upgrade
 You can also install a specific version of the collection, for example, if you need to downgrade when something is broken in the latest version (please report an issue in this repository). Use the following syntax:
 
 ```bash
-ansible-galaxy collection install ansible.mysql:==2.0.0
+ansible-galaxy collection install ansible.mysql:==5.0.0
 ```
 
 See [Ansible Using collections](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html) for more details.
+
+## Support
+
+If you obtained this collection from:
+- Ansible community package, Ansible Galaxy, or GitHub: open an issue in this repository or start a forum topic. See the [Communication section](https://github.com/ansible-collections/ansible.mysql#communication) for details.
+- Automation Hub: as Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner.
+
+## Release notes
+
+See the [CHANGELOG.rst](https://github.com/ansible-collections/ansible.mysql/blob/main/CHANGELOG.rst) for all changes.
 
 ## Licensing
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -742,3 +742,15 @@ releases:
     - 4.2.1.yml
     - mysql_query_decimal_serialization.yaml
     release_date: '2026-05-04'
+  5.0.0:
+    changes:
+      breaking_changes:
+      - The collection supports ansible-core version ``>= 2.16.0``.
+      - mysql_user - the deprecated ``user`` alias of the ``name`` argument has been removed. Use the ``name`` argument instead.
+      release_summary: 'This is a major release of the ``ansible.mysql`` collection.
+
+        Since this version, ``ansible.mysql`` superseds the ``community.mysql`` collection.'
+    fragments:
+    - 2-16-0.yml
+    - 5.0.0.yml
+    release_date: '2026-05-04'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: ansible
 name: mysql
-version: 4.2.1
+version: 5.0.0
 readme: README.md
 authors:
   - Ansible community

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.16.0'
 action_groups:
   all:
     - mysql_db

--- a/plugins/modules/mysql_user.py
+++ b/plugins/modules/mysql_user.py
@@ -20,7 +20,6 @@ options:
       - Name of the user (role) to add or remove.
     type: str
     required: true
-    aliases: ['user']
   password:
     description:
       - Set the user's password. Only for C(mysql_native_password) authentication.
@@ -461,13 +460,7 @@ from ansible.module_utils.common.text.converters import to_native
 def main():
     argument_spec = mysql_common_argument_spec()
     argument_spec.update(
-        name=dict(type='str', required=True, aliases=['user'], deprecated_aliases=[
-            {
-                'name': 'user',
-                'version': '5.0.0',
-                'collection_name': 'ansible.mysql',
-            }],
-        ),
+        name=dict(type='str', required=True),
         password=dict(type='str', no_log=True),
         encrypted=dict(type='bool', default=False),
         host=dict(type='str', default='localhost'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pymysql


### PR DESCRIPTION
##### SUMMARY
Release 5.0.0 commit

Fixes https://github.com/ansible-collections/ansible.mysql/issues/669

This PR:
- Removes a deprecated aliase

Certification compliance:
- Add the Support and Release notes sections to README
- Marks version 3 as EOL, makes 4 supported for 2 years since now
- Bumps requires_ansible to >=2.16 (we should've done it many years ago)
- Adds requirements.txt with pymysql for EE building support (later we'll add proper files like execution-environments.yml, etc.)

