### PR TITLE
feat: add mysql_password_policy module

### DIFF
--- a/plugins/modules/mysql_password_policy.py
+++ b/plugins/modules/mysql_password_policy.py
@@ -14,9 +14,11 @@ module: mysql_password_policy
 short_description: Configure MySQL password validation policy
 
 description:
-- Manage the MySQL C(validate_password) component and related global variables.
+- Manage the MySQL C(validate_password) component and related global
+  variables.
 - Install or uninstall the C(validate_password) component (MySQL 8.0+).
-- Configure password complexity requirements, lifetime, and reuse policies.
+- Configure password complexity requirements, lifetime, and reuse
+  policies.
 
 version_added: '5.1.0'
 
@@ -28,54 +30,86 @@ options:
     description:
     - V(present) ensures the C(validate_password) component is installed
       and configured with the specified settings.
-    - V(absent) uninstalls the C(validate_password) component.
+    - V(absent) uninstalls the C(validate_password) component. Any
+      global password parameters provided (O(password_lifetime),
+      O(password_history), O(reuse_interval)) are still applied,
+      allowing a single task to both uninstall the component and
+      reset global policies.
     type: str
     choices: ['present', 'absent']
     default: present
+    version_added: '5.1.0'
   policy:
     description:
     - Password validation policy level.
     - V(LOW) checks length only.
-    - V(MEDIUM) checks length, numeric, mixed case, and special characters.
+    - V(MEDIUM) checks length, numeric, mixed case, and special
+      characters.
     - V(STRONG) checks all of V(MEDIUM) plus dictionary file.
     type: str
     choices: ['LOW', 'MEDIUM', 'STRONG']
+    version_added: '5.1.0'
   length:
     description:
     - Minimum number of characters in a password.
     type: int
+    version_added: '5.1.0'
   mixed_case_count:
     description:
     - Minimum number of uppercase and lowercase characters required.
     type: int
+    version_added: '5.1.0'
   number_count:
     description:
     - Minimum number of numeric characters required.
     type: int
+    version_added: '5.1.0'
   special_char_count:
     description:
     - Minimum number of special (non-alphanumeric) characters required.
     type: int
+    version_added: '5.1.0'
   check_user_name:
     description:
     - Whether passwords are checked against the user name.
     - When V(true), passwords that match the user name are rejected.
     type: bool
+    version_added: '5.1.0'
   password_lifetime:
     description:
     - Default password expiration lifetime in days.
     - V(0) disables automatic password expiration.
+    - This is a global MySQL variable and is processed even when
+      O(state=absent).
     type: int
+    version_added: '5.1.0'
   password_history:
     description:
     - Number of previous passwords that cannot be reused.
     - V(0) disables password history checks.
+    - This is a global MySQL variable and is processed even when
+      O(state=absent).
     type: int
+    version_added: '5.1.0'
   reuse_interval:
     description:
     - Number of days before a password can be reused.
     - V(0) disables reuse interval checks.
+    - This is a global MySQL variable and is processed even when
+      O(state=absent).
     type: int
+    version_added: '5.1.0'
+  mode:
+    description:
+    - How variables are set.
+    - C(global) uses C(SET GLOBAL) which does not survive a MySQL
+      restart unless also configured in C(my.cnf).
+    - C(persist) uses C(SET PERSIST) which writes to
+      C(mysqld-auto.cnf) and survives restarts.
+    type: str
+    choices: ['global', 'persist']
+    default: global
+    version_added: '5.1.0'
 
 attributes:
   check_mode:
@@ -91,11 +125,12 @@ seealso:
   link: https://dev.mysql.com/doc/refman/8.0/en/validate-password.html
 
 notes:
-   - Requires MySQL 8.0 or later.
+   - Requires MySQL 8.0 or later. MariaDB is not supported.
    - The C(validate_password) component must be available on the server.
-   - In MySQL 5.7, the validate_password plugin uses underscores in variable
-     names (e.g., C(validate_password_policy)) rather than dots. This module
-     targets MySQL 8.0+ component syntax with dot notation.
+   - When O(mode=global), settings do not survive a MySQL restart
+     unless also set in C(my.cnf). Use O(mode=persist) or the
+     M(ansible.mysql.mysql_variables) module with C(mode=persist)
+     for persistent configuration.
 
 extends_documentation_fragment:
 - ansible.mysql.mysql
@@ -119,16 +154,20 @@ EXAMPLES = r'''
     reuse_interval: 365
     login_unix_socket: /run/mysqld/mysqld.sock
 
-- name: Uninstall validate_password component
+- name: Uninstall component and reset global policies in one task
   ansible.mysql.mysql_password_policy:
     state: absent
+    password_lifetime: 0
+    password_history: 0
+    reuse_interval: 0
     login_unix_socket: /run/mysqld/mysqld.sock
 
-- name: Enforce STRONG policy with username check
+- name: Enforce STRONG policy with username check (persistent)
   ansible.mysql.mysql_password_policy:
     policy: STRONG
     length: 16
     check_user_name: true
+    mode: persist
     login_unix_socket: /run/mysqld/mysqld.sock
 '''
 
@@ -145,18 +184,23 @@ import os
 import warnings
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.mysql.plugins.module_utils.database import mysql_quote_identifier
+from ansible_collections.ansible.mysql.plugins.module_utils.database import (
+    mysql_quote_identifier,
+)
 from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
     mysql_connect,
     mysql_driver,
     mysql_driver_fail_msg,
     mysql_common_argument_spec,
