### PR TITLE
feat: add mysql_audit and mysql_audit_info modules

### DIFF
--- a/plugins/modules/mysql_audit.py
+++ b/plugins/modules/mysql_audit.py
@@ -19,8 +19,6 @@ description:
 - Set the audit log format and trigger log rotation.
 - On MySQL 8.0+ the module uses C(INSTALL COMPONENT) for the
   C(component_audit_api_message_emit) component.
-- On MySQL 5.7 the module uses C(INSTALL PLUGIN) for the legacy
-  C(audit_log) plugin.
 
 version_added: '5.1.0'
 

--- a/plugins/modules/mysql_audit.py
+++ b/plugins/modules/mysql_audit.py
@@ -46,7 +46,6 @@ options:
     type: str
     choices: ['JSON', 'XML', 'CSV']
     default: JSON
-    version_added: '5.1.0'
   mode:
     description:
     - How the log format variable is set.

--- a/plugins/modules/mysql_audit.py
+++ b/plugins/modules/mysql_audit.py
@@ -50,9 +50,9 @@ options:
   mode:
     description:
     - How the log format variable is set.
-    - C(global) uses C(SET GLOBAL) which does not survive a MySQL restart
+    - V(global) uses C(SET GLOBAL) which does not survive a MySQL restart
       unless also configured in C(my.cnf).
-    - C(persist) uses C(SET PERSIST) (MySQL 8.0+ only) which writes the
+    - V(persist) uses C(SET PERSIST) (MySQL 8.0+ only) which writes the
       value to C(mysqld-auto.cnf) and survives restarts.
     type: str
     choices: ['global', 'persist']

