### PR TITLE
ci: bump MariaDB test version from 11.8.3 to 11.8.7

### DIFF
--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -70,7 +70,7 @@ make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" con
 make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
 
 # MariaDB example
-make ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="11.4.5" connector_name="pymysql" connector_version="1.0.2"
+make ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="11.8.7" connector_name="pymysql" connector_version="1.0.2"
 ```
 
 Key Makefile options: `db_engine_name` (mysql/mariadb), `db_engine_version`, `connector_name` (pymysql), `connector_version`, `target` (single test target), `keep_containers_alive=1` (for debugging), `continue_on_errors=1`. See `TESTING.md` for the full list of supported versions and options.

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -38,7 +38,7 @@ jobs:
           - '8.0.38'
           - '8.4.9'
           - '10.11.8'
-          - '11.8.3'
+          - '11.8.7'
         connector_name:
           - pymysql
         connector_version:
@@ -69,7 +69,7 @@ jobs:
             db_engine_version: '10.11.8'
 
           - db_engine_name: mysql
-            db_engine_version: '11.8.3'
+            db_engine_version: '11.8.7'
 
           - db_engine_name: mariadb
             db_engine_version: '8.0.38'

--- a/TESTING.md
+++ b/TESTING.md
@@ -66,7 +66,7 @@ The Makefile accept the following options
     - "8.0.38" <- mysql
     - "8.4.9" <- mysql
     - "10.11.8" <- mariadb
-    - "11.4.5" <- mariadb
+    - "11.8.7" <- mariadb
   - Description: The tag of the container to use for the service containers that will host a primary database and two replicas. Do not use short version, like `mysql:8` (don't do that) because our tests expect a full version to filter tests precisely. For instance: `when: db_version is version ('8.0.22', '>')`. You can use any tag available on [hub.docker.com/_/mysql](https://hub.docker.com/_/mysql) and [hub.docker.com/_/mariadb](https://hub.docker.com/_/mariadb) but GitHub Action will only use the versions listed above.
 
 - `connector_name`
@@ -120,7 +120,7 @@ make ansible="stable-2.16" db_engine_name="mysql" db_engine_version="8.0.31" con
 make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.31" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
 
 # If your system has an usupported version of Python:
-make local_python_version="3.10" ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="11.4.5" connector_name="pymysql" connector_version="1.0.2"
+make local_python_version="3.10" ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="11.8.7" connector_name="pymysql" connector_version="1.0.2"
 ```
 
 


### PR DESCRIPTION
#### SUMMARY
- Upgrade MariaDB integration test version from 11.8.3 to 11.8.7 (latest available in the 11.8 series on Docker Hub)
- Align TESTING.md and skill documentation with the CI matrix (previously referenced stale 11.4.5)

#### ISSUE TYPE
- Docs Pull Request

#### COMPONENT NAME
- .github/workflows/ansible-test-plugins.yml
- TESTING.md
- .agents/skills/run-tests/SKILL.md

#### ADDITIONAL INFORMATION
- Verified docker.io/library/mariadb:11.8.7 exists on Docker Hub (published 2026-05-20)
- No module code or test logic changes required (patch-level bump within same release series)
- MariaDB 10.11.8 LTS remains unchanged
- Tested locally by running full integration tests run
- PR was created with Cursor + Opus 4.6 but tested and instructed manually by a human