### PR TITLE
feat: add mysql_audit, mysql_tls, and mysql_password_policy modules

### DIFF
--- a/changelogs/fragments/mysql_audit.yaml
+++ b/changelogs/fragments/mysql_audit.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+  - mysql_audit - new module to manage MySQL audit log plugin, filters,
+    and user assignments (https://github.com/ansible-collections/ansible.mysql/pull/XXXX).
+  - mysql_audit_info - new module to gather information about MySQL audit
+    log configuration (https://github.com/ansible-collections/ansible.mysql/pull/XXXX).

--- a/changelogs/fragments/mysql_password_policy.yaml
+++ b/changelogs/fragments/mysql_password_policy.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - mysql_password_policy - new module to manage the MySQL validate_password component
+    and configure password complexity, lifetime, history, and reuse policies
+    (https://github.com/ansible-collections/ansible.mysql/pull/XXXX).

--- a/changelogs/fragments/mysql_tls.yaml
+++ b/changelogs/fragments/mysql_tls.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - mysql_tls - new module to configure server-side TLS settings for MySQL 8.0+,
+    including certificate paths, secure transport enforcement, TLS version control,
+    and hot-reload support (https://github.com/ansible-collections/ansible.mysql/pull/XXXX).

--- a/plugins/modules/mysql_audit.py
+++ b/plugins/modules/mysql_audit.py
@@ -1,0 +1,422 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_audit
+
+short_description: Manage MySQL audit log plugin and filters
+
+description:
+- Install or uninstall the MySQL audit log plugin.
+- Configure audit log filters and assign them to users.
+- Set the audit log format and trigger log rotation.
+- Supports the component_audit_api_message_emit component (MySQL 8.0+)
+  and the audit_log plugin.
+
+version_added: '5.1.0'
+
+author:
+- Steve Fulmer (@stevefulme1)
+
+options:
+  state:
+    description:
+    - Whether the audit plugin should be installed (C(present)) or removed (C(absent)).
+    type: str
+    choices: ['present', 'absent']
+    default: present
+    version_added: '5.1.0'
+  log_format:
+    description:
+    - The audit log output format.
+    - Only applied when the audit plugin is installed.
+    type: str
+    choices: ['JSON', 'XML', 'CSV']
+    default: JSON
+    version_added: '5.1.0'
+  filter_name:
+    description:
+    - Name of the audit filter to create or remove.
+    - Required when O(filter_rule) is provided.
+    type: str
+    version_added: '5.1.0'
+  filter_rule:
+    description:
+    - A dictionary defining the audit filter rule (JSON filter document).
+    - Requires O(filter_name) to be set.
+    type: dict
+    version_added: '5.1.0'
+  users:
+    description:
+    - List of MySQL user accounts (in C(user@host) format) to apply the filter to.
+    - Requires O(filter_name) to be set.
+    type: list
+    elements: str
+    version_added: '5.1.0'
+  rotate:
+    description:
+    - Whether to trigger audit log rotation.
+    type: bool
+    default: false
+    version_added: '5.1.0'
+
+attributes:
+  check_mode:
+    support: partial
+    details:
+      - In check mode the module reports what changes would be made
+        without executing them.
+  idempotent:
+    support: partial
+    details:
+      - The module checks current state before making changes.
+      - Log rotation (O(rotate=true)) always reports changed.
+
+seealso:
+- module: ansible.mysql.mysql_audit_info
+- module: ansible.mysql.mysql_variables
+- name: MySQL Audit Log reference
+  description: MySQL Enterprise Audit documentation.
+  link: https://dev.mysql.com/doc/refman/8.0/en/audit-log.html
+
+notes:
+   - Compatible with MySQL only. MariaDB has a separate audit plugin.
+   - Requires the MySQL Enterprise Audit plugin files to be available
+     on the server.
+
+extends_documentation_fragment:
+- ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Install the audit log plugin
+  ansible.mysql.mysql_audit:
+    state: present
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Set audit log format to JSON
+  ansible.mysql.mysql_audit:
+    state: present
+    log_format: JSON
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Create and assign an audit filter
+  ansible.mysql.mysql_audit:
+    state: present
+    filter_name: log_all
+    filter_rule:
+      filter:
+        log: true
+    users:
+      - root@localhost
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Rotate the audit log
+  ansible.mysql.mysql_audit:
+    state: present
+    rotate: true
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Uninstall the audit log plugin
+  ansible.mysql.mysql_audit:
+    state: absent
+    login_unix_socket: /run/mysqld/mysqld.sock
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed queries which modified the server state.
+  returned: if executed
+  type: list
+  sample: ["INSTALL COMPONENT 'file://component_audit_api_message_emit'"]
+  version_added: '5.1.0'
+'''
+
+import json
+import os
+import warnings
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+    mysql_common_argument_spec,
+)
+from ansible.module_utils.common.text.converters import to_native
+
+executed_queries = []
+
+
+def is_audit_plugin_installed(cursor):
+    """Check whether any audit log component or plugin is installed."""
+    # Check for component (MySQL 8.0+)
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM mysql.component "
+            "WHERE component_urn = 'file://component_audit_api_message_emit'"
+        )
+        row = cursor.fetchone()
+        if row and row[0] > 0:
+            return True
+    except Exception:
+        pass
+
+    # Check for legacy plugin
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM information_schema.PLUGINS "
+            "WHERE PLUGIN_NAME = 'audit_log' AND PLUGIN_STATUS = 'ACTIVE'"
+        )
+        row = cursor.fetchone()
+        if row and row[0] > 0:
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+def install_audit_plugin(cursor):
+    """Install the audit log component."""
+    query = "INSTALL COMPONENT 'file://component_audit_api_message_emit'"
+    cursor.execute(query)
+    executed_queries.append(query)
+
+
+def uninstall_audit_plugin(cursor):
+    """Uninstall the audit log component."""
+    query = "UNINSTALL COMPONENT 'file://component_audit_api_message_emit'"
+    cursor.execute(query)
+    executed_queries.append(query)
+
+
+def get_audit_log_format(cursor):
+    """Return current audit_log_format value or None."""
+    try:
+        cursor.execute("SHOW VARIABLES LIKE 'audit_log_format'")
+        row = cursor.fetchone()
+        if row:
+            return row[1]
+    except Exception:
+        pass
+    return None
+
+
+def set_audit_log_format(cursor, log_format):
+    """Set the global audit_log_format variable."""
+    query = "SET GLOBAL audit_log_format = %s"
+    cursor.execute(query, (log_format,))
+    executed_queries.append("SET GLOBAL audit_log_format = '%s'" % log_format)
+
+
+def set_audit_filter(cursor, filter_name, filter_rule):
+    """Create or replace an audit filter."""
+    rule_json = json.dumps(filter_rule)
+    query = "SELECT audit_log_filter_set_filter(%s, %s)"
+    cursor.execute(query, (filter_name, rule_json))
+    executed_queries.append(
+        "SELECT audit_log_filter_set_filter('%s', '%s')" % (filter_name, rule_json)
+    )
+
+
+def remove_audit_filter(cursor, filter_name):
+    """Remove an audit filter."""
+    query = "SELECT audit_log_filter_remove_filter(%s)"
+    cursor.execute(query, (filter_name,))
+    executed_queries.append(
+        "SELECT audit_log_filter_remove_filter('%s')" % filter_name
+    )
+
+
+def set_user_filter(cursor, user, filter_name):
+    """Assign a filter to a user."""
+    query = "SELECT audit_log_filter_set_user(%s, %s)"
+    cursor.execute(query, (user, filter_name))
+    executed_queries.append(
+        "SELECT audit_log_filter_set_user('%s', '%s')" % (user, filter_name)
+    )
+
+
+def remove_user_filter(cursor, user):
+    """Remove filter assignment from a user."""
+    query = "SELECT audit_log_filter_remove_user(%s)"
+    cursor.execute(query, (user,))
+    executed_queries.append(
+        "SELECT audit_log_filter_remove_user('%s')" % user
+    )
+
+
+def get_existing_filters(cursor):
+    """Return a dict of existing filter names to their definitions."""
+    filters = {}
+    try:
+        cursor.execute(
+            "SELECT NAME, FILTER FROM mysql.audit_log_filter"
+        )
+        for row in cursor.fetchall():
+            filters[row[0]] = row[1]
+    except Exception:
+        pass
+    return filters
+
+
+def get_user_filter_assignments(cursor):
+    """Return a dict of user -> filter_name assignments."""
+    assignments = {}
+    try:
+        cursor.execute(
+            "SELECT USER, FILTERNAME FROM mysql.audit_log_user"
+        )
+        for row in cursor.fetchall():
+            assignments[row[0]] = row[1]
+    except Exception:
+        pass
+    return assignments
+
+
+def rotate_audit_log(cursor):
+    """Trigger audit log rotation."""
+    query = "SET GLOBAL audit_log_rotate = ON"
+    cursor.execute(query)
+    executed_queries.append(query)
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        log_format=dict(type='str', choices=['JSON', 'XML', 'CSV'], default='JSON'),
+        filter_name=dict(type='str'),
+        filter_rule=dict(type='dict'),
+        users=dict(type='list', elements='str'),
+        rotate=dict(type='bool', default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_together=[
+            ('filter_name', 'filter_rule'),
+        ],
+    )
+
+    user = module.params["login_user"]
+    password = module.params["login_password"]
+    connect_timeout = module.params['connect_timeout']
+    ssl_cert = module.params["client_cert"]
+    ssl_key = module.params["client_key"]
+    ssl_ca = module.params["ca_cert"]
+    check_hostname = module.params["check_hostname"]
+    config_file = module.params['config_file']
+    db = 'mysql'
+
+    state = module.params['state']
+    log_format = module.params['log_format']
+    filter_name = module.params['filter_name']
+    filter_rule = module.params['filter_rule']
+    users = module.params['users']
+    rotate = module.params['rotate']
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+    else:
+        warnings.filterwarnings('error', category=mysql_driver.Warning)
+
+    try:
+        cursor, db_conn = mysql_connect(
+            module, user, password, config_file,
+            ssl_cert, ssl_key, ssl_ca, db,
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+        )
+    except Exception as e:
+        if os.path.exists(config_file):
+            module.fail_json(
+                msg="unable to connect to database, check login_user and "
+                    "login_password are correct or %s has the credentials. "
+                    "Exception message: %s" % (config_file, to_native(e))
+            )
+        else:
+            module.fail_json(
+                msg="unable to find %s. Exception message: %s"
+                    % (config_file, to_native(e))
+            )
+
+    changed = False
+
+    try:
+        plugin_installed = is_audit_plugin_installed(cursor)
+
+        if state == 'absent':
+            if plugin_installed:
+                if not module.check_mode:
+                    uninstall_audit_plugin(cursor)
+                changed = True
+
+            module.exit_json(changed=changed, queries=executed_queries)
+
+        # state == 'present'
+        if not plugin_installed:
+            if not module.check_mode:
+                install_audit_plugin(cursor)
+            changed = True
+
+        # Set log format if plugin is now installed
+        if not module.check_mode and (plugin_installed or changed):
+            current_format = get_audit_log_format(cursor)
+            if current_format and current_format.upper() != log_format.upper():
+                set_audit_log_format(cursor, log_format)
+                changed = True
+
+        # Configure filter
+        if filter_name and filter_rule:
+            existing_filters = get_existing_filters(cursor) if not module.check_mode else {}
+            rule_json = json.dumps(filter_rule)
+
+            needs_filter_update = True
+            if filter_name in existing_filters:
+                existing_rule = existing_filters[filter_name]
+                if isinstance(existing_rule, str):
+                    try:
+                        existing_rule = json.loads(existing_rule)
+                    except (ValueError, TypeError):
+                        pass
+                if existing_rule == filter_rule:
+                    needs_filter_update = False
+
+            if needs_filter_update:
+                if not module.check_mode:
+                    set_audit_filter(cursor, filter_name, filter_rule)
+                changed = True
+
+            # Assign filter to users
+            if users:
+                current_assignments = get_user_filter_assignments(cursor) if not module.check_mode else {}
+                for u in users:
+                    if current_assignments.get(u) != filter_name:
+                        if not module.check_mode:
+                            set_user_filter(cursor, u, filter_name)
+                        changed = True
+
+        # Rotate log
+        if rotate:
+            if not module.check_mode:
+                rotate_audit_log(cursor)
+            changed = True
+
+    except Exception as e:
+        module.fail_json(msg="Error managing audit plugin: %s" % to_native(e))
+
+    module.exit_json(changed=changed, queries=executed_queries)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_audit_info.py
+++ b/plugins/modules/mysql_audit_info.py
@@ -1,0 +1,242 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_audit_info
+
+short_description: Gather information about MySQL audit log configuration
+
+description:
+- Returns the current audit log plugin status, active filters,
+  user filter assignments, log format, and log file path.
+
+version_added: '5.1.0'
+
+author:
+- Steve Fulmer (@stevefulme1)
+
+options: {}
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+seealso:
+- module: ansible.mysql.mysql_audit
+- module: ansible.mysql.mysql_info
+
+notes:
+   - Compatible with MySQL only. MariaDB has a separate audit plugin.
+
+extends_documentation_fragment:
+- ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Gather audit log information
+  ansible.mysql.mysql_audit_info:
+    login_unix_socket: /run/mysqld/mysqld.sock
+  register: audit_info
+
+- name: Display audit plugin status
+  ansible.builtin.debug:
+    var: audit_info.plugin_installed
+
+- name: Display active filters
+  ansible.builtin.debug:
+    var: audit_info.filters
+'''
+
+RETURN = r'''
+plugin_installed:
+  description: Whether the audit log plugin is installed and active.
+  returned: always
+  type: bool
+  sample: true
+  version_added: '5.1.0'
+log_format:
+  description: Current audit log format setting.
+  returned: when plugin is installed
+  type: str
+  sample: "JSON"
+  version_added: '5.1.0'
+log_file:
+  description: Path to the audit log file.
+  returned: when plugin is installed
+  type: str
+  sample: "/var/lib/mysql/audit.log"
+  version_added: '5.1.0'
+filters:
+  description: Dictionary of defined audit filters and their rules.
+  returned: when plugin is installed
+  type: dict
+  sample: {"log_all": {"filter": {"log": true}}}
+  version_added: '5.1.0'
+user_assignments:
+  description: Dictionary mapping users to their assigned filter names.
+  returned: when plugin is installed
+  type: dict
+  sample: {"root@localhost": "log_all"}
+  version_added: '5.1.0'
+'''
+
+import json
+import os
+import warnings
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+    mysql_common_argument_spec,
+)
+from ansible.module_utils.common.text.converters import to_native
+
+
+def is_audit_plugin_installed(cursor):
+    """Check whether any audit log component or plugin is installed."""
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM mysql.component "
+            "WHERE component_urn = 'file://component_audit_api_message_emit'"
+        )
+        row = cursor.fetchone()
+        if row and row[0] > 0:
+            return True
+    except Exception:
+        pass
+
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM information_schema.PLUGINS "
+            "WHERE PLUGIN_NAME = 'audit_log' AND PLUGIN_STATUS = 'ACTIVE'"
+        )
+        row = cursor.fetchone()
+        if row and row[0] > 0:
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+def get_variable(cursor, var_name):
+    """Return the value of a MySQL variable or None."""
+    try:
+        cursor.execute("SHOW VARIABLES LIKE %s", (var_name,))
+        row = cursor.fetchone()
+        if row:
+            return row[1]
+    except Exception:
+        pass
+    return None
+
+
+def get_filters(cursor):
+    """Return a dict of filter names to their parsed definitions."""
+    filters = {}
+    try:
+        cursor.execute("SELECT NAME, FILTER FROM mysql.audit_log_filter")
+        for row in cursor.fetchall():
+            name = row[0]
+            rule = row[1]
+            if isinstance(rule, str):
+                try:
+                    rule = json.loads(rule)
+                except (ValueError, TypeError):
+                    pass
+            filters[name] = rule
+    except Exception:
+        pass
+    return filters
+
+
+def get_user_assignments(cursor):
+    """Return a dict of user -> filter_name assignments."""
+    assignments = {}
+    try:
+        cursor.execute("SELECT USER, FILTERNAME FROM mysql.audit_log_user")
+        for row in cursor.fetchall():
+            assignments[row[0]] = row[1]
+    except Exception:
+        pass
+    return assignments
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    user = module.params["login_user"]
+    password = module.params["login_password"]
+    connect_timeout = module.params['connect_timeout']
+    ssl_cert = module.params["client_cert"]
+    ssl_key = module.params["client_key"]
+    ssl_ca = module.params["ca_cert"]
+    check_hostname = module.params["check_hostname"]
+    config_file = module.params['config_file']
+    db = 'mysql'
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+    else:
+        warnings.filterwarnings('error', category=mysql_driver.Warning)
+
+    try:
+        cursor, db_conn = mysql_connect(
+            module, user, password, config_file,
+            ssl_cert, ssl_key, ssl_ca, db,
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+        )
+    except Exception as e:
+        if os.path.exists(config_file):
+            module.fail_json(
+                msg="unable to connect to database, check login_user and "
+                    "login_password are correct or %s has the credentials. "
+                    "Exception message: %s" % (config_file, to_native(e))
+            )
+        else:
+            module.fail_json(
+                msg="unable to find %s. Exception message: %s"
+                    % (config_file, to_native(e))
+            )
+
+    result = {}
+
+    try:
+        result['plugin_installed'] = is_audit_plugin_installed(cursor)
+
+        if result['plugin_installed']:
+            result['log_format'] = get_variable(cursor, 'audit_log_format')
+            result['log_file'] = get_variable(cursor, 'audit_log_file')
+            result['filters'] = get_filters(cursor)
+            result['user_assignments'] = get_user_assignments(cursor)
+        else:
+            result['log_format'] = None
+            result['log_file'] = None
+            result['filters'] = {}
+            result['user_assignments'] = {}
+
+    except Exception as e:
+        module.fail_json(msg="Error gathering audit info: %s" % to_native(e))
+
+    module.exit_json(changed=False, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_password_policy.py
+++ b/plugins/modules/mysql_password_policy.py
@@ -1,0 +1,404 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_password_policy
+
+short_description: Configure MySQL password validation policy
+
+description:
+- Manage the MySQL C(validate_password) component and related global variables.
+- Install or uninstall the C(validate_password) component (MySQL 8.0+).
+- Configure password complexity requirements, lifetime, and reuse policies.
+
+version_added: '5.1.0'
+
+author:
+- Steve Fulmer (@stevefulme1)
+
+options:
+  state:
+    description:
+    - V(present) ensures the C(validate_password) component is installed
+      and configured with the specified settings.
+    - V(absent) uninstalls the C(validate_password) component.
+    type: str
+    choices: ['present', 'absent']
+    default: present
+  policy:
+    description:
+    - Password validation policy level.
+    - V(LOW) checks length only.
+    - V(MEDIUM) checks length, numeric, mixed case, and special characters.
+    - V(STRONG) checks all of V(MEDIUM) plus dictionary file.
+    type: str
+    choices: ['LOW', 'MEDIUM', 'STRONG']
+  length:
+    description:
+    - Minimum number of characters in a password.
+    type: int
+  mixed_case_count:
+    description:
+    - Minimum number of uppercase and lowercase characters required.
+    type: int
+  number_count:
+    description:
+    - Minimum number of numeric characters required.
+    type: int
+  special_char_count:
+    description:
+    - Minimum number of special (non-alphanumeric) characters required.
+    type: int
+  check_user_name:
+    description:
+    - Whether passwords are checked against the user name.
+    - When V(true), passwords that match the user name are rejected.
+    type: bool
+  password_lifetime:
+    description:
+    - Default password expiration lifetime in days.
+    - V(0) disables automatic password expiration.
+    type: int
+  password_history:
+    description:
+    - Number of previous passwords that cannot be reused.
+    - V(0) disables password history checks.
+    type: int
+  reuse_interval:
+    description:
+    - Number of days before a password can be reused.
+    - V(0) disables reuse interval checks.
+    type: int
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+seealso:
+- module: ansible.mysql.mysql_variables
+- module: ansible.mysql.mysql_user
+- name: MySQL Password Validation Component
+  description: Reference for the validate_password component.
+  link: https://dev.mysql.com/doc/refman/8.0/en/validate-password.html
+
+notes:
+   - Requires MySQL 8.0 or later.
+   - The C(validate_password) component must be available on the server.
+   - In MySQL 5.7, the validate_password plugin uses underscores in variable
+     names (e.g., C(validate_password_policy)) rather than dots. This module
+     targets MySQL 8.0+ component syntax with dot notation.
+
+extends_documentation_fragment:
+- ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Install validate_password component with MEDIUM policy
+  ansible.mysql.mysql_password_policy:
+    state: present
+    policy: MEDIUM
+    length: 12
+    mixed_case_count: 1
+    number_count: 1
+    special_char_count: 1
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Set password lifetime and history policies
+  ansible.mysql.mysql_password_policy:
+    password_lifetime: 90
+    password_history: 5
+    reuse_interval: 365
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Uninstall validate_password component
+  ansible.mysql.mysql_password_policy:
+    state: absent
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Enforce STRONG policy with username check
+  ansible.mysql.mysql_password_policy:
+    policy: STRONG
+    length: 16
+    check_user_name: true
+    login_unix_socket: /run/mysqld/mysqld.sock
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed queries which modified the server state.
+  returned: if changed
+  type: list
+  sample: ["SET GLOBAL `validate_password.policy` = 'MEDIUM'"]
+  version_added: '5.1.0'
+'''
+
+import os
+import warnings
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.mysql.plugins.module_utils.database import mysql_quote_identifier
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+    mysql_common_argument_spec,
+)
+from ansible.module_utils.common.text.converters import to_native
+
+
+# Mapping of module parameters to MySQL global variable names
+# validate_password.* variables only exist when the component is installed
+VALIDATE_PASSWORD_PARAMS = {
+    'policy': 'validate_password.policy',
+    'length': 'validate_password.length',
+    'mixed_case_count': 'validate_password.mixed_case_count',
+    'number_count': 'validate_password.number_count',
+    'special_char_count': 'validate_password.special_char_count',
+    'check_user_name': 'validate_password.check_user_name',
+}
+
+# Global password policy variables (exist regardless of component)
+GLOBAL_PASSWORD_PARAMS = {
+    'password_lifetime': 'default_password_lifetime',
+    'password_history': 'password_history',
+    'reuse_interval': 'password_reuse_interval',
+}
+
+# Policy name to numeric value mapping for comparison
+POLICY_MAP = {
+    'LOW': '0',
+    'MEDIUM': '1',
+    'STRONG': '2',
+    '0': '0',
+    '1': '1',
+    '2': '2',
+}
+
+
+def is_component_installed(cursor):
+    """Check if validate_password component is installed."""
+    try:
+        cursor.execute("SHOW VARIABLES LIKE 'validate_password.policy'")
+        return cursor.fetchone() is not None
+    except Exception:
+        return False
+
+
+def get_current_variables(cursor, var_pattern):
+    """Retrieve current variable values matching a LIKE pattern."""
+    result = {}
+    cursor.execute("SHOW VARIABLES LIKE %s", (var_pattern,))
+    for row in cursor.fetchall():
+        result[row[0]] = row[1]
+    return result
+
+
+def get_variable(cursor, var_name):
+    """Get a single variable value."""
+    cursor.execute("SHOW VARIABLES WHERE Variable_name = %s", (var_name,))
+    row = cursor.fetchone()
+    if row:
+        return row[1]
+    return None
+
+
+def set_global_variable(cursor, var_name, value):
+    """Set a global variable and return the query string."""
+    query = "SET GLOBAL %s = " % mysql_quote_identifier(var_name, 'vars')
+    cursor.execute(query + "%s", (value,))
+    return query + "'%s'" % value
+
+
+def install_component(cursor):
+    """Install the validate_password component."""
+    query = "INSTALL COMPONENT 'file://component_validate_password'"
+    cursor.execute(query)
+    return query
+
+
+def uninstall_component(cursor):
+    """Uninstall the validate_password component."""
+    query = "UNINSTALL COMPONENT 'file://component_validate_password'"
+    cursor.execute(query)
+    return query
+
+
+def values_match(var_name, current_val, desired_val):
+    """Compare current and desired values, handling type differences."""
+    if current_val is None:
+        return False
+
+    # Policy can be reported as name or number
+    if var_name == 'validate_password.policy':
+        current_norm = POLICY_MAP.get(str(current_val).upper(), str(current_val))
+        desired_norm = POLICY_MAP.get(str(desired_val).upper(), str(desired_val))
+        return current_norm == desired_norm
+
+    # Boolean ON/OFF comparison
+    if var_name == 'validate_password.check_user_name':
+        current_norm = str(current_val).upper()
+        if isinstance(desired_val, bool):
+            desired_norm = 'ON' if desired_val else 'OFF'
+        else:
+            desired_norm = str(desired_val).upper()
+        return current_norm == desired_norm
+
+    return str(current_val) == str(desired_val)
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        policy=dict(type='str', choices=['LOW', 'MEDIUM', 'STRONG']),
+        length=dict(type='int'),
+        mixed_case_count=dict(type='int'),
+        number_count=dict(type='int'),
+        special_char_count=dict(type='int'),
+        check_user_name=dict(type='bool'),
+        password_lifetime=dict(type='int', no_log=False),
+        password_history=dict(type='int', no_log=False),
+        reuse_interval=dict(type='int'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    user = module.params["login_user"]
+    password = module.params["login_password"]
+    connect_timeout = module.params['connect_timeout']
+    ssl_cert = module.params["client_cert"]
+    ssl_key = module.params["client_key"]
+    ssl_ca = module.params["ca_cert"]
+    check_hostname = module.params["check_hostname"]
+    config_file = module.params['config_file']
+    db = 'mysql'
+
+    state = module.params['state']
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+    else:
+        warnings.filterwarnings('error', category=mysql_driver.Warning)
+
+    try:
+        cursor, db_conn = mysql_connect(
+            module, user, password, config_file,
+            ssl_cert, ssl_key, ssl_ca, db,
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+        )
+    except Exception as e:
+        if os.path.exists(config_file):
+            module.fail_json(
+                msg="unable to connect to database, check login_user and "
+                    "login_password are correct or %s has the credentials. "
+                    "Exception message: %s" % (config_file, to_native(e))
+            )
+        else:
+            module.fail_json(
+                msg="unable to find %s. Exception message: %s" % (config_file, to_native(e))
+            )
+
+    installed = is_component_installed(cursor)
+    changed = False
+    executed_queries = []
+
+    if state == 'absent':
+        if not installed:
+            module.exit_json(changed=False, msg="validate_password component is not installed.")
+
+        if module.check_mode:
+            module.exit_json(
+                changed=True,
+                queries=["UNINSTALL COMPONENT 'file://component_validate_password'"],
+            )
+
+        try:
+            query = uninstall_component(cursor)
+            executed_queries.append(query)
+            changed = True
+        except Exception as e:
+            module.fail_json(msg="Failed to uninstall validate_password component: %s" % to_native(e))
+
+        module.exit_json(changed=changed, queries=executed_queries)
+
+    # state == 'present'
+    # Install component if not present
+    if not installed:
+        if module.check_mode:
+            executed_queries.append("INSTALL COMPONENT 'file://component_validate_password'")
+            changed = True
+        else:
+            try:
+                query = install_component(cursor)
+                executed_queries.append(query)
+                changed = True
+            except Exception as e:
+                module.fail_json(
+                    msg="Failed to install validate_password component: %s" % to_native(e)
+                )
+
+    # Configure validate_password.* variables
+    for param, var_name in VALIDATE_PASSWORD_PARAMS.items():
+        desired_val = module.params[param]
+        if desired_val is None:
+            continue
+
+        if not module.check_mode:
+            current_val = get_variable(cursor, var_name)
+        else:
+            # In check mode after install, we cannot read vars that don't exist yet
+            current_val = None if not installed and changed else get_variable(cursor, var_name)
+
+        if param == 'check_user_name':
+            set_val = 'ON' if desired_val else 'OFF'
+        else:
+            set_val = desired_val
+
+        if not values_match(var_name, current_val, desired_val):
+            if module.check_mode:
+                executed_queries.append("SET GLOBAL `%s` = '%s'" % (var_name, set_val))
+            else:
+                try:
+                    query = set_global_variable(cursor, var_name, set_val)
+                    executed_queries.append(query)
+                except Exception as e:
+                    module.fail_json(msg="Failed to set %s: %s" % (var_name, to_native(e)))
+            changed = True
+
+    # Configure global password policy variables
+    for param, var_name in GLOBAL_PASSWORD_PARAMS.items():
+        desired_val = module.params[param]
+        if desired_val is None:
+            continue
+
+        current_val = get_variable(cursor, var_name)
+
+        if not values_match(var_name, current_val, desired_val):
+            if module.check_mode:
+                executed_queries.append("SET GLOBAL `%s` = '%s'" % (var_name, desired_val))
+            else:
+                try:
+                    query = set_global_variable(cursor, var_name, desired_val)
+                    executed_queries.append(query)
+                except Exception as e:
+                    module.fail_json(msg="Failed to set %s: %s" % (var_name, to_native(e)))
+            changed = True
+
+    module.exit_json(changed=changed, queries=executed_queries)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_tls.py
+++ b/plugins/modules/mysql_tls.py
@@ -1,0 +1,287 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_tls
+
+short_description: Configure server-side TLS for MySQL
+
+description:
+- Configure server-side TLS settings for MySQL 8.0+.
+- Set TLS certificate paths, enforce secure transport, and control allowed TLS versions.
+- Supports hot-reloading TLS configuration without server restart (MySQL 8.0.16+).
+
+version_added: '5.1.0'
+
+author:
+- Steve Fulmer (@stevefulme1)
+
+options:
+  server_cert:
+    description:
+    - Path to the server SSL/TLS certificate file on the MySQL server host.
+    type: path
+  server_key:
+    description:
+    - Path to the server SSL/TLS private key file on the MySQL server host.
+    type: path
+  server_ca:
+    description:
+    - Path to the Certificate Authority (CA) certificate file on the MySQL server host.
+    type: path
+  require_secure_transport:
+    description:
+    - Whether to require encrypted connections from all clients.
+    - When V(true), the server rejects non-SSL connections.
+    type: bool
+  tls_version:
+    description:
+    - Comma-separated list of TLS protocol versions the server permits.
+    - For example, V(TLSv1.2,TLSv1.3).
+    type: str
+  reload:
+    description:
+    - Whether to execute C(ALTER INSTANCE RELOAD TLS) after applying changes.
+    - This causes the server to hot-reload its TLS context without a restart.
+    - Requires MySQL 8.0.16 or later.
+    type: bool
+    default: false
+  state:
+    description:
+    - V(present) configures TLS with the specified parameters.
+    - V(absent) resets TLS-related variables to their compiled-in defaults
+      (empty strings for paths, V(OFF) for require_secure_transport).
+    type: str
+    choices: ['present', 'absent']
+    default: present
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+seealso:
+- module: ansible.mysql.mysql_variables
+- name: MySQL TLS configuration reference
+  description: Complete reference for configuring MySQL encrypted connections.
+  link: https://dev.mysql.com/doc/refman/8.0/en/using-encrypted-connections.html
+
+notes:
+   - Requires MySQL 8.0 or later.
+   - The O(server_cert), O(server_key), and O(server_ca) paths must be readable by the MySQL server process.
+   - The O(reload) option requires MySQL 8.0.16 or later.
+
+extends_documentation_fragment:
+- ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Configure TLS with certificate files
+  ansible.mysql.mysql_tls:
+    server_cert: /etc/mysql/ssl/server-cert.pem
+    server_key: /etc/mysql/ssl/server-key.pem
+    server_ca: /etc/mysql/ssl/ca-cert.pem
+    reload: true
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Enforce secure transport and restrict to TLSv1.3
+  ansible.mysql.mysql_tls:
+    require_secure_transport: true
+    tls_version: 'TLSv1.3'
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Reset TLS configuration to defaults
+  ansible.mysql.mysql_tls:
+    state: absent
+    reload: true
+    login_unix_socket: /run/mysqld/mysqld.sock
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed queries which modified the server state.
+  returned: if changed
+  type: list
+  sample: ["SET GLOBAL `ssl_cert` = '/etc/mysql/ssl/server-cert.pem'"]
+  version_added: '5.1.0'
+'''
+
+import os
+import warnings
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.mysql.plugins.module_utils.database import mysql_quote_identifier
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+    mysql_common_argument_spec,
+)
+from ansible.module_utils.common.text.converters import to_native
+
+
+# Mapping of module parameters to MySQL global variable names
+PARAM_TO_VAR = {
+    'server_cert': 'ssl_cert',
+    'server_key': 'ssl_key',
+    'server_ca': 'ssl_ca',
+    'require_secure_transport': 'require_secure_transport',
+    'tls_version': 'tls_version',
+}
+
+# Default (absent) values for each variable
+DEFAULT_VALUES = {
+    'server_cert': '',
+    'server_key': '',
+    'server_ca': '',
+    'require_secure_transport': 'OFF',
+    'tls_version': '',
+}
+
+
+def get_tls_variables(cursor):
+    """Retrieve current TLS-related global variables."""
+    result = {}
+    for var_name in PARAM_TO_VAR.values():
+        cursor.execute("SHOW VARIABLES WHERE Variable_name = %s", (var_name,))
+        row = cursor.fetchone()
+        if row:
+            result[var_name] = row[1]
+        else:
+            result[var_name] = None
+    return result
+
+
+def set_global_variable(cursor, var_name, value):
+    """Set a global variable and return the query string."""
+    query = "SET GLOBAL %s = " % mysql_quote_identifier(var_name, 'vars')
+    cursor.execute(query + "%s", (value,))
+    return query + "'%s'" % value
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        server_cert=dict(type='path'),
+        server_key=dict(type='path'),
+        server_ca=dict(type='path'),
+        require_secure_transport=dict(type='bool'),
+        tls_version=dict(type='str'),
+        reload=dict(type='bool', default=False),
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    user = module.params["login_user"]
+    password = module.params["login_password"]
+    connect_timeout = module.params['connect_timeout']
+    server_cert = module.params["client_cert"]
+    server_key = module.params["client_key"]
+    server_ca = module.params["ca_cert"]
+    check_hostname = module.params["check_hostname"]
+    config_file = module.params['config_file']
+    db = 'mysql'
+
+    state = module.params['state']
+    do_reload = module.params['reload']
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+    else:
+        warnings.filterwarnings('error', category=mysql_driver.Warning)
+
+    try:
+        cursor, db_conn = mysql_connect(
+            module, user, password, config_file,
+            server_cert, server_key, server_ca, db,
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+        )
+    except Exception as e:
+        if os.path.exists(config_file):
+            module.fail_json(
+                msg="unable to connect to database, check login_user and "
+                    "login_password are correct or %s has the credentials. "
+                    "Exception message: %s" % (config_file, to_native(e))
+            )
+        else:
+            module.fail_json(
+                msg="unable to find %s. Exception message: %s" % (config_file, to_native(e))
+            )
+
+    # Get current state
+    current = get_tls_variables(cursor)
+
+    # Build desired state
+    desired = {}
+    if state == 'absent':
+        desired = dict(DEFAULT_VALUES)
+    else:
+        for param, var_name in PARAM_TO_VAR.items():
+            val = module.params[param]
+            if val is not None:
+                if param == 'require_secure_transport':
+                    desired[var_name] = 'ON' if val else 'OFF'
+                else:
+                    desired[var_name] = val
+
+    # Determine changes needed
+    changes = {}
+    for var_name, desired_val in desired.items():
+        current_val = current.get(var_name, '')
+        if str(desired_val) != str(current_val):
+            changes[var_name] = desired_val
+
+    changed = bool(changes)
+
+    if not changed and not do_reload:
+        module.exit_json(changed=False, msg="TLS configuration is already in the desired state.")
+
+    executed_queries = []
+
+    if module.check_mode:
+        # In check mode, predict what would change
+        for var_name, val in changes.items():
+            executed_queries.append("SET GLOBAL `%s` = '%s'" % (var_name, val))
+        if do_reload and (changed or do_reload):
+            executed_queries.append("ALTER INSTANCE RELOAD TLS")
+        module.exit_json(changed=changed or do_reload, queries=executed_queries)
+
+    # Apply changes
+    try:
+        for var_name, val in changes.items():
+            query_str = set_global_variable(cursor, var_name, val)
+            executed_queries.append(query_str)
+    except Exception as e:
+        module.fail_json(msg="Failed to set TLS variable: %s" % to_native(e))
+
+    # Reload TLS context if requested
+    if do_reload:
+        try:
+            cursor.execute("ALTER INSTANCE RELOAD TLS")
+            executed_queries.append("ALTER INSTANCE RELOAD TLS")
+            changed = True
+        except Exception as e:
+            module.fail_json(
+                msg="Failed to reload TLS context. "
+                    "This requires MySQL 8.0.16 or later. "
+                    "Exception: %s" % to_native(e)
+            )
+
+    module.exit_json(changed=changed, queries=executed_queries)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/test_mysql_audit/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_audit/tasks/main.yml
@@ -1,0 +1,6 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- import_tasks: mysql_audit.yml

--- a/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
+++ b/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
@@ -1,0 +1,199 @@
+# test code for the mysql_audit and mysql_audit_info modules
+#
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    # Test: gather info when audit plugin is NOT installed
+    # ============================================================
+
+    - name: Gather audit info before install
+      mysql_audit_info:
+        <<: *mysql_params
+      register: audit_info_before
+
+    - name: Assert plugin is not installed initially
+      assert:
+        that:
+          - audit_info_before.plugin_installed == false
+          - audit_info_before.filters == {}
+          - audit_info_before.user_assignments == {}
+
+    # ============================================================
+    # Test: install audit plugin
+    # ============================================================
+
+    - name: Install audit plugin (check mode)
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+      check_mode: true
+      register: install_check
+
+    - name: Assert check mode reports changed
+      assert:
+        that:
+          - install_check is changed
+
+    - name: Install audit plugin
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+      register: install_result
+
+    - name: Assert plugin was installed
+      assert:
+        that:
+          - install_result is changed
+          - install_result.queries | length > 0
+
+    - name: Install audit plugin again (idempotency)
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+      register: install_idem
+
+    - name: Assert idempotent install
+      assert:
+        that:
+          - install_idem is not changed
+
+    # ============================================================
+    # Test: verify info module after install
+    # ============================================================
+
+    - name: Gather audit info after install
+      mysql_audit_info:
+        <<: *mysql_params
+      register: audit_info_after
+
+    - name: Assert plugin is installed
+      assert:
+        that:
+          - audit_info_after.plugin_installed == true
+          - audit_info_after.log_format is defined
+
+    # ============================================================
+    # Test: set log format
+    # ============================================================
+
+    - name: Set log format to JSON
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+        log_format: JSON
+      register: format_result
+
+    - name: Gather info to verify format
+      mysql_audit_info:
+        <<: *mysql_params
+      register: format_info
+
+    - name: Assert log format
+      assert:
+        that:
+          - format_info.log_format == 'JSON'
+
+    # ============================================================
+    # Test: create audit filter and assign to user
+    # ============================================================
+
+    - name: Create audit filter
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+        filter_name: log_all
+        filter_rule:
+          filter:
+            log: true
+        users:
+          - '{{ mysql_user }}@{{ mysql_host }}'
+      register: filter_result
+
+    - name: Assert filter was created
+      assert:
+        that:
+          - filter_result is changed
+
+    - name: Gather info to verify filter
+      mysql_audit_info:
+        <<: *mysql_params
+      register: filter_info
+
+    - name: Assert filter exists in info
+      assert:
+        that:
+          - "'log_all' in filter_info.filters"
+
+    # ============================================================
+    # Test: rotate audit log
+    # ============================================================
+
+    - name: Rotate audit log
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+        rotate: true
+      register: rotate_result
+
+    - name: Assert rotation was triggered
+      assert:
+        that:
+          - rotate_result is changed
+
+    # ============================================================
+    # Test: uninstall audit plugin
+    # ============================================================
+
+    - name: Uninstall audit plugin (check mode)
+      mysql_audit:
+        <<: *mysql_params
+        state: absent
+      check_mode: true
+      register: uninstall_check
+
+    - name: Assert check mode reports changed for uninstall
+      assert:
+        that:
+          - uninstall_check is changed
+
+    - name: Uninstall audit plugin
+      mysql_audit:
+        <<: *mysql_params
+        state: absent
+      register: uninstall_result
+
+    - name: Assert plugin was uninstalled
+      assert:
+        that:
+          - uninstall_result is changed
+
+    - name: Uninstall audit plugin again (idempotency)
+      mysql_audit:
+        <<: *mysql_params
+        state: absent
+      register: uninstall_idem
+
+    - name: Assert idempotent uninstall
+      assert:
+        that:
+          - uninstall_idem is not changed
+
+    - name: Gather info after uninstall
+      mysql_audit_info:
+        <<: *mysql_params
+      register: audit_info_final
+
+    - name: Assert plugin is no longer installed
+      assert:
+        that:
+          - audit_info_final.plugin_installed == false

--- a/tests/integration/targets/test_mysql_password_policy/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_password_policy/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for test_mysql_password_policy
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_password_policy/meta/main.yml
+++ b/tests/integration/targets/test_mysql_password_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_password_policy/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_password_policy/tasks/main.yml
@@ -1,0 +1,6 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- import_tasks: mysql_password_policy.yml

--- a/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
+++ b/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
@@ -1,0 +1,275 @@
+# test code for the mysql_password_policy module
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+# Test mysql_password_policy module
+# ============================================================
+
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    # Cleanup: ensure component is not installed before tests
+    # ============================================================
+    - name: Ensure validate_password component is absent before tests
+      mysql_password_policy:
+        <<: *mysql_params
+        state: absent
+      failed_when: false
+
+    # ============================================================
+    # Test: Install validate_password component
+    # ============================================================
+    - name: Install validate_password component
+      mysql_password_policy:
+        <<: *mysql_params
+        state: present
+      register: result_install
+
+    - name: Assert component was installed
+      assert:
+        that:
+          - result_install is changed
+          - "'INSTALL COMPONENT' in result_install.queries | join(' ')"
+
+    # ============================================================
+    # Test: Install idempotency (already installed)
+    # ============================================================
+    - name: Install validate_password component again (idempotency)
+      mysql_password_policy:
+        <<: *mysql_params
+        state: present
+      register: result_install_idem
+
+    - name: Assert no change on second install
+      assert:
+        that:
+          - result_install_idem is not changed
+
+    # ============================================================
+    # Test: Set policy to MEDIUM
+    # ============================================================
+    - name: Set password policy to MEDIUM
+      mysql_password_policy:
+        <<: *mysql_params
+        policy: MEDIUM
+      register: result_policy
+
+    - name: Read validate_password.policy variable
+      mysql_variables:
+        <<: *mysql_params
+        variable: validate_password.policy
+      register: policy_value
+
+    - name: Assert policy is MEDIUM
+      assert:
+        that:
+          - policy_value.msg == 'MEDIUM'
+
+    # ============================================================
+    # Test: Policy idempotency
+    # ============================================================
+    - name: Set password policy to MEDIUM again (idempotency)
+      mysql_password_policy:
+        <<: *mysql_params
+        policy: MEDIUM
+      register: result_policy_idem
+
+    - name: Assert no change on idempotent policy set
+      assert:
+        that:
+          - result_policy_idem is not changed
+
+    # ============================================================
+    # Test: Set multiple validate_password parameters
+    # ============================================================
+    - name: Configure password complexity
+      mysql_password_policy:
+        <<: *mysql_params
+        length: 12
+        mixed_case_count: 2
+        number_count: 2
+        special_char_count: 1
+        check_user_name: true
+      register: result_complexity
+
+    - name: Assert complexity settings changed
+      assert:
+        that:
+          - result_complexity is changed
+
+    - name: Read validate_password.length variable
+      mysql_variables:
+        <<: *mysql_params
+        variable: validate_password.length
+      register: length_value
+
+    - name: Assert length is 12
+      assert:
+        that:
+          - length_value.msg == '12'
+
+    # ============================================================
+    # Test: Complexity idempotency
+    # ============================================================
+    - name: Configure same password complexity again (idempotency)
+      mysql_password_policy:
+        <<: *mysql_params
+        length: 12
+        mixed_case_count: 2
+        number_count: 2
+        special_char_count: 1
+        check_user_name: true
+      register: result_complexity_idem
+
+    - name: Assert no change on idempotent complexity set
+      assert:
+        that:
+          - result_complexity_idem is not changed
+
+    # ============================================================
+    # Test: Set global password lifetime
+    # ============================================================
+    - name: Set default password lifetime to 90 days
+      mysql_password_policy:
+        <<: *mysql_params
+        password_lifetime: 90
+      register: result_lifetime
+
+    - name: Assert password lifetime changed
+      assert:
+        that:
+          - result_lifetime is changed
+
+    - name: Read default_password_lifetime variable
+      mysql_variables:
+        <<: *mysql_params
+        variable: default_password_lifetime
+      register: lifetime_value
+
+    - name: Assert password lifetime is 90
+      assert:
+        that:
+          - lifetime_value.msg == '90'
+
+    # ============================================================
+    # Test: Set password history and reuse interval
+    # ============================================================
+    - name: Set password history and reuse interval
+      mysql_password_policy:
+        <<: *mysql_params
+        password_history: 5
+        reuse_interval: 365
+      register: result_history
+
+    - name: Assert history settings changed
+      assert:
+        that:
+          - result_history is changed
+
+    - name: Read password_history variable
+      mysql_variables:
+        <<: *mysql_params
+        variable: password_history
+      register: history_value
+
+    - name: Assert password history is 5
+      assert:
+        that:
+          - history_value.msg == '5'
+
+    # ============================================================
+    # Test: check_mode on install (with component already installed)
+    # ============================================================
+    - name: Set policy to STRONG in check_mode
+      mysql_password_policy:
+        <<: *mysql_params
+        policy: STRONG
+      check_mode: true
+      register: result_check
+
+    - name: Assert check_mode reports change
+      assert:
+        that:
+          - result_check is changed
+
+    - name: Verify policy unchanged after check_mode
+      mysql_variables:
+        <<: *mysql_params
+        variable: validate_password.policy
+      register: policy_after_check
+
+    - name: Assert policy is still MEDIUM (check_mode did not apply)
+      assert:
+        that:
+          - policy_after_check.msg == 'MEDIUM'
+
+    # ============================================================
+    # Test: Uninstall validate_password component
+    # ============================================================
+    - name: Uninstall validate_password component
+      mysql_password_policy:
+        <<: *mysql_params
+        state: absent
+      register: result_uninstall
+
+    - name: Assert component was uninstalled
+      assert:
+        that:
+          - result_uninstall is changed
+          - "'UNINSTALL COMPONENT' in result_uninstall.queries | join(' ')"
+
+    # ============================================================
+    # Test: Uninstall idempotency
+    # ============================================================
+    - name: Uninstall validate_password component again (idempotency)
+      mysql_password_policy:
+        <<: *mysql_params
+        state: absent
+      register: result_uninstall_idem
+
+    - name: Assert no change on second uninstall
+      assert:
+        that:
+          - result_uninstall_idem is not changed
+
+    # ============================================================
+    # Cleanup: reset global password variables
+    # ============================================================
+    - name: Reset default_password_lifetime to 0
+      mysql_variables:
+        <<: *mysql_params
+        variable: default_password_lifetime
+        value: '0'
+
+    - name: Reset password_history to 0
+      mysql_variables:
+        <<: *mysql_params
+        variable: password_history
+        value: '0'
+
+    - name: Reset password_reuse_interval to 0
+      mysql_variables:
+        <<: *mysql_params
+        variable: password_reuse_interval
+        value: '0'

--- a/tests/integration/targets/test_mysql_tls/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_tls/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for test_mysql_tls
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_tls/meta/main.yml
+++ b/tests/integration/targets/test_mysql_tls/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_tls/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_tls/tasks/main.yml
@@ -1,0 +1,6 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- import_tasks: mysql_tls.yml

--- a/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
+++ b/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
@@ -1,0 +1,162 @@
+# test code for the mysql_tls module
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+# Test mysql_tls module
+# ============================================================
+
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    # Test: Read current TLS state (no changes, state=present with no params)
+    # ============================================================
+    - name: Get current TLS settings (no changes expected)
+      mysql_tls:
+        <<: *mysql_params
+        state: present
+      register: result
+
+    - name: Assert no change when no params specified
+      assert:
+        that:
+          - result is not changed
+
+    # ============================================================
+    # Test: Set require_secure_transport in check_mode
+    # ============================================================
+    - name: Set require_secure_transport in check_mode
+      mysql_tls:
+        <<: *mysql_params
+        require_secure_transport: false
+      check_mode: true
+      register: result_check
+
+    - name: Verify check_mode returns queries
+      assert:
+        that:
+          - result_check is not failed
+
+    # ============================================================
+    # Test: Set tls_version
+    # ============================================================
+    - name: Set tls_version to TLSv1.2,TLSv1.3
+      mysql_tls:
+        <<: *mysql_params
+        tls_version: 'TLSv1.2,TLSv1.3'
+      register: result_tls_ver
+
+    # Verify by reading the variable directly
+    - name: Read tls_version variable
+      mysql_variables:
+        <<: *mysql_params
+        variable: tls_version
+      register: tls_ver_value
+
+    - name: Assert tls_version was set
+      assert:
+        that:
+          - tls_ver_value.msg == 'TLSv1.2,TLSv1.3'
+
+    # ============================================================
+    # Test: Idempotency - set same tls_version again
+    # ============================================================
+    - name: Set tls_version again (idempotency)
+      mysql_tls:
+        <<: *mysql_params
+        tls_version: 'TLSv1.2,TLSv1.3'
+      register: result_idem
+
+    - name: Assert no change on idempotent run
+      assert:
+        that:
+          - result_idem is not changed
+
+    # ============================================================
+    # Test: Set require_secure_transport to ON
+    # ============================================================
+    - name: Enable require_secure_transport
+      mysql_tls:
+        <<: *mysql_params
+        require_secure_transport: true
+      register: result_secure
+
+    - name: Read require_secure_transport variable
+      mysql_variables:
+        <<: *mysql_params
+        variable: require_secure_transport
+      register: secure_value
+
+    - name: Assert require_secure_transport is ON
+      assert:
+        that:
+          - secure_value.msg == 'ON'
+
+    # ============================================================
+    # Test: Reset to defaults with state=absent
+    # ============================================================
+    - name: Reset TLS to defaults
+      mysql_tls:
+        <<: *mysql_params
+        state: absent
+      register: result_absent
+
+    - name: Read require_secure_transport after reset
+      mysql_variables:
+        <<: *mysql_params
+        variable: require_secure_transport
+      register: secure_after_reset
+
+    - name: Assert require_secure_transport is OFF after reset
+      assert:
+        that:
+          - secure_after_reset.msg == 'OFF'
+
+    # ============================================================
+    # Test: state=absent idempotency
+    # ============================================================
+    - name: Reset TLS to defaults again (idempotency)
+      mysql_tls:
+        <<: *mysql_params
+        state: absent
+      register: result_absent_idem
+
+    - name: Assert no change on second absent run
+      assert:
+        that:
+          - result_absent_idem is not changed
+
+    # ============================================================
+    # Test: reload option
+    # ============================================================
+    - name: Reload TLS context
+      mysql_tls:
+        <<: *mysql_params
+        reload: true
+      register: result_reload
+
+    - name: Assert reload caused a change
+      assert:
+        that:
+          - result_reload is changed
+          - "'ALTER INSTANCE RELOAD TLS' in result_reload.queries"


### PR DESCRIPTION
## Summary

Adds three new security and compliance modules as proposed in #805:

- **`mysql_audit`** / **`mysql_audit_info`** — Install and configure the MySQL audit log component (`component_audit_api_message_emit`), manage audit filter rules via `audit_log_filter_set_filter()`, assign filters to users, control log format (JSON/XML/CSV) and rotation.

- **`mysql_tls`** — Configure server-side TLS: certificate paths, `require_secure_transport`, minimum TLS version, and hot-reload certificates via `ALTER INSTANCE RELOAD TLS` (MySQL 8.0.16+).

- **`mysql_password_policy`** — Install and configure the `validate_password` component: password complexity (length, mixed case, numbers, special chars), policy level (LOW/MEDIUM/STRONG), expiration, history depth, and reuse interval.

## Design Decisions

- All modules use `mysql_common_argument_spec()` and `mysql_connect()` — no custom connection params
- SQL variable names are quoted via `mysql_quote_identifier()` (same pattern as `mysql_variables.py`)
- `version_added: '5.1.0'` on all new modules and parameters
- All modules support `check_mode`
- Modules return `queries` list showing executed SQL (same as `mysql_variables`)

## Security Review

- Ran Semgrep with `p/python` + `p/security-audit` rules — 0 findings
- SQL parameterization follows the exact upstream pattern from `mysql_variables.py`
- `password_history` and `password_lifetime` params have explicit `no_log=False` (they're integers, not secrets)

## Test Plan

- [x] `ansible-test sanity --test validate-modules` — PASS
- [x] `ansible-test sanity --test ansible-doc` — PASS
- [x] `ansible-test sanity --test pep8` — PASS
- [x] `ansible-test sanity --test pylint` — PASS
- [x] Semgrep security scan — 0 findings
- [x] Integration tests for all 3 module domains (audit, TLS, password policy)
- [x] No `ignore_errors` in any test file
- [ ] Integration tests against MySQL 8.0+ (requires CI environment)

## Changelog Fragments

Included for all 3 modules in `changelogs/fragments/`.

Closes #805