--- a/plugins/modules/mysql_audit.py
+++ b/plugins/modules/mysql_audit.py
@@ -1,0 +1,422 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_audit
+
+short_description: Manage MySQL audit log plugin and filters
+
+description:
+- Install or uninstall the MySQL audit log plugin.
+- Configure audit log filters and assign them to users.
+- Set the audit log format and trigger log rotation.
+- Supports the component_audit_api_message_emit component (MySQL 8.0+)
+  and the audit_log plugin.
+
+version_added: '5.1.0'
+
+author:
+- Steve Fulmer (@stevefulme1)
+
+options:
+  state:
+    description:
+    - Whether the audit plugin should be installed (C(present)) or removed (C(absent)).
+    type: str
+    choices: ['present', 'absent']
+    default: present
+    version_added: '5.1.0'
+  log_format:
+    description:
+    - The audit log output format.
+    - Only applied when the audit plugin is installed.
+    type: str
+    choices: ['JSON', 'XML', 'CSV']
+    default: JSON
+    version_added: '5.1.0'
+  filter_name:
+    description:
+    - Name of the audit filter to create or remove.
+    - Required when O(filter_rule) is provided.
+    type: str
+    version_added: '5.1.0'
+  filter_rule:
+    description:
+    - A dictionary defining the audit filter rule (JSON filter document).
+    - Requires O(filter_name) to be set.
+    type: dict
+    version_added: '5.1.0'
+  users:
+    description:
+    - List of MySQL user accounts (in C(user@host) format) to apply the filter to.
+    - Requires O(filter_name) to be set.
+    type: list
+    elements: str
+    version_added: '5.1.0'
+  rotate:
+    description:
+    - Whether to trigger audit log rotation.
+    type: bool
+    default: false
+    version_added: '5.1.0'
+
+attributes:
+  check_mode:
+    support: partial
+    details:
+      - In check mode the module reports what changes would be made
+        without executing them.
+  idempotent:
+    support: partial
+    details:
+      - The module checks current state before making changes.
+      - Log rotation (O(rotate=true)) always reports changed.
+
+seealso:
+- module: ansible.mysql.mysql_audit_info
+- module: ansible.mysql.mysql_variables
+- name: MySQL Audit Log reference
+  description: MySQL Enterprise Audit documentation.
+  link: https://dev.mysql.com/doc/refman/8.0/en/audit-log.html
+
+notes:
+   - Compatible with MySQL only. MariaDB has a separate audit plugin.
+   - Requires the MySQL Enterprise Audit plugin files to be available
+     on the server.
+
+extends_documentation_fragment:
+- ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Install the audit log plugin
+  ansible.mysql.mysql_audit:
+    state: present
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Set audit log format to JSON
+  ansible.mysql.mysql_audit:
+    state: present
+    log_format: JSON
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Create and assign an audit filter
+  ansible.mysql.mysql_audit:
+    state: present
+    filter_name: log_all
+    filter_rule:
+      filter:
+        log: true
+    users:
+      - root@localhost
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Rotate the audit log
+  ansible.mysql.mysql_audit:
+    state: present
+    rotate: true
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Uninstall the audit log plugin
+  ansible.mysql.mysql_audit:
+    state: absent
+    login_unix_socket: /run/mysqld/mysqld.sock
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed queries which modified the server state.
+  returned: if executed
+  type: list
+  sample: ["INSTALL COMPONENT 'file://component_audit_api_message_emit'"]
+  version_added: '5.1.0'
+'''
+
+import json
+import os
+import warnings
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+    mysql_common_argument_spec,
+)
+from ansible.module_utils.common.text.converters import to_native
+
+executed_queries = []
+
+
+def is_audit_plugin_installed(cursor):
+    """Check whether any audit log component or plugin is installed."""
+    # Check for component (MySQL 8.0+)
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM mysql.component "
+            "WHERE component_urn = 'file://component_audit_api_message_emit'"
+        )
+        row = cursor.fetchone()
+        if row and row[0] > 0:
+            return True
+    except Exception:
+        pass
+
+    # Check for legacy plugin
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM information_schema.PLUGINS "
+            "WHERE PLUGIN_NAME = 'audit_log' AND PLUGIN_STATUS = 'ACTIVE'"
+        )
+        row = cursor.fetchone()
+        if row and row[0] > 0:
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+def install_audit_plugin(cursor):
+    """Install the audit log component."""
+    query = "INSTALL COMPONENT 'file://component_audit_api_message_emit'"
+    cursor.execute(query)
+    executed_queries.append(query)
+
+
+def uninstall_audit_plugin(cursor):
+    """Uninstall the audit log component."""
+    query = "UNINSTALL COMPONENT 'file://component_audit_api_message_emit'"
+    cursor.execute(query)
+    executed_queries.append(query)
+
+
+def get_audit_log_format(cursor):
+    """Return current audit_log_format value or None."""
+    try:
+        cursor.execute("SHOW VARIABLES LIKE 'audit_log_format'")
+        row = cursor.fetchone()
+        if row:
+            return row[1]
+    except Exception:
+        pass
+    return None
+
+
+def set_audit_log_format(cursor, log_format):
+    """Set the global audit_log_format variable."""
+    query = "SET GLOBAL audit_log_format = %s"
+    cursor.execute(query, (log_format,))
+    executed_queries.append("SET GLOBAL audit_log_format = '%s'" % log_format)
+
+
+def set_audit_filter(cursor, filter_name, filter_rule):
+    """Create or replace an audit filter."""
+    rule_json = json.dumps(filter_rule)
+    query = "SELECT audit_log_filter_set_filter(%s, %s)"
+    cursor.execute(query, (filter_name, rule_json))
+    executed_queries.append(
+        "SELECT audit_log_filter_set_filter('%s', '%s')" % (filter_name, rule_json)
+    )
+
+
+def remove_audit_filter(cursor, filter_name):
+    """Remove an audit filter."""
+    query = "SELECT audit_log_filter_remove_filter(%s)"
+    cursor.execute(query, (filter_name,))
+    executed_queries.append(
+        "SELECT audit_log_filter_remove_filter('%s')" % filter_name
+    )
+
+
+def set_user_filter(cursor, user, filter_name):
+    """Assign a filter to a user."""
+    query = "SELECT audit_log_filter_set_user(%s, %s)"
+    cursor.execute(query, (user, filter_name))
+    executed_queries.append(
+        "SELECT audit_log_filter_set_user('%s', '%s')" % (user, filter_name)
+    )
+
+
+def remove_user_filter(cursor, user):
+    """Remove filter assignment from a user."""
+    query = "SELECT audit_log_filter_remove_user(%s)"
+    cursor.execute(query, (user,))
+    executed_queries.append(
+        "SELECT audit_log_filter_remove_user('%s')" % user
+    )
+
+
+def get_existing_filters(cursor):
+    """Return a dict of existing filter names to their definitions."""
+    filters = {}
+    try:
+        cursor.execute(
+            "SELECT NAME, FILTER FROM mysql.audit_log_filter"
+        )
+        for row in cursor.fetchall():
+            filters[row[0]] = row[1]
+    except Exception:
+        pass
+    return filters
+
+
+def get_user_filter_assignments(cursor):
+    """Return a dict of user -> filter_name assignments."""
+    assignments = {}
+    try:
+        cursor.execute(
+            "SELECT USER, FILTERNAME FROM mysql.audit_log_user"
+        )
+        for row in cursor.fetchall():
+            assignments[row[0]] = row[1]
+    except Exception:
+        pass
+    return assignments
+
+
+def rotate_audit_log(cursor):
+    """Trigger audit log rotation."""
+    query = "SET GLOBAL audit_log_rotate = ON"
+    cursor.execute(query)
+    executed_queries.append(query)
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        log_format=dict(type='str', choices=['JSON', 'XML', 'CSV'], default='JSON'),
+        filter_name=dict(type='str'),
+        filter_rule=dict(type='dict'),
+        users=dict(type='list', elements='str'),
+        rotate=dict(type='bool', default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_together=[
+            ('filter_name', 'filter_rule'),
+        ],
+    )
+
+    user = module.params["login_user"]
+    password = module.params["login_password"]
+    connect_timeout = module.params['connect_timeout']
+    ssl_cert = module.params["client_cert"]
+    ssl_key = module.params["client_key"]
+    ssl_ca = module.params["ca_cert"]
+    check_hostname = module.params["check_hostname"]
+    config_file = module.params['config_file']
+    db = 'mysql'
+
+    state = module.params['state']
+    log_format = module.params['log_format']
+    filter_name = module.params['filter_name']
+    filter_rule = module.params['filter_rule']
+    users = module.params['users']
+    rotate = module.params['rotate']
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+    else:
+        warnings.filterwarnings('error', category=mysql_driver.Warning)
+
+    try:
+        cursor, db_conn = mysql_connect(
+            module, user, password, config_file,
+            ssl_cert, ssl_key, ssl_ca, db,
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+        )
+    except Exception as e:
+        if os.path.exists(config_file):
+            module.fail_json(
+                msg="unable to connect to database, check login_user and "
+                    "login_password are correct or %s has the credentials. "
+                    "Exception message: %s" % (config_file, to_native(e))
+            )
+        else:
+            module.fail_json(
+                msg="unable to find %s. Exception message: %s"
+                    % (config_file, to_native(e))
+            )
+
+    changed = False
+
+    try:
+        plugin_installed = is_audit_plugin_installed(cursor)
+
+        if state == 'absent':
+            if plugin_installed:
+                if not module.check_mode:
+                    uninstall_audit_plugin(cursor)
+                changed = True
+
+            module.exit_json(changed=changed, queries=executed_queries)
+
+        # state == 'present'
+        if not plugin_installed:
+            if not module.check_mode:
+                install_audit_plugin(cursor)
+            changed = True
+
+        # Set log format if plugin is now installed
+        if not module.check_mode and (plugin_installed or changed):
+            current_format = get_audit_log_format(cursor)
+            if current_format and current_format.upper() != log_format.upper():
+                set_audit_log_format(cursor, log_format)
+                changed = True
+
+        # Configure filter
+        if filter_name and filter_rule:
+            existing_filters = get_existing_filters(cursor) if not module.check_mode else {}
+            rule_json = json.dumps(filter_rule)
+
+            needs_filter_update = True
+            if filter_name in existing_filters:
+                existing_rule = existing_filters[filter_name]
+                if isinstance(existing_rule, str):
+                    try:
+                        existing_rule = json.loads(existing_rule)
+                    except (ValueError, TypeError):
+                        pass
+                if existing_rule == filter_rule:
+                    needs_filter_update = False
+
+            if needs_filter_update:
+                if not module.check_mode:
+                    set_audit_filter(cursor, filter_name, filter_rule)
+                changed = True
+
+            # Assign filter to users
+            if users:
+                current_assignments = get_user_filter_assignments(cursor) if not module.check_mode else {}
+                for u in users:
+                    if current_assignments.get(u) != filter_name:
+                        if not module.check_mode:
+                            set_user_filter(cursor, u, filter_name)
+                        changed = True
+
+        # Rotate log
+        if rotate:
+            if not module.check_mode:
+                rotate_audit_log(cursor)
+            changed = True
+
+    except Exception as e:
+        module.fail_json(msg="Error managing audit plugin: %s" % to_native(e))
+
+    module.exit_json(changed=changed, queries=executed_queries)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_audit.py
+++ b/plugins/modules/mysql_audit.py
@@ -39,7 +39,6 @@ options:
     type: str
     choices: ['present', 'absent']
     default: present
-    version_added: '5.1.0'
   log_format:
     description:
     - The audit log output format.

--- a/plugins/modules/mysql_audit.py
+++ b/plugins/modules/mysql_audit.py
@@ -29,12 +29,12 @@ options:
   state:
     description:
     - Controls what the module manages.
-    - When C(present), installs the audit plugin (if needed), configures
+    - When V(present), installs the audit plugin, configures
       log format, creates or updates filters, and assigns users.
-    - When C(absent) without O(filter_name), uninstalls the audit plugin.
-    - When C(absent) with O(filter_name), removes the named filter and
+    - When V(absent) without O(filter_name), uninstalls the audit plugin.
+    - When V(absent) with O(filter_name), removes the named filter and
       all its user assignments.
-    - When C(absent) with O(filter_name) and O(users), removes only the
+    - When V(absent) with O(filter_name) and O(users), removes only the
       listed users from the filter without deleting the filter itself.
     type: str
     choices: ['present', 'absent']

--- a/plugins/modules/mysql_audit.py
+++ b/plugins/modules/mysql_audit.py
@@ -149,6 +149,7 @@ from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
     mysql_driver,
     mysql_driver_fail_msg,
     mysql_common_argument_spec,
+    get_server_implementation,
 )
 from ansible.module_utils.common.text.converters import to_native
 
@@ -349,6 +350,14 @@ def main():
                 msg="unable to find %s. Exception message: %s"
                     % (config_file, to_native(e))
             )
+
+    server_implementation = get_server_implementation(cursor)
+    if server_implementation == "mariadb":
+        module.fail_json(
+            msg="mysql_audit does not support MariaDB. "
+                "MariaDB uses a separate audit plugin (server_audit). "
+                "See https://mariadb.com/kb/en/mariadb-audit-plugin/"
+        )
 
     changed = False
 

--- a/plugins/modules/mysql_audit.py
+++ b/plugins/modules/mysql_audit.py
@@ -17,8 +17,10 @@ description:
 - Install or uninstall the MySQL audit log plugin.
 - Configure audit log filters and assign them to users.
 - Set the audit log format and trigger log rotation.
-- Supports the component_audit_api_message_emit component (MySQL 8.0+)
-  and the audit_log plugin.
+- On MySQL 8.0+ the module uses C(INSTALL COMPONENT) for the
+  C(component_audit_api_message_emit) component.
+- On MySQL 5.7 the module uses C(INSTALL PLUGIN) for the legacy
+  C(audit_log) plugin.
 
 version_added: '5.1.0'
 
@@ -28,7 +30,14 @@ author:
 options:
   state:
     description:
-    - Whether the audit plugin should be installed (C(present)) or removed (C(absent)).
+    - Controls what the module manages.
+    - When C(present), installs the audit plugin (if needed), configures
+      log format, creates or updates filters, and assigns users.
+    - When C(absent) without O(filter_name), uninstalls the audit plugin.
+    - When C(absent) with O(filter_name), removes the named filter and
+      all its user assignments.
+    - When C(absent) with O(filter_name) and O(users), removes only the
+      listed users from the filter without deleting the filter itself.
     type: str
     choices: ['present', 'absent']
     default: present
@@ -41,24 +50,61 @@ options:
     choices: ['JSON', 'XML', 'CSV']
     default: JSON
     version_added: '5.1.0'
+  mode:
+    description:
+    - How the log format variable is set.
+    - C(global) uses C(SET GLOBAL) which does not survive a MySQL restart
+      unless also configured in C(my.cnf).
+    - C(persist) uses C(SET PERSIST) (MySQL 8.0+ only) which writes the
+      value to C(mysqld-auto.cnf) and survives restarts.
+    type: str
+    choices: ['global', 'persist']
+    default: global
+    version_added: '5.1.0'
   filter_name:
     description:
-    - Name of the audit filter to create or remove.
-    - Required when O(filter_rule) is provided.
+    - Name of the audit filter to manage.
+    - When O(state=present) and O(filter_rule) is provided, creates or
+      replaces the filter.
+    - When O(state=present) without O(filter_rule), the filter must
+      already exist; users can be assigned to it.
+    - When O(state=absent), removes the filter or specific users from it
+      (see O(state) for details).
     type: str
     version_added: '5.1.0'
   filter_rule:
     description:
     - A dictionary defining the audit filter rule (JSON filter document).
-    - Requires O(filter_name) to be set.
+    - Required when creating a new filter with O(state=present).
+    - Optional when assigning users to an existing filter.
     type: dict
     version_added: '5.1.0'
   users:
     description:
-    - List of MySQL user accounts (in C(user@host) format) to apply the filter to.
+    - List of MySQL user accounts (in C(user@host) format) to manage.
     - Requires O(filter_name) to be set.
+    - By default the module enforces exact match (replace mode). Users
+      assigned to the filter but not in this list are removed.
+    - Use O(append_users=true) for additive-only assignment.
+    - Use O(detach_users=true) to remove listed users from the filter.
     type: list
     elements: str
+    version_added: '5.1.0'
+  append_users:
+    description:
+    - When C(true), users in O(users) are added to the filter without
+      removing existing assignments (additive mode).
+    - Mutually exclusive with O(detach_users).
+    type: bool
+    default: false
+    version_added: '5.1.0'
+  detach_users:
+    description:
+    - When C(true), users in O(users) are removed from the filter
+      (subtractive mode).
+    - Mutually exclusive with O(append_users).
+    type: bool
+    default: false
     version_added: '5.1.0'
   rotate:
     description:
@@ -90,6 +136,13 @@ notes:
    - Compatible with MySQL only. MariaDB has a separate audit plugin.
    - Requires the MySQL Enterprise Audit plugin files to be available
      on the server.
+   - On MySQL 8.0+ the module manages the audit component.
+     On MySQL 5.7 it manages the legacy audit_log plugin.
+   - When O(mode=global), the log format setting does not survive a
+     MySQL restart unless also set in C(my.cnf).
+     Use O(mode=persist) on MySQL 8.0+ or the
+     M(ansible.mysql.mysql_variables) module with C(mode=persist)
+     for persistent configuration.
 
 extends_documentation_fragment:
 - ansible.mysql.mysql
@@ -101,10 +154,11 @@ EXAMPLES = r'''
     state: present
     login_unix_socket: /run/mysqld/mysqld.sock
 
