### PR TITLE
ci(ansible-test-plugins.yml): add stable-2.21 to integration tests; remove remnants of stable-2.15

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -29,6 +29,7 @@ jobs:
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         db_engine_name:
           - mysql
@@ -83,6 +84,12 @@ jobs:
             ansible: stable-2.17
 
           - db_engine_version: '8.0.38'
+            ansible: stable-2.21
+
+          - db_engine_version: '10.11.8'
+            ansible: stable-2.21
+
+          - db_engine_version: '8.0.38'
             ansible: devel
 
           - db_engine_version: '10.11.8'
@@ -99,12 +106,6 @@ jobs:
 
           - db_engine_version: '10.11.8'
             connector_version: '2.0.1'
-
-          - db_engine_version: '10.11.8'
-            ansible: stable-2.15
-
-          - db_engine_version: '8.4.1'
-            ansible: stable-2.15
 
     services:
       db_primary:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Here is the table for the support timeline:
 - stable-2.18
 - stable-2.19
 - stable-2.20
+- stable-2.21
 - current development version
 
 ### Python


### PR DESCRIPTION
##### SUMMARY
ci(ansible-test-plugins.yml): add stable-2.21 to integration tests; remove remnants of stable-2.15