### PR TITLE
docs: align testing docs and scripts with current CI matrix

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -38,18 +38,19 @@ The Makefile accept the following options
 - `local_python_version`
   - Mandatory: false
   - Choices:
-    - "3.8"
-    - "3.9"
     - "3.10"
-    - "3.11" (for stable-2.15+)
-  - Description: If `Python -V` shows an unsupported version, use this option to select a compatible Python version available on your system. Use `ls /usr/bin/python3*|grep -v config` to list the available versions (You may have to install one). Unsupported versions are those that are too recent for the Ansible version you are using. In such cases, you will see an error message similar to: 'This version of ansible-test cannot be executed with Python version 3.12.3. Supported Python versions are: 3.9, 3.10, 3.11'.
+    - "3.11"
+    - "3.12"
+  - Description: If `Python -V` shows an unsupported version, use this option to select a compatible Python version available on your system. Use `ls /usr/bin/python3*|grep -v config` to list the available versions (You may have to install one). Unsupported versions are those that are too recent for the Ansible version you are using. In such cases, you will see an error message similar to: 'This version of ansible-test cannot be executed with Python version 3.13. Supported Python versions are: 3.10, 3.11, 3.12'.
 
 - `ansible`
   - Mandatory: true
   - Choices:
-    - "stable-2.15"
-    - "stable-2.16"
     - "stable-2.17"
+    - "stable-2.18"
+    - "stable-2.19"
+    - "stable-2.20"
+    - "stable-2.21"
     - "devel"
   - Description: Version of ansible to install in a venv to run ansible-test
 
@@ -110,14 +111,14 @@ tests will overwrite the 3 databases containers so no need to kill them in advan
 
 ```sh
 # Run all targets
-make ansible="stable-2.16" db_engine_name="mysql" db_engine_version="8.0.31" connector_name="pymysql" connector_version="1.0.2"
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2"
 
 # A single target
-make ansible="stable-2.16" db_engine_name="mysql" db_engine_version="8.0.31" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
 
 # Keep databases and ansible tests containers alives
 # A single target and continue on errors
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.31" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
 
 # If your system has an usupported version of Python:
 make local_python_version="3.10" ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="11.8.7" connector_name="pymysql" connector_version="1.0.2"

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -73,25 +73,22 @@ def main():
     for ansible in tests_matrix_yaml.get('ansible'):
         for db_engine_name in tests_matrix_yaml.get('db_engine_name'):
             for db_engine_version in tests_matrix_yaml.get('db_engine_version'):
-                for python in tests_matrix_yaml.get('python'):
-                    for connector_name in tests_matrix_yaml.get('connector_name'):
-                        for connector_version in tests_matrix_yaml.get('connector_version'):
-                            test_suite = {
-                                'ansible': ansible,
-                                'db_engine_name': db_engine_name,
-                                'db_engine_version': db_engine_version,
-                                'python': python,
-                                'connector_name': connector_name,
-                                'connector_version': connector_version
-                            }
-                            if not is_exclude(exclude_list, test_suite):
-                                matrix.append(test_suite)
+                for connector_name in tests_matrix_yaml.get('connector_name'):
+                    for connector_version in tests_matrix_yaml.get('connector_version'):
+                        test_suite = {
+                            'ansible': ansible,
+                            'db_engine_name': db_engine_name,
+                            'db_engine_version': db_engine_version,
+                            'connector_name': connector_name,
+                            'connector_version': connector_version
+                        }
+                        if not is_exclude(exclude_list, test_suite):
+                            matrix.append(test_suite)
 
     for tests in matrix:
         a = tests.get('ansible')
         dn = tests.get('db_engine_name')
         dv = tests.get('db_engine_version')
-        p = tests.get('python')
         cn = tests.get('connector_name')
         cv = tests.get('connector_version')
         make_cmd = (
@@ -99,12 +96,11 @@ def main():
             f'ansible="{a}" '
             f'db_engine_name="{dn}" '
             f'db_engine_version="{dv}" '
-            f'python="{p}" '
             f'connector_name="{cn}" '
             f'connector_version="{cv}" '
             f'test-integration'
         )
-        print(f'Run tests for: Ansible: {a}, DB: {dn} {dv}, Python: {p}, Connector: {cn} {cv}')
+        print(f'Run tests for: Ansible: {a}, DB: {dn} {dv}, Connector: {cn} {cv}')
         os.system(make_cmd)
         # TODO, allow for CTRL+C to break the loop more easily
         # TODO, store the failures from this iteration


### PR DESCRIPTION
#### SUMMARY
- Update TESTING.md to reflect current CI versions: ansible stable-2.17 through stable-2.21, MariaDB 11.8.3, Python 3.10-3.12
- Update usage examples to use versions actually tested in CI (8.0.38 instead of 8.0.31)
- Fix run_all_tests.py which crashed because it iterated over a removed 'python' matrix key

#### ISSUE TYPE
- Docs Pull Request

#### COMPONENT NAME
- TESTING.md
- run_all_tests.py

#### ADDITIONAL INFORMATION
- No functional changes to modules or plugins
- run_all_tests.py was broken (TypeError on NoneType iteration) since the python key was removed from the CI workflow matrix
- PR was created by the help of Cursor + Opus 4.6 with Human review, manual tests and feedback.