-- name: Set audit log format to JSON
+- name: Set audit log format to JSON (persists across restart)
   ansible.mysql.mysql_audit:
     state: present
     log_format: JSON
+    mode: persist
     login_unix_socket: /run/mysqld/mysqld.sock
 
 - name: Create and assign an audit filter
@@ -116,6 +170,38 @@ EXAMPLES = r'''
         log: true
     users:
       - root@localhost
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Assign users to an existing filter (no rule needed)
+  ansible.mysql.mysql_audit:
+    state: present
+    filter_name: log_all
+    users:
+      - app@10.0.0.%
+    append_users: true
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Remove specific users from a filter
+  ansible.mysql.mysql_audit:
+    state: present
+    filter_name: log_all
+    users:
+      - app@10.0.0.%
+    detach_users: true
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Remove users from a filter using state absent
+  ansible.mysql.mysql_audit:
+    state: absent
+    filter_name: log_all
+    users:
+      - root@localhost
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Remove a filter and all its user assignments
+  ansible.mysql.mysql_audit:
+    state: absent
+    filter_name: log_all
     login_unix_socket: /run/mysqld/mysqld.sock
 
 - name: Rotate the audit log
@@ -150,15 +236,18 @@ from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
     mysql_driver_fail_msg,
     mysql_common_argument_spec,
     get_server_implementation,
+    get_server_version,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils._version import (
+    LooseVersion,
 )
 from ansible.module_utils.common.text.converters import to_native
 
 executed_queries = []
 
 
-def is_audit_plugin_installed(cursor):
-    """Check whether any audit log component or plugin is installed."""
-    # Check for component (MySQL 8.0+)
+def get_audit_plugin_type(cursor):
+    """Return 'component', 'plugin', or None."""
     try:
         cursor.execute(
             "SELECT COUNT(*) FROM mysql.component "
@@ -166,11 +255,10 @@ def is_audit_plugin_installed(cursor):
         )
         row = cursor.fetchone()
         if row and row[0] > 0:
-            return True
+            return 'component'
     except Exception:
         pass
 
-    # Check for legacy plugin
     try:
         cursor.execute(
             "SELECT COUNT(*) FROM information_schema.PLUGINS "
@@ -178,23 +266,32 @@ def is_audit_plugin_installed(cursor):
         )
         row = cursor.fetchone()
         if row and row[0] > 0:
-            return True
+            return 'plugin'
     except Exception:
         pass
 
-    return False
+    return None
 
 
-def install_audit_plugin(cursor):
-    """Install the audit log component."""
-    query = "INSTALL COMPONENT 'file://component_audit_api_message_emit'"
+def install_audit_plugin(cursor, server_version):
+    """Install the audit plugin using the appropriate method."""
+    version = server_version.split('-')[0]
+    if LooseVersion(version) >= LooseVersion("8.0"):
+        query = "INSTALL COMPONENT 'file://component_audit_api_message_emit'"
+    else:
+        query = "INSTALL PLUGIN audit_log SONAME 'audit_log.so'"
     cursor.execute(query)
     executed_queries.append(query)
 
 
-def uninstall_audit_plugin(cursor):
-    """Uninstall the audit log component."""
-    query = "UNINSTALL COMPONENT 'file://component_audit_api_message_emit'"
+def uninstall_audit_plugin(cursor, plugin_type):
+    """Uninstall the audit plugin based on detected install type."""
+    if plugin_type == 'component':
+        query = "UNINSTALL COMPONENT 'file://component_audit_api_message_emit'"
+    elif plugin_type == 'plugin':
+        query = "UNINSTALL PLUGIN audit_log"
+    else:
+        return
     cursor.execute(query)
     executed_queries.append(query)
 
@@ -211,11 +308,21 @@ def get_audit_log_format(cursor):
     return None
 
 
-def set_audit_log_format(cursor, log_format):
-    """Set the global audit_log_format variable."""
-    query = "SET GLOBAL audit_log_format = %s"
+def set_audit_log_format(cursor, log_format, mode, server_version):
+    """Set the audit_log_format variable."""
+    if mode == 'persist':
+        version = server_version.split('-')[0]
+        if LooseVersion(version) < LooseVersion("8.0"):
+            raise Exception(
+                "mode=persist requires MySQL 8.0+, "
+                "server is %s" % server_version
+            )
+        query = "SET PERSIST audit_log_format = %s"
+    else:
+        query = "SET GLOBAL audit_log_format = %s"
     cursor.execute(query, (log_format,))
-    executed_queries.append("SET GLOBAL audit_log_format = '%s'" % log_format)
+    display = query.replace('%s', "'%s'" % log_format)
+    executed_queries.append(display)
 
 
 def set_audit_filter(cursor, filter_name, filter_rule):
@@ -224,7 +331,8 @@ def set_audit_filter(cursor, filter_name, filter_rule):
     query = "SELECT audit_log_filter_set_filter(%s, %s)"
     cursor.execute(query, (filter_name, rule_json))
     executed_queries.append(
-        "SELECT audit_log_filter_set_filter('%s', '%s')" % (filter_name, rule_json)
+        "SELECT audit_log_filter_set_filter('%s', '%s')"
+        % (filter_name, rule_json)
     )
 
 
@@ -242,7 +350,8 @@ def set_user_filter(cursor, user, filter_name):
     query = "SELECT audit_log_filter_set_user(%s, %s)"
     cursor.execute(query, (user, filter_name))
     executed_queries.append(
-        "SELECT audit_log_filter_set_user('%s', '%s')" % (user, filter_name)
+        "SELECT audit_log_filter_set_user('%s', '%s')"
+        % (user, filter_name)
     )
 
 
@@ -283,6 +392,21 @@ def get_user_filter_assignments(cursor):
     return assignments
 
 
+def get_users_for_filter(cursor, filter_name):
+    """Return list of users assigned to a specific filter."""
+    users = []
+    try:
+        cursor.execute(
+            "SELECT USER FROM mysql.audit_log_user WHERE FILTERNAME = %s",
+            (filter_name,)
+        )
+        for row in cursor.fetchall():
+            users.append(row[0])
+    except Exception:
+        pass
+    return users
+
+
 def rotate_audit_log(cursor):
     """Trigger audit log rotation."""
     query = "SET GLOBAL audit_log_rotate = ON"
@@ -293,24 +417,30 @@ def rotate_audit_log(cursor):
 def main():
     argument_spec = mysql_common_argument_spec()
     argument_spec.update(
-        state=dict(type='str', choices=['present', 'absent'], default='present'),
-        log_format=dict(type='str', choices=['JSON', 'XML', 'CSV'], default='JSON'),
+        state=dict(type='str', choices=['present', 'absent'],
+                   default='present'),
+        log_format=dict(type='str', choices=['JSON', 'XML', 'CSV'],
+                        default='JSON'),
+        mode=dict(type='str', choices=['global', 'persist'],
+                  default='global'),
         filter_name=dict(type='str'),
         filter_rule=dict(type='dict'),
         users=dict(type='list', elements='str'),
+        append_users=dict(type='bool', default=False),
+        detach_users=dict(type='bool', default=False),
         rotate=dict(type='bool', default=False),
     )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_together=[
-            ('filter_name', 'filter_rule'),
+        mutually_exclusive=[
+            ('append_users', 'detach_users'),
         ],
     )
 
-    user = module.params["login_user"]
-    password = module.params["login_password"]
+    login_user = module.params["login_user"]
+    login_password = module.params["login_password"]
     connect_timeout = module.params['connect_timeout']
     ssl_cert = module.params["client_cert"]
     ssl_key = module.params["client_key"]
@@ -321,10 +451,24 @@ def main():
 
     state = module.params['state']
     log_format = module.params['log_format']
+    mode = module.params['mode']
     filter_name = module.params['filter_name']
     filter_rule = module.params['filter_rule']
     users = module.params['users']
+    append_users = module.params['append_users']
+    detach_users = module.params['detach_users']
     rotate = module.params['rotate']
+
+    # Manual validation
+    if users and not filter_name:
+        module.fail_json(
+            msg="'users' requires 'filter_name' to be set."
+        )
+    if (append_users or detach_users) and not users:
+        module.fail_json(
+            msg="'append_users' and 'detach_users' require "
+                "'users' to be set."
+        )
 
     if mysql_driver is None:
         module.fail_json(msg=mysql_driver_fail_msg)
@@ -333,7 +477,7 @@ def main():
 
     try:
         cursor, db_conn = mysql_connect(
-            module, user, password, config_file,
+            module, login_user, login_password, config_file,
             ssl_cert, ssl_key, ssl_ca, db,
             connect_timeout=connect_timeout,
             check_hostname=check_hostname,
@@ -359,61 +503,129 @@ def main():
                 "See https://mariadb.com/kb/en/mariadb-audit-plugin/"
         )
 
+    server_version = get_server_version(cursor)
     changed = False
 
     try:
-        plugin_installed = is_audit_plugin_installed(cursor)
+        plugin_type = get_audit_plugin_type(cursor)
 
+        # ---- state=absent ----
         if state == 'absent':
-            if plugin_installed:
+            if filter_name and users:
+                # Remove specific users from the filter
                 if not module.check_mode:
-                    uninstall_audit_plugin(cursor)
-                changed = True
+                    current_filter_users = get_users_for_filter(
+                        cursor, filter_name)
+                    for u in users:
+                        if u in current_filter_users:
+                            remove_user_filter(cursor, u)
+                            changed = True
+                else:
+                    changed = True
+
+            elif filter_name:
+                # Remove filter and all its user assignments
+                existing_filters = (
+                    get_existing_filters(cursor)
+                    if not module.check_mode else {}
+                )
+                if module.check_mode or filter_name in existing_filters:
+                    if not module.check_mode:
+                        for u in get_users_for_filter(cursor, filter_name):
+                            remove_user_filter(cursor, u)
+                        remove_audit_filter(cursor, filter_name)
+                    changed = True
+
+            else:
+                # Uninstall the plugin entirely
+                if plugin_type is not None:
+                    if not module.check_mode:
+                        uninstall_audit_plugin(cursor, plugin_type)
+                    changed = True
 
             module.exit_json(changed=changed, queries=executed_queries)
 
-        # state == 'present'
-        if not plugin_installed:
+        # ---- state=present ----
+        # Install plugin if needed
+        if plugin_type is None:
             if not module.check_mode:
-                install_audit_plugin(cursor)
+                install_audit_plugin(cursor, server_version)
             changed = True
 
-        # Set log format if plugin is now installed
-        if not module.check_mode and (plugin_installed or changed):
+        # Set log format
+        if not module.check_mode and (plugin_type is not None or changed):
             current_format = get_audit_log_format(cursor)
-            if current_format and current_format.upper() != log_format.upper():
-                set_audit_log_format(cursor, log_format)
+            if (current_format
+                    and current_format.upper() != log_format.upper()):
+                set_audit_log_format(
+                    cursor, log_format, mode, server_version)
                 changed = True
 
         # Configure filter
-        if filter_name and filter_rule:
-            existing_filters = get_existing_filters(cursor) if not module.check_mode else {}
-            rule_json = json.dumps(filter_rule)
+        if filter_name:
+            if filter_rule:
+                # Create or update filter
+                existing_filters = (
+                    get_existing_filters(cursor)
+                    if not module.check_mode else {}
+                )
+                needs_update = True
+                if filter_name in existing_filters:
+                    existing_rule = existing_filters[filter_name]
+                    if isinstance(existing_rule, str):
+                        try:
+                            existing_rule = json.loads(existing_rule)
+                        except (ValueError, TypeError):
+                            pass
+                    if existing_rule == filter_rule:
+                        needs_update = False
 
-            needs_filter_update = True
-            if filter_name in existing_filters:
-                existing_rule = existing_filters[filter_name]
-                if isinstance(existing_rule, str):
-                    try:
-                        existing_rule = json.loads(existing_rule)
-                    except (ValueError, TypeError):
-                        pass
-                if existing_rule == filter_rule:
-                    needs_filter_update = False
-
-            if needs_filter_update:
+                if needs_update:
+                    if not module.check_mode:
+                        set_audit_filter(cursor, filter_name, filter_rule)
+                    changed = True
+            else:
+                # Verify existing filter
                 if not module.check_mode:
-                    set_audit_filter(cursor, filter_name, filter_rule)
-                changed = True
+                    existing_filters = get_existing_filters(cursor)
+                    if filter_name not in existing_filters:
+                        module.fail_json(
+                            msg="Filter '%s' does not exist. Provide "
+                                "'filter_rule' to create it."
+                                % filter_name
+                        )
 
-            # Assign filter to users
-            if users:
-                current_assignments = get_user_filter_assignments(cursor) if not module.check_mode else {}
-                for u in users:
-                    if current_assignments.get(u) != filter_name:
-                        if not module.check_mode:
+        # Manage user assignments
+        if users and filter_name:
+            if not module.check_mode:
+                current_assignments = get_user_filter_assignments(cursor)
+                current_filter_users = get_users_for_filter(
+                    cursor, filter_name)
+
+                if detach_users:
+                    for u in users:
+                        if u in current_filter_users:
+                            remove_user_filter(cursor, u)
+                            changed = True
+
+                elif append_users:
+                    for u in users:
+                        if current_assignments.get(u) != filter_name:
                             set_user_filter(cursor, u, filter_name)
-                        changed = True
+                            changed = True
+
+                else:
+                    # Replace mode: enforce exact match
+                    for u in users:
+                        if current_assignments.get(u) != filter_name:
+                            set_user_filter(cursor, u, filter_name)
+                            changed = True
+                    for u in current_filter_users:
+                        if u not in users:
+                            remove_user_filter(cursor, u)
+                            changed = True
+            else:
+                changed = True
 
         # Rotate log
         if rotate:
@@ -422,7 +634,8 @@ def main():
             changed = True
 
     except Exception as e:
-        module.fail_json(msg="Error managing audit plugin: %s" % to_native(e))
+        module.fail_json(
+            msg="Error managing audit plugin: %s" % to_native(e))
 
     module.exit_json(changed=changed, queries=executed_queries)
 

--- a/plugins/modules/mysql_audit_info.py
+++ b/plugins/modules/mysql_audit_info.py
@@ -84,7 +84,6 @@ user_assignments:
   returned: when plugin is installed
   type: dict
   sample: {"root@localhost": "log_all"}
-  version_added: '5.1.0'
 '''
 
 import json