+    get_server_implementation,
+    get_server_version,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils._version import (
+    LooseVersion,
 )
 from ansible.module_utils.common.text.converters import to_native
 
 
-# Mapping of module parameters to MySQL global variable names
-# validate_password.* variables only exist when the component is installed
 VALIDATE_PASSWORD_PARAMS = {
     'policy': 'validate_password.policy',
     'length': 'validate_password.length',
@@ -166,14 +210,12 @@ VALIDATE_PASSWORD_PARAMS = {
     'check_user_name': 'validate_password.check_user_name',
 }
 
-# Global password policy variables (exist regardless of component)
 GLOBAL_PASSWORD_PARAMS = {
     'password_lifetime': 'default_password_lifetime',
     'password_history': 'password_history',
     'reuse_interval': 'password_reuse_interval',
 }
 
-# Policy name to numeric value mapping for comparison
 POLICY_MAP = {
     'LOW': '0',
     'MEDIUM': '1',
@@ -187,33 +229,30 @@ POLICY_MAP = {
 def is_component_installed(cursor):
     """Check if validate_password component is installed."""
     try:
-        cursor.execute("SHOW VARIABLES LIKE 'validate_password.policy'")
+        cursor.execute(
+            "SHOW VARIABLES LIKE 'validate_password.policy'")
         return cursor.fetchone() is not None
     except Exception:
         return False
 
 
-def get_current_variables(cursor, var_pattern):
-    """Retrieve current variable values matching a LIKE pattern."""
-    result = {}
-    cursor.execute("SHOW VARIABLES LIKE %s", (var_pattern,))
-    for row in cursor.fetchall():
-        result[row[0]] = row[1]
-    return result
-
-
 def get_variable(cursor, var_name):
     """Get a single variable value."""
-    cursor.execute("SHOW VARIABLES WHERE Variable_name = %s", (var_name,))
+    cursor.execute(
+        "SHOW VARIABLES WHERE Variable_name = %s", (var_name,))
     row = cursor.fetchone()
     if row:
         return row[1]
     return None
 
 
-def set_global_variable(cursor, var_name, value):
-    """Set a global variable and return the query string."""
-    query = "SET GLOBAL %s = " % mysql_quote_identifier(var_name, 'vars')
+def set_variable(cursor, var_name, value, mode='global'):
+    """Set a global or persistent variable and return the query."""
+    if mode == 'persist':
+        prefix = "SET PERSIST"
+    else:
+        prefix = "SET GLOBAL"
+    query = "%s %s = " % (prefix, mysql_quote_identifier(var_name, 'vars'))
     cursor.execute(query + "%s", (value,))
     return query + "'%s'" % value
 
@@ -237,13 +276,13 @@ def values_match(var_name, current_val, desired_val):
     if current_val is None:
         return False
 
-    # Policy can be reported as name or number
     if var_name == 'validate_password.policy':
-        current_norm = POLICY_MAP.get(str(current_val).upper(), str(current_val))
-        desired_norm = POLICY_MAP.get(str(desired_val).upper(), str(desired_val))
+        current_norm = POLICY_MAP.get(
+            str(current_val).upper(), str(current_val))
+        desired_norm = POLICY_MAP.get(
+            str(desired_val).upper(), str(desired_val))
         return current_norm == desired_norm
 
-    # Boolean ON/OFF comparison
     if var_name == 'validate_password.check_user_name':
         current_norm = str(current_val).upper()
         if isinstance(desired_val, bool):
@@ -258,7 +297,8 @@ def values_match(var_name, current_val, desired_val):
 def main():
     argument_spec = mysql_common_argument_spec()
     argument_spec.update(
-        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        state=dict(type='str', choices=['present', 'absent'],
+                   default='present'),
         policy=dict(type='str', choices=['LOW', 'MEDIUM', 'STRONG']),
         length=dict(type='int'),
         mixed_case_count=dict(type='int'),
@@ -268,6 +308,8 @@ def main():
         password_lifetime=dict(type='int', no_log=False),
         password_history=dict(type='int', no_log=False),
         reuse_interval=dict(type='int'),
+        mode=dict(type='str', choices=['global', 'persist'],
+                  default='global'),
     )
 
     module = AnsibleModule(
@@ -275,8 +317,8 @@ def main():
         supports_check_mode=True,
     )
 
-    user = module.params["login_user"]
-    password = module.params["login_password"]
+    login_user = module.params["login_user"]
+    login_password = module.params["login_password"]
     connect_timeout = module.params['connect_timeout']
     ssl_cert = module.params["client_cert"]
     ssl_key = module.params["client_key"]
@@ -286,6 +328,7 @@ def main():
     db = 'mysql'
 
     state = module.params['state']
+    mode = module.params['mode']
 
     if mysql_driver is None:
         module.fail_json(msg=mysql_driver_fail_msg)
@@ -294,7 +337,7 @@ def main():
 
     try:
         cursor, db_conn = mysql_connect(
-            module, user, password, config_file,
+            module, login_user, login_password, config_file,
             ssl_cert, ssl_key, ssl_ca, db,
             connect_timeout=connect_timeout,
             check_hostname=check_hostname,
@@ -308,77 +351,105 @@ def main():
             )
         else:
             module.fail_json(
-                msg="unable to find %s. Exception message: %s" % (config_file, to_native(e))
+                msg="unable to find %s. Exception message: %s"
+                    % (config_file, to_native(e))
             )
+
+    # Engine and version guardrails
+    server_impl = get_server_implementation(cursor)
+    if server_impl == "mariadb":
+        module.fail_json(
+            msg="mysql_password_policy does not support MariaDB. "
+                "MariaDB password validation uses the "
+                "simple_password_check or cracklib_password_check "
+                "plugins. See https://mariadb.com/kb/en/"
+                "password-validation-plugin-api/"
+        )
+
+    server_version = get_server_version(cursor)
+    version_clean = server_version.split('-')[0]
+    if LooseVersion(version_clean) < LooseVersion("8.0"):
+        module.fail_json(
+            msg="mysql_password_policy requires MySQL 8.0 or later. "
+                "Detected version: %s" % server_version
+        )
 
     installed = is_component_installed(cursor)
     changed = False
     executed_queries = []
 
+    # ---- Component install/uninstall ----
     if state == 'absent':
-        if not installed:
-            module.exit_json(changed=False, msg="validate_password component is not installed.")
-
-        if module.check_mode:
-            module.exit_json(
-                changed=True,
-                queries=["UNINSTALL COMPONENT 'file://component_validate_password'"],
-            )
-
-        try:
-            query = uninstall_component(cursor)
-            executed_queries.append(query)
-            changed = True
-        except Exception as e:
-            module.fail_json(msg="Failed to uninstall validate_password component: %s" % to_native(e))
-
-        module.exit_json(changed=changed, queries=executed_queries)
-
-    # state == 'present'
-    # Install component if not present
-    if not installed:
-        if module.check_mode:
-            executed_queries.append("INSTALL COMPONENT 'file://component_validate_password'")
-            changed = True
-        else:
-            try:
-                query = install_component(cursor)
-                executed_queries.append(query)
-                changed = True
-            except Exception as e:
-                module.fail_json(
-                    msg="Failed to install validate_password component: %s" % to_native(e)
-                )
-
-    # Configure validate_password.* variables
-    for param, var_name in VALIDATE_PASSWORD_PARAMS.items():
-        desired_val = module.params[param]
-        if desired_val is None:
-            continue
-
-        if not module.check_mode:
-            current_val = get_variable(cursor, var_name)
-        else:
-            # In check mode after install, we cannot read vars that don't exist yet
-            current_val = None if not installed and changed else get_variable(cursor, var_name)
-
-        if param == 'check_user_name':
-            set_val = 'ON' if desired_val else 'OFF'
-        else:
-            set_val = desired_val
-
-        if not values_match(var_name, current_val, desired_val):
+        if installed:
             if module.check_mode:
-                executed_queries.append("SET GLOBAL `%s` = '%s'" % (var_name, set_val))
+                executed_queries.append(
+                    "UNINSTALL COMPONENT "
+                    "'file://component_validate_password'")
+                changed = True
             else:
                 try:
-                    query = set_global_variable(cursor, var_name, set_val)
+                    query = uninstall_component(cursor)
                     executed_queries.append(query)
+                    changed = True
                 except Exception as e:
-                    module.fail_json(msg="Failed to set %s: %s" % (var_name, to_native(e)))
-            changed = True
+                    module.fail_json(
+                        msg="Failed to uninstall validate_password "
+                            "component: %s" % to_native(e))
+        # Do NOT exit here — fall through to process global params
 
-    # Configure global password policy variables
+    elif state == 'present':
+        if not installed:
+            if module.check_mode:
+                executed_queries.append(
+                    "INSTALL COMPONENT "
+                    "'file://component_validate_password'")
+                changed = True
+            else:
+                try:
+                    query = install_component(cursor)
+                    executed_queries.append(query)
+                    changed = True
+                except Exception as e:
+                    module.fail_json(
+                        msg="Failed to install validate_password "
+                            "component: %s" % to_native(e))
+
+        # Configure validate_password.* variables (only when present)
+        for param, var_name in VALIDATE_PASSWORD_PARAMS.items():
+            desired_val = module.params[param]
+            if desired_val is None:
+                continue
+
+            if not module.check_mode:
+                current_val = get_variable(cursor, var_name)
+            else:
+                current_val = (
+                    None if not installed and changed
+                    else get_variable(cursor, var_name))
+
+            if param == 'check_user_name':
+                set_val = 'ON' if desired_val else 'OFF'
+            else:
+                set_val = desired_val
+
+            if not values_match(var_name, current_val, desired_val):
+                if module.check_mode:
+                    executed_queries.append(
+                        "SET %s `%s` = '%s'"
+                        % ('PERSIST' if mode == 'persist' else 'GLOBAL',
+                           var_name, set_val))
+                else:
+                    try:
+                        query = set_variable(
+                            cursor, var_name, set_val, mode)
+                        executed_queries.append(query)
+                    except Exception as e:
+                        module.fail_json(
+                            msg="Failed to set %s: %s"
+                                % (var_name, to_native(e)))
+                changed = True
+
+    # ---- Global password params (always processed) ----
     for param, var_name in GLOBAL_PASSWORD_PARAMS.items():
         desired_val = module.params[param]
         if desired_val is None:
@@ -388,13 +459,19 @@ def main():
 
         if not values_match(var_name, current_val, desired_val):
             if module.check_mode:
-                executed_queries.append("SET GLOBAL `%s` = '%s'" % (var_name, desired_val))
+                executed_queries.append(
+                    "SET %s `%s` = '%s'"
+                    % ('PERSIST' if mode == 'persist' else 'GLOBAL',
+                       var_name, desired_val))
             else:
                 try:
-                    query = set_global_variable(cursor, var_name, desired_val)
+                    query = set_variable(
+                        cursor, var_name, desired_val, mode)
                     executed_queries.append(query)
                 except Exception as e:
-                    module.fail_json(msg="Failed to set %s: %s" % (var_name, to_native(e)))
+                    module.fail_json(
+                        msg="Failed to set %s: %s"
+                            % (var_name, to_native(e)))
             changed = True
 
     module.exit_json(changed=changed, queries=executed_queries)

--- a/plugins/modules/mysql_password_policy.py
+++ b/plugins/modules/mysql_password_policy.py
@@ -1,0 +1,404 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_password_policy
+
+short_description: Configure MySQL password validation policy
+
+description:
+- Manage the MySQL C(validate_password) component and related global variables.
+- Install or uninstall the C(validate_password) component (MySQL 8.0+).
+- Configure password complexity requirements, lifetime, and reuse policies.
+
+version_added: '5.1.0'
+
+author:
+- Steve Fulmer (@stevefulme1)
+
+options:
+  state:
+    description:
+    - V(present) ensures the C(validate_password) component is installed
+      and configured with the specified settings.
+    - V(absent) uninstalls the C(validate_password) component.
+    type: str
+    choices: ['present', 'absent']
+    default: present
+  policy:
+    description:
+    - Password validation policy level.
+    - V(LOW) checks length only.
+    - V(MEDIUM) checks length, numeric, mixed case, and special characters.
+    - V(STRONG) checks all of V(MEDIUM) plus dictionary file.
+    type: str
+    choices: ['LOW', 'MEDIUM', 'STRONG']
+  length:
+    description:
+    - Minimum number of characters in a password.
+    type: int
+  mixed_case_count:
+    description:
+    - Minimum number of uppercase and lowercase characters required.
+    type: int
+  number_count:
+    description:
+    - Minimum number of numeric characters required.
+    type: int
+  special_char_count:
+    description:
+    - Minimum number of special (non-alphanumeric) characters required.
+    type: int
+  check_user_name:
+    description:
+    - Whether passwords are checked against the user name.
+    - When V(true), passwords that match the user name are rejected.
+    type: bool
+  password_lifetime:
+    description:
+    - Default password expiration lifetime in days.
+    - V(0) disables automatic password expiration.
+    type: int
+  password_history:
+    description:
+    - Number of previous passwords that cannot be reused.
+    - V(0) disables password history checks.
+    type: int
+  reuse_interval:
+    description:
+    - Number of days before a password can be reused.
+    - V(0) disables reuse interval checks.
+    type: int
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+seealso:
+- module: ansible.mysql.mysql_variables
+- module: ansible.mysql.mysql_user
+- name: MySQL Password Validation Component
+  description: Reference for the validate_password component.
+  link: https://dev.mysql.com/doc/refman/8.0/en/validate-password.html
+
+notes:
+   - Requires MySQL 8.0 or later.
+   - The C(validate_password) component must be available on the server.
+   - In MySQL 5.7, the validate_password plugin uses underscores in variable
+     names (e.g., C(validate_password_policy)) rather than dots. This module
+     targets MySQL 8.0+ component syntax with dot notation.
+
+extends_documentation_fragment:
+- ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Install validate_password component with MEDIUM policy
+  ansible.mysql.mysql_password_policy:
+    state: present
+    policy: MEDIUM
+    length: 12
+    mixed_case_count: 1
+    number_count: 1
+    special_char_count: 1
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Set password lifetime and history policies
+  ansible.mysql.mysql_password_policy:
+    password_lifetime: 90
+    password_history: 5
+    reuse_interval: 365
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Uninstall validate_password component
+  ansible.mysql.mysql_password_policy:
+    state: absent
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Enforce STRONG policy with username check
+  ansible.mysql.mysql_password_policy:
+    policy: STRONG
+    length: 16
+    check_user_name: true
+    login_unix_socket: /run/mysqld/mysqld.sock
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed queries which modified the server state.
+  returned: if changed
+  type: list
+  sample: ["SET GLOBAL `validate_password.policy` = 'MEDIUM'"]
+  version_added: '5.1.0'
+'''
+
+import os
+import warnings
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.mysql.plugins.module_utils.database import mysql_quote_identifier
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+    mysql_common_argument_spec,
+)
+from ansible.module_utils.common.text.converters import to_native
+
+
+# Mapping of module parameters to MySQL global variable names
+# validate_password.* variables only exist when the component is installed
+VALIDATE_PASSWORD_PARAMS = {
+    'policy': 'validate_password.policy',
+    'length': 'validate_password.length',
+    'mixed_case_count': 'validate_password.mixed_case_count',
+    'number_count': 'validate_password.number_count',
+    'special_char_count': 'validate_password.special_char_count',
+    'check_user_name': 'validate_password.check_user_name',
+}
+
+# Global password policy variables (exist regardless of component)
+GLOBAL_PASSWORD_PARAMS = {
+    'password_lifetime': 'default_password_lifetime',
+    'password_history': 'password_history',
+    'reuse_interval': 'password_reuse_interval',
+}
+
+# Policy name to numeric value mapping for comparison
+POLICY_MAP = {
+    'LOW': '0',
+    'MEDIUM': '1',
+    'STRONG': '2',
+    '0': '0',
+    '1': '1',
+    '2': '2',
+}
+
+
+def is_component_installed(cursor):
+    """Check if validate_password component is installed."""
+    try:
+        cursor.execute("SHOW VARIABLES LIKE 'validate_password.policy'")
+        return cursor.fetchone() is not None
+    except Exception:
+        return False
+
+
+def get_current_variables(cursor, var_pattern):
+    """Retrieve current variable values matching a LIKE pattern."""
+    result = {}
+    cursor.execute("SHOW VARIABLES LIKE %s", (var_pattern,))
+    for row in cursor.fetchall():
+        result[row[0]] = row[1]
+    return result
+
+
+def get_variable(cursor, var_name):
+    """Get a single variable value."""
+    cursor.execute("SHOW VARIABLES WHERE Variable_name = %s", (var_name,))
+    row = cursor.fetchone()
+    if row:
+        return row[1]
+    return None
+
+
+def set_global_variable(cursor, var_name, value):
+    """Set a global variable and return the query string."""
+    query = "SET GLOBAL %s = " % mysql_quote_identifier(var_name, 'vars')
+    cursor.execute(query + "%s", (value,))
+    return query + "'%s'" % value
+
+
+def install_component(cursor):
+    """Install the validate_password component."""
+    query = "INSTALL COMPONENT 'file://component_validate_password'"
+    cursor.execute(query)
+    return query
+
+
+def uninstall_component(cursor):
+    """Uninstall the validate_password component."""
+    query = "UNINSTALL COMPONENT 'file://component_validate_password'"
+    cursor.execute(query)
+    return query
+
+
+def values_match(var_name, current_val, desired_val):
+    """Compare current and desired values, handling type differences."""
+    if current_val is None:
+        return False
+
+    # Policy can be reported as name or number
+    if var_name == 'validate_password.policy':
+        current_norm = POLICY_MAP.get(str(current_val).upper(), str(current_val))
+        desired_norm = POLICY_MAP.get(str(desired_val).upper(), str(desired_val))
+        return current_norm == desired_norm
+
+    # Boolean ON/OFF comparison
+    if var_name == 'validate_password.check_user_name':
+        current_norm = str(current_val).upper()
+        if isinstance(desired_val, bool):
+            desired_norm = 'ON' if desired_val else 'OFF'
+        else:
+            desired_norm = str(desired_val).upper()
+        return current_norm == desired_norm
+
+    return str(current_val) == str(desired_val)
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        policy=dict(type='str', choices=['LOW', 'MEDIUM', 'STRONG']),
+        length=dict(type='int'),
+        mixed_case_count=dict(type='int'),
+        number_count=dict(type='int'),
+        special_char_count=dict(type='int'),
+        check_user_name=dict(type='bool'),
+        password_lifetime=dict(type='int', no_log=False),
+        password_history=dict(type='int', no_log=False),
+        reuse_interval=dict(type='int'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    user = module.params["login_user"]
+    password = module.params["login_password"]
+    connect_timeout = module.params['connect_timeout']
+    ssl_cert = module.params["client_cert"]
+    ssl_key = module.params["client_key"]
+    ssl_ca = module.params["ca_cert"]
+    check_hostname = module.params["check_hostname"]
+    config_file = module.params['config_file']
+    db = 'mysql'
+
+    state = module.params['state']
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+    else:
+        warnings.filterwarnings('error', category=mysql_driver.Warning)
+
+    try:
+        cursor, db_conn = mysql_connect(
+            module, user, password, config_file,
+            ssl_cert, ssl_key, ssl_ca, db,
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+        )
+    except Exception as e:
+        if os.path.exists(config_file):
+            module.fail_json(
+                msg="unable to connect to database, check login_user and "
+                    "login_password are correct or %s has the credentials. "
+                    "Exception message: %s" % (config_file, to_native(e))
+            )
+        else:
+            module.fail_json(
+                msg="unable to find %s. Exception message: %s" % (config_file, to_native(e))
+            )
+
+    installed = is_component_installed(cursor)
+    changed = False
+    executed_queries = []
+
+    if state == 'absent':
+        if not installed:
+            module.exit_json(changed=False, msg="validate_password component is not installed.")
+
+        if module.check_mode:
+            module.exit_json(
+                changed=True,
+                queries=["UNINSTALL COMPONENT 'file://component_validate_password'"],
+            )
+
+        try:
+            query = uninstall_component(cursor)
+            executed_queries.append(query)
+            changed = True
+        except Exception as e:
+            module.fail_json(msg="Failed to uninstall validate_password component: %s" % to_native(e))
+
+        module.exit_json(changed=changed, queries=executed_queries)
+
+    # state == 'present'
+    # Install component if not present
+    if not installed:
+        if module.check_mode:
+            executed_queries.append("INSTALL COMPONENT 'file://component_validate_password'")
+            changed = True
+        else:
+            try:
+                query = install_component(cursor)
+                executed_queries.append(query)
+                changed = True
+            except Exception as e:
+                module.fail_json(
+                    msg="Failed to install validate_password component: %s" % to_native(e)
+                )
+
+    # Configure validate_password.* variables
+    for param, var_name in VALIDATE_PASSWORD_PARAMS.items():
+        desired_val = module.params[param]
+        if desired_val is None:
+            continue
+
+        if not module.check_mode:
+            current_val = get_variable(cursor, var_name)
+        else:
+            # In check mode after install, we cannot read vars that don't exist yet
+            current_val = None if not installed and changed else get_variable(cursor, var_name)
+
+        if param == 'check_user_name':
+            set_val = 'ON' if desired_val else 'OFF'
+        else:
+            set_val = desired_val
+
+        if not values_match(var_name, current_val, desired_val):
+            if module.check_mode:
+                executed_queries.append("SET GLOBAL `%s` = '%s'" % (var_name, set_val))
+            else:
+                try:
+                    query = set_global_variable(cursor, var_name, set_val)
+                    executed_queries.append(query)
+                except Exception as e:
+                    module.fail_json(msg="Failed to set %s: %s" % (var_name, to_native(e)))
+            changed = True
+
+    # Configure global password policy variables
+    for param, var_name in GLOBAL_PASSWORD_PARAMS.items():
+        desired_val = module.params[param]
+        if desired_val is None:
+            continue
+
+        current_val = get_variable(cursor, var_name)
+
+        if not values_match(var_name, current_val, desired_val):
+            if module.check_mode:
+                executed_queries.append("SET GLOBAL `%s` = '%s'" % (var_name, desired_val))
+            else:
+                try:
+                    query = set_global_variable(cursor, var_name, desired_val)
+                    executed_queries.append(query)
+                except Exception as e:
+                    module.fail_json(msg="Failed to set %s: %s" % (var_name, to_native(e)))
+            changed = True
+
+    module.exit_json(changed=changed, queries=executed_queries)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/test_mysql_password_policy/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_password_policy/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for test_mysql_password_policy
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_password_policy/meta/main.yml
+++ b/tests/integration/targets/test_mysql_password_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_password_policy/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_password_policy/tasks/main.yml
@@ -1,0 +1,6 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- import_tasks: mysql_password_policy.yml

--- a/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
+++ b/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
@@ -1,22 +1,37 @@
 # test code for the mysql_password_policy module
-
-# This file is part of Ansible
 #
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # ============================================================
-# Test mysql_password_policy module
+# MariaDB: verify module fails with a clear error message
+# ============================================================
+
+- vars:
+    mysql_parameters: &mysql_params_mariadb
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  when: db_engine == 'mariadb'
+  block:
+
+    - name: Verify mysql_password_policy fails on MariaDB
+      mysql_password_policy:
+        <<: *mysql_params_mariadb
+        state: present
+      register: mariadb_result
+      failed_when: false
+
+    - name: Assert mysql_password_policy rejects MariaDB
+      assert:
+        that:
+          - "'does not support MariaDB' in mariadb_result.msg"
+          - mariadb_result.changed == false
+
+# ============================================================
+# MySQL: password policy module test suite
 # ============================================================
 
 - vars:
@@ -26,11 +41,13 @@
       login_host: '{{ mysql_host }}'
       login_port: '{{ mysql_primary_port }}'
 
+  when: db_engine == 'mysql'
   block:
 
     # ============================================================
     # Cleanup: ensure component is not installed before tests
     # ============================================================
+
     - name: Ensure validate_password component is absent before tests
       mysql_password_policy:
         <<: *mysql_params
@@ -40,6 +57,7 @@
     # ============================================================
     # Test: Install validate_password component
     # ============================================================
+
     - name: Install validate_password component
       mysql_password_policy:
         <<: *mysql_params
@@ -53,8 +71,9 @@
           - "'INSTALL COMPONENT' in result_install.queries | join(' ')"
 
     # ============================================================
-    # Test: Install idempotency (already installed)
+    # Test: Install idempotency
     # ============================================================
+
     - name: Install validate_password component again (idempotency)
       mysql_password_policy:
         <<: *mysql_params
@@ -69,6 +88,7 @@
     # ============================================================
     # Test: Set policy to MEDIUM
     # ============================================================
+
     - name: Set password policy to MEDIUM
       mysql_password_policy:
         <<: *mysql_params
@@ -89,6 +109,7 @@
     # ============================================================
     # Test: Policy idempotency
     # ============================================================
+
     - name: Set password policy to MEDIUM again (idempotency)
       mysql_password_policy:
         <<: *mysql_params
@@ -101,8 +122,9 @@
           - result_policy_idem is not changed
 
     # ============================================================
-    # Test: Set multiple validate_password parameters
+    # Test: Set multiple complexity parameters
     # ============================================================
+
     - name: Configure password complexity
       mysql_password_policy:
         <<: *mysql_params
@@ -132,7 +154,8 @@
     # ============================================================
     # Test: Complexity idempotency
     # ============================================================
-    - name: Configure same password complexity again (idempotency)
+
+    - name: Configure same complexity again (idempotency)
       mysql_password_policy:
         <<: *mysql_params
         length: 12
@@ -142,7 +165,7 @@
         check_user_name: true
       register: result_complexity_idem
 
-    - name: Assert no change on idempotent complexity set
+    - name: Assert no change on idempotent complexity
       assert:
         that:
           - result_complexity_idem is not changed
@@ -150,6 +173,7 @@
     # ============================================================
     # Test: Set global password lifetime
     # ============================================================
+
     - name: Set default password lifetime to 90 days
       mysql_password_policy:
         <<: *mysql_params
@@ -175,6 +199,7 @@
     # ============================================================
     # Test: Set password history and reuse interval
     # ============================================================
+
     - name: Set password history and reuse interval
       mysql_password_policy:
         <<: *mysql_params
@@ -199,8 +224,9 @@
           - history_value.msg == '5'
 
     # ============================================================
-    # Test: check_mode on install (with component already installed)
+    # Test: check_mode
     # ============================================================
+
     - name: Set policy to STRONG in check_mode
       mysql_password_policy:
         <<: *mysql_params
@@ -219,29 +245,67 @@
         variable: validate_password.policy
       register: policy_after_check
 
-    - name: Assert policy is still MEDIUM (check_mode did not apply)
+    - name: Assert policy is still MEDIUM
       assert:
         that:
           - policy_after_check.msg == 'MEDIUM'
 
     # ============================================================
-    # Test: Uninstall validate_password component
+    # Test: state=absent uninstalls component AND resets globals
     # ============================================================
-    - name: Uninstall validate_password component
+
+    - name: Uninstall component and reset global params in one task
       mysql_password_policy:
         <<: *mysql_params
         state: absent
-      register: result_uninstall
+        password_lifetime: 0
+        password_history: 0
+        reuse_interval: 0
+      register: result_absent_with_globals
 
-    - name: Assert component was uninstalled
+    - name: Assert component uninstalled and globals reset
       assert:
         that:
-          - result_uninstall is changed
-          - "'UNINSTALL COMPONENT' in result_uninstall.queries | join(' ')"
+          - result_absent_with_globals is changed
+          - "'UNINSTALL COMPONENT' in result_absent_with_globals.queries | join(' ')"
+
+    - name: Read default_password_lifetime after absent
+      mysql_variables:
+        <<: *mysql_params
+        variable: default_password_lifetime
+      register: lifetime_after_absent
+
+    - name: Assert password lifetime is 0 after absent
+      assert:
+        that:
+          - lifetime_after_absent.msg == '0'
+
+    - name: Read password_history after absent
+      mysql_variables:
+        <<: *mysql_params
+        variable: password_history
+      register: history_after_absent
+
+    - name: Assert password history is 0 after absent
+      assert:
+        that:
+          - history_after_absent.msg == '0'
+
+    - name: Read password_reuse_interval after absent
+      mysql_variables:
+        <<: *mysql_params
+        variable: password_reuse_interval
+      register: reuse_after_absent
+
+    - name: Assert reuse interval is 0 after absent
+      assert:
+        that:
+          - reuse_after_absent.msg == '0'
 
     # ============================================================
     # Test: Uninstall idempotency
     # ============================================================
+
     - name: Uninstall validate_password component again (idempotency)
       mysql_password_policy:
         <<: *mysql_params
@@ -252,24 +316,3 @@
       assert:
         that:
           - result_uninstall_idem is not changed
-
-    # ============================================================
-    # Cleanup: reset global password variables
-    # ============================================================
-    - name: Reset default_password_lifetime to 0
-      mysql_variables:
-        <<: *mysql_params
-        variable: default_password_lifetime
-        value: '0'
-
-    - name: Reset password_history to 0
-      mysql_variables:
-        <<: *mysql_params
-        variable: password_history
-        value: '0'
-
-    - name: Reset password_reuse_interval to 0
-      mysql_variables:
-        <<: *mysql_params
-        variable: password_reuse_interval
-        value: '0'

--- a/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
+++ b/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
@@ -1,0 +1,275 @@
+# test code for the mysql_password_policy module
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+# Test mysql_password_policy module
+# ============================================================
+
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+
+    # ============================================================
+    # Cleanup: ensure component is not installed before tests
+    # ============================================================
+    - name: Ensure validate_password component is absent before tests
+      mysql_password_policy:
+        <<: *mysql_params
+        state: absent
+      failed_when: false
+
+    # ============================================================
+    # Test: Install validate_password component
+    # ============================================================
+    - name: Install validate_password component
+      mysql_password_policy:
+        <<: *mysql_params
+        state: present
+      register: result_install
+
+    - name: Assert component was installed
+      assert:
+        that:
+          - result_install is changed
+          - "'INSTALL COMPONENT' in result_install.queries | join(' ')"
+
+    # ============================================================
+    # Test: Install idempotency (already installed)
+    # ============================================================
+    - name: Install validate_password component again (idempotency)
+      mysql_password_policy:
+        <<: *mysql_params
+        state: present
+      register: result_install_idem
+
+    - name: Assert no change on second install
+      assert:
+        that:
+          - result_install_idem is not changed
+
+    # ============================================================
+    # Test: Set policy to MEDIUM
+    # ============================================================
+    - name: Set password policy to MEDIUM
+      mysql_password_policy:
+        <<: *mysql_params
+        policy: MEDIUM
+      register: result_policy
+
+    - name: Read validate_password.policy variable
+      mysql_variables:
+        <<: *mysql_params
+        variable: validate_password.policy
+      register: policy_value
+
+    - name: Assert policy is MEDIUM
+      assert:
+        that:
+          - policy_value.msg == 'MEDIUM'
+
+    # ============================================================
+    # Test: Policy idempotency
+    # ============================================================
+    - name: Set password policy to MEDIUM again (idempotency)
+      mysql_password_policy:
+        <<: *mysql_params
+        policy: MEDIUM
+      register: result_policy_idem
+
+    - name: Assert no change on idempotent policy set
+      assert:
+        that:
+          - result_policy_idem is not changed
+
+    # ============================================================
+    # Test: Set multiple validate_password parameters
+    # ============================================================
+    - name: Configure password complexity
+      mysql_password_policy:
+        <<: *mysql_params
+        length: 12
+        mixed_case_count: 2
+        number_count: 2
+        special_char_count: 1
+        check_user_name: true
+      register: result_complexity
+
+    - name: Assert complexity settings changed
+      assert:
+        that:
+          - result_complexity is changed
+
+    - name: Read validate_password.length variable
+      mysql_variables:
+        <<: *mysql_params
+        variable: validate_password.length
+      register: length_value
+
+    - name: Assert length is 12
+      assert:
+        that:
+          - length_value.msg == '12'
+
+    # ============================================================
+    # Test: Complexity idempotency
+    # ============================================================
+    - name: Configure same password complexity again (idempotency)
+      mysql_password_policy:
+        <<: *mysql_params
+        length: 12
+        mixed_case_count: 2
+        number_count: 2
+        special_char_count: 1
+        check_user_name: true
+      register: result_complexity_idem
+
+    - name: Assert no change on idempotent complexity set
+      assert:
+        that:
+          - result_complexity_idem is not changed
+
+    # ============================================================
+    # Test: Set global password lifetime
+    # ============================================================
+    - name: Set default password lifetime to 90 days
+      mysql_password_policy:
+        <<: *mysql_params
+        password_lifetime: 90
+      register: result_lifetime
+
+    - name: Assert password lifetime changed
+      assert:
+        that:
+          - result_lifetime is changed
+
+    - name: Read default_password_lifetime variable
+      mysql_variables:
+        <<: *mysql_params
+        variable: default_password_lifetime
+      register: lifetime_value
+
+    - name: Assert password lifetime is 90
+      assert:
+        that:
+          - lifetime_value.msg == '90'
+
+    # ============================================================
+    # Test: Set password history and reuse interval
+    # ============================================================
+    - name: Set password history and reuse interval
+      mysql_password_policy:
+        <<: *mysql_params
+        password_history: 5
+        reuse_interval: 365
+      register: result_history
+
+    - name: Assert history settings changed
+      assert:
+        that:
+          - result_history is changed
+
+    - name: Read password_history variable
+      mysql_variables:
+        <<: *mysql_params
+        variable: password_history
+      register: history_value
+
+    - name: Assert password history is 5
+      assert:
+        that:
+          - history_value.msg == '5'
+
+    # ============================================================
+    # Test: check_mode on install (with component already installed)
+    # ============================================================
+    - name: Set policy to STRONG in check_mode
+      mysql_password_policy:
+        <<: *mysql_params
+        policy: STRONG
+      check_mode: true
+      register: result_check
+
+    - name: Assert check_mode reports change
+      assert:
+        that:
+          - result_check is changed
+
+    - name: Verify policy unchanged after check_mode
+      mysql_variables:
+        <<: *mysql_params
+        variable: validate_password.policy
+      register: policy_after_check
+
+    - name: Assert policy is still MEDIUM (check_mode did not apply)
+      assert:
+        that:
+          - policy_after_check.msg == 'MEDIUM'
+
+    # ============================================================
+    # Test: Uninstall validate_password component
+    # ============================================================
+    - name: Uninstall validate_password component
+      mysql_password_policy:
+        <<: *mysql_params
+        state: absent
+      register: result_uninstall
+
+    - name: Assert component was uninstalled
+      assert:
+        that:
+          - result_uninstall is changed
+          - "'UNINSTALL COMPONENT' in result_uninstall.queries | join(' ')"
+
+    # ============================================================
+    # Test: Uninstall idempotency
+    # ============================================================
+    - name: Uninstall validate_password component again (idempotency)
+      mysql_password_policy:
+        <<: *mysql_params
+        state: absent
+      register: result_uninstall_idem
+
+    - name: Assert no change on second uninstall
+      assert:
+        that:
+          - result_uninstall_idem is not changed
+
+    # ============================================================
+    # Cleanup: reset global password variables
+    # ============================================================
+    - name: Reset default_password_lifetime to 0
+      mysql_variables:
+        <<: *mysql_params
+        variable: default_password_lifetime
+        value: '0'
+
+    - name: Reset password_history to 0
+      mysql_variables:
+        <<: *mysql_params
+        variable: password_history
+        value: '0'
+
+    - name: Reset password_reuse_interval to 0
+      mysql_variables:
+        <<: *mysql_params
+        variable: password_reuse_interval
+        value: '0'


### PR DESCRIPTION
## Summary

Adds a module to manage the MySQL `validate_password` component (split from #811 per reviewer feedback):

- **`mysql_password_policy`** — Install/uninstall the `validate_password` component (MySQL 8.0+), configure password complexity (length, mixed case, numbers, special chars), policy level (LOW/MEDIUM/STRONG), username-in-password check, password expiration lifetime, history depth, and reuse interval.

## Design

- Uses `mysql_common_argument_spec()` and `mysql_connect()` — no custom connection params
- Variable setting uses `mysql_quote_identifier()` (same pattern as `mysql_variables.py`)
- `version_added: '5.1.0'` on all new parameters
- Full `check_mode` and idempotency support
- `password_history` and `password_lifetime` params have explicit `no_log=False` (they're integers, not secrets)
- Returns `queries` list showing executed SQL

## Testing

- [x] `ansible-test sanity --test validate-modules` — PASS
- [x] `ansible-test sanity --test pep8` — PASS
- [x] Integration tests for component install/uninstall, policy setting, complexity configuration, lifetime/history/reuse, and check_mode verification
- [x] No `ignore_errors` in test files
- [x] No changelog fragments (auto-generated from `version_added`)

Ref #805