--- a/plugins/modules/mysql_audit_info.py
+++ b/plugins/modules/mysql_audit_info.py
@@ -78,7 +78,6 @@ filters:
   returned: when plugin is installed
   type: dict
   sample: {"log_all": {"filter": {"log": true}}}
-  version_added: '5.1.0'
 user_assignments:
   description: Dictionary mapping users to their assigned filter names.
   returned: when plugin is installed

--- a/plugins/modules/mysql_audit_info.py
+++ b/plugins/modules/mysql_audit_info.py
@@ -67,7 +67,6 @@ log_format:
   returned: when plugin is installed
   type: str
   sample: "JSON"
-  version_added: '5.1.0'
 log_file:
   description: Path to the audit log file.
   returned: when plugin is installed

--- a/plugins/modules/mysql_audit_info.py
+++ b/plugins/modules/mysql_audit_info.py
@@ -62,7 +62,6 @@ plugin_installed:
   returned: always
   type: bool
   sample: true
-  version_added: '5.1.0'
 log_format:
   description: Current audit log format setting.
   returned: when plugin is installed

--- a/plugins/modules/mysql_audit_info.py
+++ b/plugins/modules/mysql_audit_info.py
@@ -72,7 +72,6 @@ log_file:
   returned: when plugin is installed
   type: str
   sample: "/var/lib/mysql/audit.log"
-  version_added: '5.1.0'
 filters:
   description: Dictionary of defined audit filters and their rules.
   returned: when plugin is installed

--- a/plugins/modules/mysql_audit_info.py
+++ b/plugins/modules/mysql_audit_info.py
@@ -1,0 +1,242 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_audit_info
+
+short_description: Gather information about MySQL audit log configuration
+
+description:
+- Returns the current audit log plugin status, active filters,
+  user filter assignments, log format, and log file path.
+
+version_added: '5.1.0'
+
+author:
+- Steve Fulmer (@stevefulme1)
+
+options: {}
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+seealso:
+- module: ansible.mysql.mysql_audit
+- module: ansible.mysql.mysql_info
+
+notes:
+   - Compatible with MySQL only. MariaDB has a separate audit plugin.
+
+extends_documentation_fragment:
+- ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Gather audit log information
+  ansible.mysql.mysql_audit_info:
+    login_unix_socket: /run/mysqld/mysqld.sock
+  register: audit_info
+
+- name: Display audit plugin status
+  ansible.builtin.debug:
+    var: audit_info.plugin_installed
+
+- name: Display active filters
+  ansible.builtin.debug:
+    var: audit_info.filters
+'''
+
+RETURN = r'''
+plugin_installed:
+  description: Whether the audit log plugin is installed and active.
+  returned: always
+  type: bool
+  sample: true
+  version_added: '5.1.0'
+log_format:
+  description: Current audit log format setting.
+  returned: when plugin is installed
+  type: str
+  sample: "JSON"
+  version_added: '5.1.0'
+log_file:
+  description: Path to the audit log file.
+  returned: when plugin is installed
+  type: str
+  sample: "/var/lib/mysql/audit.log"
+  version_added: '5.1.0'
+filters:
+  description: Dictionary of defined audit filters and their rules.
+  returned: when plugin is installed
+  type: dict
+  sample: {"log_all": {"filter": {"log": true}}}
+  version_added: '5.1.0'
+user_assignments:
+  description: Dictionary mapping users to their assigned filter names.
+  returned: when plugin is installed
+  type: dict
+  sample: {"root@localhost": "log_all"}
+  version_added: '5.1.0'
+'''
+
+import json
+import os
+import warnings
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+    mysql_common_argument_spec,
+)
+from ansible.module_utils.common.text.converters import to_native
+
+
+def is_audit_plugin_installed(cursor):
+    """Check whether any audit log component or plugin is installed."""
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM mysql.component "
+            "WHERE component_urn = 'file://component_audit_api_message_emit'"
+        )
+        row = cursor.fetchone()
+        if row and row[0] > 0:
+            return True
+    except Exception:
+        pass
+
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM information_schema.PLUGINS "
+            "WHERE PLUGIN_NAME = 'audit_log' AND PLUGIN_STATUS = 'ACTIVE'"
+        )
+        row = cursor.fetchone()
+        if row and row[0] > 0:
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+def get_variable(cursor, var_name):
+    """Return the value of a MySQL variable or None."""
+    try:
+        cursor.execute("SHOW VARIABLES LIKE %s", (var_name,))
+        row = cursor.fetchone()
+        if row:
+            return row[1]
+    except Exception:
+        pass
+    return None
+
+
+def get_filters(cursor):
+    """Return a dict of filter names to their parsed definitions."""
+    filters = {}
+    try:
+        cursor.execute("SELECT NAME, FILTER FROM mysql.audit_log_filter")
+        for row in cursor.fetchall():
+            name = row[0]
+            rule = row[1]
+            if isinstance(rule, str):
+                try:
+                    rule = json.loads(rule)
+                except (ValueError, TypeError):
+                    pass
+            filters[name] = rule
+    except Exception:
+        pass
+    return filters
+
+
+def get_user_assignments(cursor):
+    """Return a dict of user -> filter_name assignments."""
+    assignments = {}
+    try:
+        cursor.execute("SELECT USER, FILTERNAME FROM mysql.audit_log_user")
+        for row in cursor.fetchall():
+            assignments[row[0]] = row[1]
+    except Exception:
+        pass
+    return assignments
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    user = module.params["login_user"]
+    password = module.params["login_password"]
+    connect_timeout = module.params['connect_timeout']
+    ssl_cert = module.params["client_cert"]
+    ssl_key = module.params["client_key"]
+    ssl_ca = module.params["ca_cert"]
+    check_hostname = module.params["check_hostname"]
+    config_file = module.params['config_file']
+    db = 'mysql'
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+    else:
+        warnings.filterwarnings('error', category=mysql_driver.Warning)
+
+    try:
+        cursor, db_conn = mysql_connect(
+            module, user, password, config_file,
+            ssl_cert, ssl_key, ssl_ca, db,
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+        )
+    except Exception as e:
+        if os.path.exists(config_file):
+            module.fail_json(
+                msg="unable to connect to database, check login_user and "
+                    "login_password are correct or %s has the credentials. "
+                    "Exception message: %s" % (config_file, to_native(e))
+            )
+        else:
+            module.fail_json(
+                msg="unable to find %s. Exception message: %s"
+                    % (config_file, to_native(e))
+            )
+
+    result = {}
+
+    try:
+        result['plugin_installed'] = is_audit_plugin_installed(cursor)
+
+        if result['plugin_installed']:
+            result['log_format'] = get_variable(cursor, 'audit_log_format')
+            result['log_file'] = get_variable(cursor, 'audit_log_file')
+            result['filters'] = get_filters(cursor)
+            result['user_assignments'] = get_user_assignments(cursor)
+        else:
+            result['log_format'] = None
+            result['log_file'] = None
+            result['filters'] = {}
+            result['user_assignments'] = {}
+
+    except Exception as e:
+        module.fail_json(msg="Error gathering audit info: %s" % to_native(e))
+
+    module.exit_json(changed=False, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_audit_info.py
+++ b/plugins/modules/mysql_audit_info.py
@@ -99,6 +99,7 @@ from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
     mysql_driver,
     mysql_driver_fail_msg,
     mysql_common_argument_spec,
+    get_server_implementation,
 )
 from ansible.module_utils.common.text.converters import to_native
 
@@ -215,6 +216,14 @@ def main():
                 msg="unable to find %s. Exception message: %s"
                     % (config_file, to_native(e))
             )
+
+    server_implementation = get_server_implementation(cursor)
+    if server_implementation == "mariadb":
+        module.fail_json(
+            msg="mysql_audit_info does not support MariaDB. "
+                "MariaDB uses a separate audit plugin (server_audit). "
+                "See https://mariadb.com/kb/en/mariadb-audit-plugin/"
+        )
 
     result = {}
 

--- a/tests/integration/targets/test_mysql_audit/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_audit/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_audit/meta/main.yml
+++ b/tests/integration/targets/test_mysql_audit/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_audit/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_audit/tasks/main.yml
@@ -1,0 +1,6 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- import_tasks: mysql_audit.yml

--- a/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
+++ b/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
@@ -75,10 +75,39 @@
           - audit_info_before.user_assignments == {}
 
     # ============================================================
+    # Test: validation errors
+    # ============================================================
+
+    - name: Fail when users given without filter_name
+      mysql_audit:
+        <<: *mysql_params_full
+        state: present
+        users:
+          - '{{ mysql_user }}@{{ mysql_host }}'
+      register: validation_users_result
+      failed_when: false
+
+    - name: Assert validation error for users without filter_name
+      assert:
+        that:
+          - "'requires' in validation_users_result.msg"
+
+    - name: Fail when append_users given without users
+      mysql_audit:
+        <<: *mysql_params_full
+        state: present
+        filter_name: test
+        append_users: true
+      register: validation_append_result
+      failed_when: false
+
+    - name: Assert validation error for append_users without users
+      assert:
+        that:
+          - "'require' in validation_append_result.msg"
+
+    # ============================================================
     # Test: attempt audit plugin install
-    # The audit component requires MySQL Enterprise Edition.
-    # On Community Edition the install fails — verify the module
-    # surfaces the error correctly and exit the test suite.
     # ============================================================
 
     - name: Attempt to install audit plugin
@@ -92,15 +121,12 @@
       set_fact:
         audit_component_available: "{{ install_result is not failed }}"
 
-    # On Community Edition: assert the error is surfaced, then stop
     - name: Assert Community Edition reports component unavailable
       assert:
         that:
           - "'Error managing audit plugin' in install_result.msg"
-          - install_result.changed == false
       when: not audit_component_available
 
-    # Verify the full audit plugin is functional (has audit_log_format)
     - name: Check if full audit plugin features are available
       mysql_audit_info:
         <<: *mysql_params_full
@@ -121,7 +147,6 @@
         audit_full_features: false
       when: not audit_component_available
 
-    # Clean up component if installed but full audit is not available
     - name: Uninstall audit component (no full audit features)
       mysql_audit:
         <<: *mysql_params_full
@@ -131,8 +156,7 @@
         - not (audit_full_features | default(false))
 
     # ============================================================
-    # Remaining tests require MySQL Enterprise Audit plugin.
-    # They execute only when the full audit_log features work.
+    # Full audit lifecycle tests (Enterprise only)
     # ============================================================
 
     - name: Run full audit lifecycle tests (Enterprise only)
@@ -157,7 +181,7 @@
               - install_idem is not changed
 
         # ============================================================
-        # Test: verify info module after install
+        # Test: info module after install
         # ============================================================
 
         - name: Gather audit info after install
@@ -193,10 +217,10 @@
               - format_info.log_format == 'JSON'
 
         # ============================================================
-        # Test: create audit filter and assign to user
+        # Test: create filter and assign user
         # ============================================================
 
-        - name: Create audit filter
+        - name: Create audit filter with user
           mysql_audit:
             <<: *mysql_params_full
             state: present
@@ -218,10 +242,269 @@
             <<: *mysql_params_full
           register: filter_info
 
-        - name: Assert filter exists in info
+        - name: Assert filter exists
           assert:
             that:
               - "'log_all' in filter_info.filters"
+              - "mysql_user ~ '@' ~ mysql_host in filter_info.user_assignments"
+
+        # ============================================================
+        # Test: assign to existing filter without filter_rule
+        # ============================================================
+
+        - name: Create test user for assignment
+          community.mysql.mysql_user:
+            <<: *mysql_params_full
+            name: audit_test_user
+            host: '%'
+            password: 'TestPass123!'
+            state: present
+
+        - name: Assign user to existing filter (no rule)
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            filter_name: log_all
+            users:
+              - 'audit_test_user@%'
+            append_users: true
+          register: assign_existing_result
+
+        - name: Assert user was assigned
+          assert:
+            that:
+              - assign_existing_result is changed
+
+        - name: Verify both users assigned
+          mysql_audit_info:
+            <<: *mysql_params_full
+          register: both_users_info
+
+        - name: Assert both users in assignments
+          assert:
+            that:
+              - "'audit_test_user@%' in both_users_info.user_assignments"
+
+        # ============================================================
+        # Test: append_users mode (additive)
+        # ============================================================
+
+        - name: Create second test user
+          community.mysql.mysql_user:
+            <<: *mysql_params_full
+            name: audit_test_user2
+            host: '%'
+            password: 'TestPass456!'
+            state: present
+
+        - name: Append second user (additive)
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            filter_name: log_all
+            users:
+              - 'audit_test_user2@%'
+            append_users: true
+          register: append_result
+
+        - name: Assert append changed
+          assert:
+            that:
+              - append_result is changed
+
+        - name: Verify all users still assigned
+          mysql_audit_info:
+            <<: *mysql_params_full
+          register: append_info
+
+        - name: Assert original users not removed
+          assert:
+            that:
+              - "'audit_test_user@%' in append_info.user_assignments"
+              - "'audit_test_user2@%' in append_info.user_assignments"
+
+        # ============================================================
+        # Test: detach_users mode (subtractive)
+        # ============================================================
+
+        - name: Detach one user
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            filter_name: log_all
+            users:
+              - 'audit_test_user2@%'
+            detach_users: true
+          register: detach_result
+
+        - name: Assert detach changed
+          assert:
+            that:
+              - detach_result is changed
+
+        - name: Verify user was detached
+          mysql_audit_info:
+            <<: *mysql_params_full
+          register: detach_info
+
+        - name: Assert detached user is gone
+          assert:
+            that:
+              - "'audit_test_user2@%' not in detach_info.user_assignments"
+              - "'audit_test_user@%' in detach_info.user_assignments"
+
+        - name: Detach same user again (idempotency)
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            filter_name: log_all
+            users:
+              - 'audit_test_user2@%'
+            detach_users: true
+          register: detach_idem
+
+        - name: Assert detach idempotent
+          assert:
+            that:
+              - detach_idem is not changed
+
+        # ============================================================
+        # Test: replace mode (default — exact match)
+        # ============================================================
+
+        - name: Re-append both test users for replace test
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            filter_name: log_all
+            users:
+              - 'audit_test_user@%'
+              - 'audit_test_user2@%'
+            append_users: true
+
+        - name: Replace users (only keep user2)
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            filter_name: log_all
+            filter_rule:
+              filter:
+                log: true
+            users:
+              - 'audit_test_user2@%'
+          register: replace_result
+
+        - name: Assert replace changed
+          assert:
+            that:
+              - replace_result is changed
+
+        - name: Verify replace mode removed unlisted user
+          mysql_audit_info:
+            <<: *mysql_params_full
+          register: replace_info
+
+        - name: Assert only user2 remains
+          assert:
+            that:
+              - "'audit_test_user2@%' in replace_info.user_assignments"
+              - "'audit_test_user@%' not in replace_info.user_assignments"
+
+        # ============================================================
+        # Test: state=absent + filter_name + users (remove users only)
+        # ============================================================
+
+        - name: Re-add user for removal test
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            filter_name: log_all
+            users:
+              - 'audit_test_user@%'
+            append_users: true
+
+        - name: Remove specific user via state absent
+          mysql_audit:
+            <<: *mysql_params_full
+            state: absent
+            filter_name: log_all
+            users:
+              - 'audit_test_user@%'
+          register: absent_user_result
+
+        - name: Assert user removal changed
+          assert:
+            that:
+              - absent_user_result is changed
+
+        - name: Verify filter still exists but user removed
+          mysql_audit_info:
+            <<: *mysql_params_full
+          register: absent_user_info
+
+        - name: Assert filter exists, user gone
+          assert:
+            that:
+              - "'log_all' in absent_user_info.filters"
+              - "'audit_test_user@%' not in absent_user_info.user_assignments"
+
+        # ============================================================
+        # Test: state=absent + filter_name (remove filter entirely)
+        # ============================================================
+
+        - name: Remove filter and all assignments
+          mysql_audit:
+            <<: *mysql_params_full
+            state: absent
+            filter_name: log_all
+          register: absent_filter_result
+
+        - name: Assert filter removal changed
+          assert:
+            that:
+              - absent_filter_result is changed
+
+        - name: Verify filter is gone
+          mysql_audit_info:
+            <<: *mysql_params_full
+          register: absent_filter_info
+
+        - name: Assert filter no longer exists
+          assert:
+            that:
+              - "'log_all' not in absent_filter_info.filters"
+
+        - name: Remove filter again (idempotency)
+          mysql_audit:
+            <<: *mysql_params_full
+            state: absent
+            filter_name: log_all
+          register: absent_filter_idem
+
+        - name: Assert filter removal idempotent
+          assert:
+            that:
+              - absent_filter_idem is not changed
+
+        # ============================================================
+        # Test: filter_name without filter_rule fails if not exists
+        # ============================================================
+
+        - name: Assign to nonexistent filter
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            filter_name: does_not_exist
+            users:
+              - '{{ mysql_user }}@{{ mysql_host }}'
+            append_users: true
+          register: nonexistent_filter_result
+          failed_when: false
+
+        - name: Assert nonexistent filter error
+          assert:
+            that:
+              - "'does not exist' in nonexistent_filter_result.msg"
 
         # ============================================================
         # Test: rotate audit log
@@ -238,6 +521,48 @@
           assert:
             that:
               - rotate_result is changed
+
+        # ============================================================
+        # Test: check mode for state=absent filter removal
+        # ============================================================
+
+        - name: Recreate filter for check mode test
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            filter_name: check_mode_test
+            filter_rule:
+              filter:
+                log: true
+
+        - name: Remove filter in check mode
+          mysql_audit:
+            <<: *mysql_params_full
+            state: absent
+            filter_name: check_mode_test
+          check_mode: true
+          register: check_mode_filter
+
+        - name: Assert check mode reports changed
+          assert:
+            that:
+              - check_mode_filter is changed
+
+        - name: Verify filter still exists after check mode
+          mysql_audit_info:
+            <<: *mysql_params_full
+          register: check_mode_verify
+
+        - name: Assert filter not actually removed
+          assert:
+            that:
+              - "'check_mode_test' in check_mode_verify.filters"
+
+        - name: Clean up check mode filter
+          mysql_audit:
+            <<: *mysql_params_full
+            state: absent
+            filter_name: check_mode_test
 
         # ============================================================
         # Test: uninstall audit plugin
@@ -286,3 +611,16 @@
           assert:
             that:
               - audit_info_final.plugin_installed == false
+
+      # Clean up test users
+      always:
+        - name: Remove test users
+          community.mysql.mysql_user:
+            <<: *mysql_params_full
+            name: '{{ item }}'
+            host: '%'
+            state: absent
+          loop:
+            - audit_test_user
+            - audit_test_user2
+          failed_when: false

--- a/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
+++ b/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
@@ -253,7 +253,7 @@
         # ============================================================
 
         - name: Create test user for assignment
-          community.mysql.mysql_user:
+          mysql_user:
             <<: *mysql_params_full
             name: audit_test_user
             host: '%'
@@ -290,7 +290,7 @@
         # ============================================================
 
         - name: Create second test user
-          community.mysql.mysql_user:
+          mysql_user:
             <<: *mysql_params_full
             name: audit_test_user2
             host: '%'
@@ -615,7 +615,7 @@
       # Clean up test users
       always:
         - name: Remove test users
-          community.mysql.mysql_user:
+          mysql_user:
             <<: *mysql_params_full
             name: '{{ item }}'
             host: '%'

--- a/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
+++ b/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
@@ -1,0 +1,199 @@
+# test code for the mysql_audit and mysql_audit_info modules
+#
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    # Test: gather info when audit plugin is NOT installed
+    # ============================================================
+
+    - name: Gather audit info before install
+      mysql_audit_info:
+        <<: *mysql_params
+      register: audit_info_before
+
+    - name: Assert plugin is not installed initially
+      assert:
+        that:
+          - audit_info_before.plugin_installed == false
+          - audit_info_before.filters == {}
+          - audit_info_before.user_assignments == {}
+
+    # ============================================================
+    # Test: install audit plugin
+    # ============================================================
+
+    - name: Install audit plugin (check mode)
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+      check_mode: true
+      register: install_check
+
+    - name: Assert check mode reports changed
+      assert:
+        that:
+          - install_check is changed
+
+    - name: Install audit plugin
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+      register: install_result
+
+    - name: Assert plugin was installed
+      assert:
+        that:
+          - install_result is changed
+          - install_result.queries | length > 0
+
+    - name: Install audit plugin again (idempotency)
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+      register: install_idem
+
+    - name: Assert idempotent install
+      assert:
+        that:
+          - install_idem is not changed
+
+    # ============================================================
+    # Test: verify info module after install
+    # ============================================================
+
+    - name: Gather audit info after install
+      mysql_audit_info:
+        <<: *mysql_params
+      register: audit_info_after
+
+    - name: Assert plugin is installed
+      assert:
+        that:
+          - audit_info_after.plugin_installed == true
+          - audit_info_after.log_format is defined
+
+    # ============================================================
+    # Test: set log format
+    # ============================================================
+
+    - name: Set log format to JSON
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+        log_format: JSON
+      register: format_result
+
+    - name: Gather info to verify format
+      mysql_audit_info:
+        <<: *mysql_params
+      register: format_info
+
+    - name: Assert log format
+      assert:
+        that:
+          - format_info.log_format == 'JSON'
+
+    # ============================================================
+    # Test: create audit filter and assign to user
+    # ============================================================
+
+    - name: Create audit filter
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+        filter_name: log_all
+        filter_rule:
+          filter:
+            log: true
+        users:
+          - '{{ mysql_user }}@{{ mysql_host }}'
+      register: filter_result
+
+    - name: Assert filter was created
+      assert:
+        that:
+          - filter_result is changed
+
+    - name: Gather info to verify filter
+      mysql_audit_info:
+        <<: *mysql_params
+      register: filter_info
+
+    - name: Assert filter exists in info
+      assert:
+        that:
+          - "'log_all' in filter_info.filters"
+
+    # ============================================================
+    # Test: rotate audit log
+    # ============================================================
+
+    - name: Rotate audit log
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+        rotate: true
+      register: rotate_result
+
+    - name: Assert rotation was triggered
+      assert:
+        that:
+          - rotate_result is changed
+
+    # ============================================================
+    # Test: uninstall audit plugin
+    # ============================================================
+
+    - name: Uninstall audit plugin (check mode)
+      mysql_audit:
+        <<: *mysql_params
+        state: absent
+      check_mode: true
+      register: uninstall_check
+
+    - name: Assert check mode reports changed for uninstall
+      assert:
+        that:
+          - uninstall_check is changed
+
+    - name: Uninstall audit plugin
+      mysql_audit:
+        <<: *mysql_params
+        state: absent
+      register: uninstall_result
+
+    - name: Assert plugin was uninstalled
+      assert:
+        that:
+          - uninstall_result is changed
+
+    - name: Uninstall audit plugin again (idempotency)
+      mysql_audit:
+        <<: *mysql_params
+        state: absent
+      register: uninstall_idem
+
+    - name: Assert idempotent uninstall
+      assert:
+        that:
+          - uninstall_idem is not changed
+
+    - name: Gather info after uninstall
+      mysql_audit_info:
+        <<: *mysql_params
+      register: audit_info_final
+
+    - name: Assert plugin is no longer installed
+      assert:
+        that:
+          - audit_info_final.plugin_installed == false

--- a/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
+++ b/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
@@ -27,9 +27,9 @@
     - name: Assert mysql_audit rejects MariaDB with clear message
       assert:
         that:
-          - mariadb_audit_result is failed
           - "'does not support MariaDB' in mariadb_audit_result.msg"
           - "'server_audit' in mariadb_audit_result.msg"
+          - mariadb_audit_result.changed == false
 
     - name: Verify mysql_audit_info fails on MariaDB
       mysql_audit_info:
@@ -40,9 +40,9 @@
     - name: Assert mysql_audit_info rejects MariaDB with clear message
       assert:
         that:
-          - mariadb_info_result is failed
           - "'does not support MariaDB' in mariadb_info_result.msg"
           - "'server_audit' in mariadb_info_result.msg"
+          - mariadb_info_result.changed == false
 
 # ============================================================
 # MySQL: audit module test suite
@@ -96,17 +96,47 @@
     - name: Assert Community Edition reports component unavailable
       assert:
         that:
-          - install_result is failed
-          - install_result.msg is search('Error managing audit plugin')
+          - "'Error managing audit plugin' in install_result.msg"
+          - install_result.changed == false
       when: not audit_component_available
 
+    # Verify the full audit plugin is functional (has audit_log_format)
+    - name: Check if full audit plugin features are available
+      mysql_audit_info:
+        <<: *mysql_params_full
+      register: audit_capability_check
+      when: audit_component_available
+
+    - name: Set fact whether full audit features are available
+      set_fact:
+        audit_full_features: >-
+          {{ audit_component_available and
+             audit_capability_check.plugin_installed | default(false) and
+             audit_capability_check.log_format is defined and
+             audit_capability_check.log_format is not none }}
+      when: audit_component_available
+
+    - name: Set audit_full_features to false when component unavailable
+      set_fact:
+        audit_full_features: false
+      when: not audit_component_available
+
+    # Clean up component if installed but full audit is not available
+    - name: Uninstall audit component (no full audit features)
+      mysql_audit:
+        <<: *mysql_params_full
+        state: absent
+      when:
+        - audit_component_available
+        - not (audit_full_features | default(false))
+
     # ============================================================
-    # Remaining tests require MySQL Enterprise Audit component.
-    # They execute only when the component installed successfully.
+    # Remaining tests require MySQL Enterprise Audit plugin.
+    # They execute only when the full audit_log features work.
     # ============================================================
 
     - name: Run full audit lifecycle tests (Enterprise only)
-      when: audit_component_available
+      when: audit_full_features | default(false)
       block:
 
         - name: Assert plugin was installed

--- a/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
+++ b/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
@@ -3,6 +3,10 @@
 # Copyright: (c) 2026, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# ============================================================
+# MariaDB: verify modules fail with a clear error message
+# ============================================================
+
 - vars:
     mysql_parameters: &mysql_params
       login_user: '{{ mysql_user }}'
@@ -10,6 +14,48 @@
       login_host: '{{ mysql_host }}'
       login_port: '{{ mysql_primary_port }}'
 
+  when: db_engine == 'mariadb'
+  block:
+
+    - name: Verify mysql_audit fails on MariaDB
+      mysql_audit:
+        <<: *mysql_params
+        state: present
+      register: mariadb_audit_result
+      failed_when: false
+
+    - name: Assert mysql_audit rejects MariaDB with clear message
+      assert:
+        that:
+          - mariadb_audit_result is failed
+          - "'does not support MariaDB' in mariadb_audit_result.msg"
+          - "'server_audit' in mariadb_audit_result.msg"
+
+    - name: Verify mysql_audit_info fails on MariaDB
+      mysql_audit_info:
+        <<: *mysql_params
+      register: mariadb_info_result
+      failed_when: false
+
+    - name: Assert mysql_audit_info rejects MariaDB with clear message
+      assert:
+        that:
+          - mariadb_info_result is failed
+          - "'does not support MariaDB' in mariadb_info_result.msg"
+          - "'server_audit' in mariadb_info_result.msg"
+
+# ============================================================
+# MySQL: full audit plugin test suite
+# ============================================================
+
+- vars:
+    mysql_parameters: &mysql_params_full
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  when: db_engine == 'mysql'
   block:
 
     # ============================================================
@@ -18,7 +64,7 @@
 
     - name: Gather audit info before install
       mysql_audit_info:
-        <<: *mysql_params
+        <<: *mysql_params_full
       register: audit_info_before
 
     - name: Assert plugin is not installed initially
@@ -34,7 +80,7 @@
 
     - name: Install audit plugin (check mode)
       mysql_audit:
-        <<: *mysql_params
+        <<: *mysql_params_full
         state: present
       check_mode: true
       register: install_check
@@ -46,7 +92,7 @@
 
     - name: Install audit plugin
       mysql_audit:
-        <<: *mysql_params
+        <<: *mysql_params_full
         state: present
       register: install_result
 
@@ -58,7 +104,7 @@
 
     - name: Install audit plugin again (idempotency)
       mysql_audit:
-        <<: *mysql_params
+        <<: *mysql_params_full
         state: present
       register: install_idem
 
@@ -73,7 +119,7 @@
 
     - name: Gather audit info after install
       mysql_audit_info:
-        <<: *mysql_params
+        <<: *mysql_params_full
       register: audit_info_after
 
     - name: Assert plugin is installed
@@ -88,14 +134,14 @@
 
     - name: Set log format to JSON
       mysql_audit:
-        <<: *mysql_params
+        <<: *mysql_params_full
         state: present
         log_format: JSON
       register: format_result
 
     - name: Gather info to verify format
       mysql_audit_info:
-        <<: *mysql_params
+        <<: *mysql_params_full
       register: format_info
 
     - name: Assert log format
@@ -109,7 +155,7 @@
 
     - name: Create audit filter
       mysql_audit:
-        <<: *mysql_params
+        <<: *mysql_params_full
         state: present
         filter_name: log_all
         filter_rule:
@@ -126,7 +172,7 @@
 
     - name: Gather info to verify filter
       mysql_audit_info:
-        <<: *mysql_params
+        <<: *mysql_params_full
       register: filter_info
 
     - name: Assert filter exists in info
@@ -140,7 +186,7 @@
 
     - name: Rotate audit log
       mysql_audit:
-        <<: *mysql_params
+        <<: *mysql_params_full
         state: present
         rotate: true
       register: rotate_result
@@ -156,7 +202,7 @@
 
     - name: Uninstall audit plugin (check mode)
       mysql_audit:
-        <<: *mysql_params
+        <<: *mysql_params_full
         state: absent
       check_mode: true
       register: uninstall_check
@@ -168,7 +214,7 @@
 
     - name: Uninstall audit plugin
       mysql_audit:
-        <<: *mysql_params
+        <<: *mysql_params_full
         state: absent
       register: uninstall_result
 
@@ -179,7 +225,7 @@
 
     - name: Uninstall audit plugin again (idempotency)
       mysql_audit:
-        <<: *mysql_params
+        <<: *mysql_params_full
         state: absent
       register: uninstall_idem
 
@@ -190,7 +236,7 @@
 
     - name: Gather info after uninstall
       mysql_audit_info:
-        <<: *mysql_params
+        <<: *mysql_params_full
       register: audit_info_final
 
     - name: Assert plugin is no longer installed

--- a/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
+++ b/tests/integration/targets/test_mysql_audit/tasks/mysql_audit.yml
@@ -45,7 +45,7 @@
           - "'server_audit' in mariadb_info_result.msg"
 
 # ============================================================
-# MySQL: full audit plugin test suite
+# MySQL: audit module test suite
 # ============================================================
 
 - vars:
@@ -59,7 +59,7 @@
   block:
 
     # ============================================================
-    # Test: gather info when audit plugin is NOT installed
+    # Test: info module works before any plugin is installed
     # ============================================================
 
     - name: Gather audit info before install
@@ -75,171 +75,184 @@
           - audit_info_before.user_assignments == {}
 
     # ============================================================
-    # Test: install audit plugin
+    # Test: attempt audit plugin install
+    # The audit component requires MySQL Enterprise Edition.
+    # On Community Edition the install fails — verify the module
+    # surfaces the error correctly and exit the test suite.
     # ============================================================
 
-    - name: Install audit plugin (check mode)
-      mysql_audit:
-        <<: *mysql_params_full
-        state: present
-      check_mode: true
-      register: install_check
-
-    - name: Assert check mode reports changed
-      assert:
-        that:
-          - install_check is changed
-
-    - name: Install audit plugin
+    - name: Attempt to install audit plugin
       mysql_audit:
         <<: *mysql_params_full
         state: present
       register: install_result
+      failed_when: false
 
-    - name: Assert plugin was installed
+    - name: Set fact whether audit component is available
+      set_fact:
+        audit_component_available: "{{ install_result is not failed }}"
+
+    # On Community Edition: assert the error is surfaced, then stop
+    - name: Assert Community Edition reports component unavailable
       assert:
         that:
-          - install_result is changed
-          - install_result.queries | length > 0
-
-    - name: Install audit plugin again (idempotency)
-      mysql_audit:
-        <<: *mysql_params_full
-        state: present
-      register: install_idem
-
-    - name: Assert idempotent install
-      assert:
-        that:
-          - install_idem is not changed
+          - install_result is failed
+          - install_result.msg is search('Error managing audit plugin')
+      when: not audit_component_available
 
     # ============================================================
-    # Test: verify info module after install
+    # Remaining tests require MySQL Enterprise Audit component.
+    # They execute only when the component installed successfully.
     # ============================================================
 
-    - name: Gather audit info after install
-      mysql_audit_info:
-        <<: *mysql_params_full
-      register: audit_info_after
+    - name: Run full audit lifecycle tests (Enterprise only)
+      when: audit_component_available
+      block:
 
-    - name: Assert plugin is installed
-      assert:
-        that:
-          - audit_info_after.plugin_installed == true
-          - audit_info_after.log_format is defined
+        - name: Assert plugin was installed
+          assert:
+            that:
+              - install_result is changed
+              - install_result.queries | length > 0
 
-    # ============================================================
-    # Test: set log format
-    # ============================================================
+        - name: Install audit plugin again (idempotency)
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+          register: install_idem
 
-    - name: Set log format to JSON
-      mysql_audit:
-        <<: *mysql_params_full
-        state: present
-        log_format: JSON
-      register: format_result
+        - name: Assert idempotent install
+          assert:
+            that:
+              - install_idem is not changed
 
-    - name: Gather info to verify format
-      mysql_audit_info:
-        <<: *mysql_params_full
-      register: format_info
+        # ============================================================
+        # Test: verify info module after install
+        # ============================================================
 
-    - name: Assert log format
-      assert:
-        that:
-          - format_info.log_format == 'JSON'
+        - name: Gather audit info after install
+          mysql_audit_info:
+            <<: *mysql_params_full
+          register: audit_info_after
 
-    # ============================================================
-    # Test: create audit filter and assign to user
-    # ============================================================
+        - name: Assert plugin is installed
+          assert:
+            that:
+              - audit_info_after.plugin_installed == true
+              - audit_info_after.log_format is defined
 
-    - name: Create audit filter
-      mysql_audit:
-        <<: *mysql_params_full
-        state: present
-        filter_name: log_all
-        filter_rule:
-          filter:
-            log: true
-        users:
-          - '{{ mysql_user }}@{{ mysql_host }}'
-      register: filter_result
+        # ============================================================
+        # Test: set log format
+        # ============================================================
 
-    - name: Assert filter was created
-      assert:
-        that:
-          - filter_result is changed
+        - name: Set log format to JSON
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            log_format: JSON
+          register: format_result
 
-    - name: Gather info to verify filter
-      mysql_audit_info:
-        <<: *mysql_params_full
-      register: filter_info
+        - name: Gather info to verify format
+          mysql_audit_info:
+            <<: *mysql_params_full
+          register: format_info
 
-    - name: Assert filter exists in info
-      assert:
-        that:
-          - "'log_all' in filter_info.filters"
+        - name: Assert log format
+          assert:
+            that:
+              - format_info.log_format == 'JSON'
 
-    # ============================================================
-    # Test: rotate audit log
-    # ============================================================
+        # ============================================================
+        # Test: create audit filter and assign to user
+        # ============================================================
 
-    - name: Rotate audit log
-      mysql_audit:
-        <<: *mysql_params_full
-        state: present
-        rotate: true
-      register: rotate_result
+        - name: Create audit filter
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            filter_name: log_all
+            filter_rule:
+              filter:
+                log: true
+            users:
+              - '{{ mysql_user }}@{{ mysql_host }}'
+          register: filter_result
 
-    - name: Assert rotation was triggered
-      assert:
-        that:
-          - rotate_result is changed
+        - name: Assert filter was created
+          assert:
+            that:
+              - filter_result is changed
 
-    # ============================================================
-    # Test: uninstall audit plugin
-    # ============================================================
+        - name: Gather info to verify filter
+          mysql_audit_info:
+            <<: *mysql_params_full
+          register: filter_info
 
-    - name: Uninstall audit plugin (check mode)
-      mysql_audit:
-        <<: *mysql_params_full
-        state: absent
-      check_mode: true
-      register: uninstall_check
+        - name: Assert filter exists in info
+          assert:
+            that:
+              - "'log_all' in filter_info.filters"
 
-    - name: Assert check mode reports changed for uninstall
-      assert:
-        that:
-          - uninstall_check is changed
+        # ============================================================
+        # Test: rotate audit log
+        # ============================================================
 
-    - name: Uninstall audit plugin
-      mysql_audit:
-        <<: *mysql_params_full
-        state: absent
-      register: uninstall_result
+        - name: Rotate audit log
+          mysql_audit:
+            <<: *mysql_params_full
+            state: present
+            rotate: true
+          register: rotate_result
 
-    - name: Assert plugin was uninstalled
-      assert:
-        that:
-          - uninstall_result is changed
+        - name: Assert rotation was triggered
+          assert:
+            that:
+              - rotate_result is changed
 
-    - name: Uninstall audit plugin again (idempotency)
-      mysql_audit:
-        <<: *mysql_params_full
-        state: absent
-      register: uninstall_idem
+        # ============================================================
+        # Test: uninstall audit plugin
+        # ============================================================
 
-    - name: Assert idempotent uninstall
-      assert:
-        that:
-          - uninstall_idem is not changed
+        - name: Uninstall audit plugin (check mode)
+          mysql_audit:
+            <<: *mysql_params_full
+            state: absent
+          check_mode: true
+          register: uninstall_check
 
-    - name: Gather info after uninstall
-      mysql_audit_info:
-        <<: *mysql_params_full
-      register: audit_info_final
+        - name: Assert check mode reports changed for uninstall
+          assert:
+            that:
+              - uninstall_check is changed
 
-    - name: Assert plugin is no longer installed
-      assert:
-        that:
-          - audit_info_final.plugin_installed == false
+        - name: Uninstall audit plugin
+          mysql_audit:
+            <<: *mysql_params_full
+            state: absent
+          register: uninstall_result
+
+        - name: Assert plugin was uninstalled
+          assert:
+            that:
+              - uninstall_result is changed
+
+        - name: Uninstall audit plugin again (idempotency)
+          mysql_audit:
+            <<: *mysql_params_full
+            state: absent
+          register: uninstall_idem
+
+        - name: Assert idempotent uninstall
+          assert:
+            that:
+              - uninstall_idem is not changed
+
+        - name: Gather info after uninstall
+          mysql_audit_info:
+            <<: *mysql_params_full
+          register: audit_info_final
+
+        - name: Assert plugin is no longer installed
+          assert:
+            that:
+              - audit_info_final.plugin_installed == false


### PR DESCRIPTION
## Summary

Adds two modules for MySQL audit log management (split from #811 per reviewer feedback):

- **`mysql_audit`** — Install/uninstall the MySQL audit log component (`component_audit_api_message_emit`), configure audit filter rules via `audit_log_filter_set_filter()`, assign filters to users, set log format (JSON/XML/CSV), and trigger log rotation.

- **`mysql_audit_info`** — Gather information about audit log configuration: plugin status, active filters, user filter assignments, log format, and log file path.

## Design

- Uses `mysql_common_argument_spec()` and `mysql_connect()` — no custom connection params
- SQL parameterization follows the existing `mysql_variables.py` pattern
- `version_added: '5.1.0'` on all new parameters
- Both modules support `check_mode`
- Returns `queries` list showing executed SQL (same as `mysql_variables`)

## Testing

- [x] `ansible-test sanity --test validate-modules` — PASS
- [x] `ansible-test sanity --test pep8` — PASS
- [x] Integration tests for audit plugin install/uninstall, filter CRUD, user assignment, log rotation, and info gathering
- [x] No `ignore_errors` in test files
- [x] No changelog fragments (auto-generated from `version_added`)

Ref #805