### PR TITLE
Add mysql_binlog_info module

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -89,6 +89,7 @@ The Makefile accept the following options
 - `target`
   - Mandatory: false
   - Choices:
+    - "test_mysql_binlog_info"
     - "test_mysql_db"
     - "test_mysql_info"
     - "test_mysql_query"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -3,6 +3,7 @@ requires_ansible: '>=2.16.0'
 action_groups:
   all:
     - mysql_db
+    - mysql_binlog_info
     - mysql_info
     - mysql_query
     - mysql_replication

--- a/plugins/modules/mysql_binlog_info.py
+++ b/plugins/modules/mysql_binlog_info.py
@@ -1,0 +1,327 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_binlog_info
+
+short_description: Gather MySQL or MariaDB binary log information
+
+description:
+  - Gather binary log information from MySQL or MariaDB servers.
+  - Returns the current binary log status, available binary log files, aggregate log totals,
+    and selected binary-log-related settings.
+  - This module is read-only. Use M(ansible.mysql.mysql_variables) for mutable binlog settings.
+
+author:
+  - Ron Gershburg (@rgershbu)
+
+version_added: '5.1.0'
+
+options:
+  filter:
+    description:
+      - Limit the collected information by comma separated string or YAML list.
+      - Allowable values are C(current), C(logs), C(totals), and C(settings).
+      - By default, collects all subsets.
+      - You can use C(!) before a value, for example C(!settings), to exclude it from the information.
+      - If you pass including and excluding values together, the excluding values are ignored.
+    type: list
+    elements: str
+    version_added: '5.1.0'
+
+notes:
+  - Compatible with MariaDB or MySQL.
+  - The module does not modify server state.
+  - Some mutable binlog settings are dynamic and can be managed with M(ansible.mysql.mysql_variables).
+  - Startup-only or restart-managed settings remain outside this module's scope.
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+seealso:
+  - module: ansible.mysql.mysql_variables
+  - module: ansible.mysql.mysql_replication
+
+extends_documentation_fragment:
+  - ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Collect all binlog information
+  ansible.mysql.mysql_binlog_info:
+    login_user: root
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Collect only current binlog status and log list
+  ansible.mysql.mysql_binlog_info:
+    login_user: root
+    login_password: rootpass
+    filter:
+      - current
+      - logs
+
+- name: Collect all binlog info except settings
+  ansible.mysql.mysql_binlog_info:
+    login_user: root
+    login_password: rootpass
+    filter:
+      - "!settings"
+'''
+
+RETURN = r'''
+current:
+  description: Current binary log status information.
+  returned: if not excluded by filter
+  type: dict
+  sample:
+    file: primary-bin.000003
+    position: 158
+    executed_gtid_set: "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-1234"
+logs:
+  description: List of binary log files.
+  returned: if not excluded by filter
+  type: list
+  elements: dict
+  sample:
+    - name: primary-bin.000001
+      size: 181
+      encrypted: 'No'
+    - name: primary-bin.000002
+      size: 2997943
+      encrypted: 'No'
+    - name: primary-bin.000003
+      size: 158
+      encrypted: 'No'
+totals:
+  description: Aggregate information about binary log files.
+  returned: if not excluded by filter
+  type: dict
+  sample:
+    count: 3
+    size: 2998282
+settings:
+  description: Selected binary-log-related global settings.
+  returned: if not excluded by filter
+  type: dict
+  sample:
+    log_bin: 'ON'
+    binlog_format: ROW
+    max_binlog_size: 1073741824
+    sync_binlog: 1
+    binlog_expire_logs_seconds: 2592000
+    binlog_encryption: 'OFF'
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.ansible.mysql.plugins.module_utils.command_resolver import (
+    CommandResolver,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    get_server_implementation,
+    get_server_version,
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+
+
+class MySQL_Binlog_Info(object):
+    SETTINGS_VARS = (
+        'log_bin',
+        'binlog_format',
+        'max_binlog_size',
+        'sync_binlog',
+        'binlog_expire_logs_seconds',
+        'expire_logs_days',
+        'binlog_encryption',
+        'encrypt_binlog',
+    )
+
+    def __init__(self, module, cursor, server_implementation, server_version):
+        self.module = module
+        self.cursor = cursor
+        self.server_implementation = server_implementation
+        self.command_resolver = CommandResolver(server_implementation, server_version)
+        self.info = {
+            'current': {},
+            'logs': [],
+            'totals': {},
+            'settings': {},
+        }
+
+    def get_info(self, filter_):
+        wanted = set(self.__get_wanted(filter_))
+        self.__collect(wanted)
+        return dict((key, self.info[key]) for key in self.info if key in wanted)
+
+    def __get_wanted(self, filter_):
+        if not filter_:
+            return self.info
+
+        included = []
+        excluded = []
+
+        for item in filter_:
+            key = item.lstrip('!')
+            if key not in self.info:
+                continue
+
+            if item.startswith('!'):
+                excluded.append(key)
+            else:
+                included.append(key)
+
+        if included:
+            return included
+
+        return [key for key in self.info if key not in excluded]
+
+    def __collect(self, wanted):
+        if 'current' in wanted:
+            self.__get_current_status()
+
+        if 'logs' in wanted or 'totals' in wanted:
+            self.__get_logs()
+
+        if 'totals' in wanted:
+            self.info['totals'] = {
+                'count': len(self.info['logs']),
+                'size': sum(log['size'] for log in self.info['logs']),
+            }
+
+        if 'settings' in wanted:
+            self.__get_settings()
+
+    def __get_current_status(self):
+        query = self.command_resolver.resolve_command("SHOW MASTER STATUS")
+        res = self.__exec_sql(query)
+        if not res:
+            return
+
+        current = res[0]
+        executed_gtid_set = current.get('Executed_Gtid_Set') or current.get('Gtid_Binlog_Pos')
+
+        if executed_gtid_set is None and self.server_implementation == 'mariadb':
+            gtid_res = self.__exec_sql('SELECT @@global.gtid_binlog_pos AS gtid_binlog_pos')
+            if gtid_res:
+                executed_gtid_set = gtid_res[0].get('gtid_binlog_pos')
+
+        self.info['current'] = {
+            'file': current.get('File'),
+            'position': self.__convert(current.get('Position')),
+            'executed_gtid_set': executed_gtid_set,
+        }
+
+    def __get_logs(self):
+        res = self.__exec_sql('SHOW BINARY LOGS')
+        self.info['logs'] = []
+
+        if not res:
+            return
+
+        for line in res:
+            self.info['logs'].append({
+                'name': line.get('Log_name'),
+                'size': self.__convert(line.get('File_size')),
+                'encrypted': line.get('Encrypted'),
+            })
+
+    def __get_settings(self):
+        res = self.__exec_sql('SHOW GLOBAL VARIABLES')
+        self.info['settings'] = {}
+
+        if not res:
+            return
+
+        for line in res:
+            variable_name = line.get('Variable_name')
+            if variable_name in self.SETTINGS_VARS:
+                self.info['settings'][variable_name] = self.__convert(line.get('Value'))
+
+    def __exec_sql(self, query):
+        try:
+            self.cursor.execute(query)
+            return self.cursor.fetchall()
+        except Exception as e:
+            self.module.fail_json(msg="Cannot execute SQL '%s': %s" % (query, to_native(e)))
+        return False
+
+    @staticmethod
+    def __convert(val):
+        try:
+            return int(val)
+        except (TypeError, ValueError):
+            return val
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        filter=dict(type='list', elements='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    connect_timeout = module.params['connect_timeout']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    ssl_cert = module.params['client_cert']
+    ssl_key = module.params['client_key']
+    ssl_ca = module.params['ca_cert']
+    check_hostname = module.params['check_hostname']
+    config_file = module.params['config_file']
+    filter_ = module.params['filter']
+
+    if filter_:
+        filter_ = [item.strip() for item in filter_]
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    try:
+        cursor, _db_conn = mysql_connect(
+            module,
+            login_user,
+            login_password,
+            config_file,
+            ssl_cert,
+            ssl_key,
+            ssl_ca,
+            'mysql',
+            check_hostname=check_hostname,
+            connect_timeout=connect_timeout,
+            cursor_class='DictCursor',
+        )
+    except Exception as e:
+        module.fail_json(
+            msg="unable to connect to database, check login_user and "
+                "login_password are correct or %s has the credentials. "
+                "Exception message: %s" % (config_file, to_native(e))
+        )
+
+    server_implementation = get_server_implementation(cursor)
+    server_version = get_server_version(cursor)
+
+    mysql = MySQL_Binlog_Info(module, cursor, server_implementation, server_version)
+
+    module.exit_json(changed=False, **mysql.get_info(filter_))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_binlog_info.py
+++ b/plugins/modules/mysql_binlog_info.py
@@ -28,13 +28,12 @@ options:
   filter:
     description:
       - Limit the collected information by comma separated string or YAML list.
-      - Allowable values are C(current), C(logs), C(totals), and C(settings).
+      - Allowable values are V(current), V(logs), V(totals), and V(settings).
       - By default, collects all subsets.
-      - You can use C(!) before a value, for example C(!settings), to exclude it from the information.
+      - You can use C(!) before a value, for example V(!settings), to exclude it from the information.
       - If you pass including and excluding values together, the excluding values are ignored.
     type: list
     elements: str
-    version_added: '5.1.0'
 
 notes:
   - Compatible with MariaDB or MySQL.

--- a/plugins/modules/mysql_binlog_info.py
+++ b/plugins/modules/mysql_binlog_info.py
@@ -38,6 +38,7 @@ options:
 notes:
   - Compatible with MariaDB or MySQL.
   - The module does not modify server state.
+  - The module requires binary logging to be enabled and fails when C(log_bin=OFF).
   - Some mutable binlog settings are dynamic and can be managed with M(ansible.mysql.mysql_variables).
   - Startup-only or restart-managed settings remain outside this module's scope.
 
@@ -163,6 +164,7 @@ class MySQL_Binlog_Info(object):
 
     def get_info(self, filter_):
         wanted = set(self.__get_wanted(filter_))
+        self.__ensure_binary_logging_enabled()
         self.__collect(wanted)
         return dict((key, self.info[key]) for key in self.info if key in wanted)
 
@@ -203,6 +205,17 @@ class MySQL_Binlog_Info(object):
 
         if 'settings' in wanted:
             self.__get_settings()
+
+    def __ensure_binary_logging_enabled(self):
+        res = self.__exec_sql("SHOW GLOBAL VARIABLES LIKE 'log_bin'")
+        if not res:
+            return
+
+        log_bin = res[0].get('Value')
+        if str(log_bin).upper() in ('OFF', '0'):
+            self.module.fail_json(
+                msg='Binary logging is disabled (log_bin=OFF), mysql_binlog_info cannot be used.'
+            )
 
     def __get_current_status(self):
         query = self.command_resolver.resolve_command("SHOW MASTER STATUS")

--- a/tests/integration/targets/test_mysql_binlog_info/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_binlog_info/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for test_mysql_binlog_info
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_binlog_info/meta/main.yml
+++ b/tests/integration/targets/test_mysql_binlog_info/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_binlog_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_binlog_info/tasks/main.yml
@@ -2,7 +2,7 @@
 
 # Test code for mysql_binlog_info module #
 
-- name: mysql_binlog_info | Run integration checks
+- name: MySQL binlog info | Run integration checks
   vars:
     mysql_parameters: &mysql_params
       login_user: "{{ mysql_user }}"
@@ -96,3 +96,4 @@
           - filtered_result.totals is defined
           - filtered_result.current is not defined
           - filtered_result.settings is not defined
+

--- a/tests/integration/targets/test_mysql_binlog_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_binlog_info/tasks/main.yml
@@ -1,0 +1,98 @@
+---
+
+# Test code for mysql_binlog_info module #
+
+- name: mysql_binlog_info | Run integration checks
+  vars:
+    mysql_parameters: &mysql_params
+      login_user: "{{ mysql_user }}"
+      login_password: "{{ mysql_password }}"
+      login_host: "{{ mysql_host }}"
+      login_port: "{{ mysql_primary_port }}"
+
+  block:
+    - name: Collect binlog info in check mode
+      check_mode: true
+      ansible.mysql.mysql_binlog_info:
+        <<: *mysql_params
+      register: check_result
+
+    - name: Assert check mode result
+      ansible.builtin.assert:
+        that:
+          - check_result is not changed
+          - check_result.current.file is defined
+          - check_result.current.position | int > 0
+          - check_result.logs | length > 0
+          - check_result.totals.count == check_result.logs | length
+          - check_result.totals.size | int > 0
+          - check_result.settings.binlog_format is defined
+
+    - name: Collect binlog info
+      ansible.mysql.mysql_binlog_info:
+        <<: *mysql_params
+      register: result
+
+    - name: Assert normal result
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.current.file is defined
+          - result.current.position | int > 0
+          - result.logs | length > 0
+          - result.totals.count == result.logs | length
+          - result.totals.size | int > 0
+          - result.settings.binlog_format is defined
+
+    - name: Get primary status through mysql_replication for comparison
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        mode: getprimary
+      register: primary_status
+
+    - name: Assert current status matches mysql_replication output
+      ansible.builtin.assert:
+        that:
+          - result.current.file == primary_status.File
+          - result.current.position == primary_status.Position
+
+    - name: Query MariaDB GTID binlog position directly
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: "SELECT @@global.gtid_binlog_pos AS gtid_binlog_pos"
+      register: mariadb_gtid
+      when: db_engine == 'mariadb'
+
+    - name: Assert current GTID matches MariaDB global GTID binlog position
+      ansible.builtin.assert:
+        that:
+          - result.current.executed_gtid_set == mariadb_gtid.query_result[0][0].gtid_binlog_pos
+      when: db_engine == 'mariadb'
+
+    - name: Query binary logs directly
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: "SHOW BINARY LOGS"
+      register: log_query
+
+    - name: Assert log count matches direct query
+      ansible.builtin.assert:
+        that:
+          - result.logs | length == log_query.query_result[0] | length
+
+    - name: Collect only logs and totals
+      ansible.mysql.mysql_binlog_info:
+        <<: *mysql_params
+        filter:
+          - logs
+          - totals
+      register: filtered_result
+
+    - name: Assert filtered output
+      ansible.builtin.assert:
+        that:
+          - filtered_result is not changed
+          - filtered_result.logs is defined
+          - filtered_result.totals is defined
+          - filtered_result.current is not defined
+          - filtered_result.settings is not defined

--- a/tests/integration/targets/test_mysql_binlog_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_binlog_info/tasks/main.yml
@@ -96,4 +96,3 @@
           - filtered_result.totals is defined
           - filtered_result.current is not defined
           - filtered_result.settings is not defined
-

--- a/tests/unit/plugins/modules/test_mysql_binlog_info.py
+++ b/tests/unit/plugins/modules/test_mysql_binlog_info.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+from ansible_collections.ansible.mysql.plugins.modules.mysql_binlog_info import MySQL_Binlog_Info
+
+
+def test_get_info_returns_requested_subsets_with_normalized_totals():
+    query_results = {
+        'SHOW BINARY LOG STATUS': [
+            {'File': 'binlog.000003', 'Position': '456', 'Executed_Gtid_Set': 'uuid:1-9'}
+        ],
+        'SHOW BINARY LOGS': [
+            {'Log_name': 'binlog.000001', 'File_size': '123', 'Encrypted': 'No'},
+            {'Log_name': 'binlog.000002', 'File_size': '456', 'Encrypted': 'Yes'},
+        ],
+    }
+
+    cursor = MagicMock()
+
+    def execute_side_effect(query):
+        cursor.fetchall.return_value = query_results[query]
+
+    cursor.execute.side_effect = execute_side_effect
+
+    info = MySQL_Binlog_Info(MagicMock(), cursor, 'mysql', '8.4.9')
+
+    result = info.get_info(['current', 'logs', 'totals'])
+
+    assert result == {
+        'current': {
+            'file': 'binlog.000003',
+            'position': 456,
+            'executed_gtid_set': 'uuid:1-9',
+        },
+        'logs': [
+            {'name': 'binlog.000001', 'size': 123, 'encrypted': 'No'},
+            {'name': 'binlog.000002', 'size': 456, 'encrypted': 'Yes'},
+        ],
+        'totals': {
+            'count': 2,
+            'size': 579,
+        },
+    }
+
+
+def test_get_info_settings_returns_only_binlog_related_variables():
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [
+        {'Variable_name': 'log_bin', 'Value': 'ON'},
+        {'Variable_name': 'binlog_format', 'Value': 'ROW'},
+        {'Variable_name': 'max_binlog_size', 'Value': '1048576'},
+        {'Variable_name': 'sync_binlog', 'Value': '1'},
+        {'Variable_name': 'version', 'Value': '8.4.9'},
+    ]
+
+    info = MySQL_Binlog_Info(MagicMock(), cursor, 'mysql', '8.4.9')
+
+    result = info.get_info(['settings'])
+
+    cursor.execute.assert_called_once_with('SHOW GLOBAL VARIABLES')
+    assert result == {
+        'settings': {
+            'log_bin': 'ON',
+            'binlog_format': 'ROW',
+            'max_binlog_size': 1048576,
+            'sync_binlog': 1,
+        },
+    }
+
+
+def test_get_info_uses_mariadb_gtid_fallback_when_missing_from_status():
+    query_results = {
+        'SHOW BINLOG STATUS': [
+            {'File': 'mariadb-bin.000001', 'Position': '789'}
+        ],
+        'SELECT @@global.gtid_binlog_pos AS gtid_binlog_pos': [
+            {'gtid_binlog_pos': '0-1-2'}
+        ],
+    }
+
+    cursor = MagicMock()
+
+    def execute_side_effect(query):
+        cursor.fetchall.return_value = query_results[query]
+
+    cursor.execute.side_effect = execute_side_effect
+
+    info = MySQL_Binlog_Info(MagicMock(), cursor, 'mariadb', '10.11.8')
+
+    result = info.get_info(['current'])
+
+    assert result == {
+        'current': {
+            'file': 'mariadb-bin.000001',
+            'position': 789,
+            'executed_gtid_set': '0-1-2',
+        },
+    }
+
+
+def test_get_info_exclusion_filter_omits_requested_subset():
+    query_results = {
+        'SHOW BINARY LOG STATUS': [
+            {'File': 'binlog.000003', 'Position': '456', 'Executed_Gtid_Set': 'uuid:1-9'}
+        ],
+        'SHOW BINARY LOGS': [
+            {'Log_name': 'binlog.000001', 'File_size': '123', 'Encrypted': 'No'},
+        ],
+    }
+
+    cursor = MagicMock()
+
+    def execute_side_effect(query):
+        cursor.fetchall.return_value = query_results[query]
+
+    cursor.execute.side_effect = execute_side_effect
+
+    info = MySQL_Binlog_Info(MagicMock(), cursor, 'mysql', '8.4.9')
+
+    result = info.get_info(['!settings'])
+
+    assert result == {
+        'current': {
+            'file': 'binlog.000003',
+            'position': 456,
+            'executed_gtid_set': 'uuid:1-9',
+        },
+        'logs': [
+            {'name': 'binlog.000001', 'size': 123, 'encrypted': 'No'},
+        ],
+        'totals': {
+            'count': 1,
+            'size': 123,
+        },
+    }

--- a/tests/unit/plugins/modules/test_mysql_binlog_info.py
+++ b/tests/unit/plugins/modules/test_mysql_binlog_info.py
@@ -3,6 +3,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import pytest
+
 try:
     from unittest.mock import MagicMock
 except ImportError:
@@ -13,6 +15,9 @@ from ansible_collections.ansible.mysql.plugins.modules.mysql_binlog_info import 
 
 def test_get_info_returns_requested_subsets_with_normalized_totals():
     query_results = {
+        "SHOW GLOBAL VARIABLES LIKE 'log_bin'": [
+            {'Variable_name': 'log_bin', 'Value': 'ON'}
+        ],
         'SHOW BINARY LOG STATUS': [
             {'File': 'binlog.000003', 'Position': '456', 'Executed_Gtid_Set': 'uuid:1-9'}
         ],
@@ -52,19 +57,30 @@ def test_get_info_returns_requested_subsets_with_normalized_totals():
 
 def test_get_info_settings_returns_only_binlog_related_variables():
     cursor = MagicMock()
-    cursor.fetchall.return_value = [
-        {'Variable_name': 'log_bin', 'Value': 'ON'},
-        {'Variable_name': 'binlog_format', 'Value': 'ROW'},
-        {'Variable_name': 'max_binlog_size', 'Value': '1048576'},
-        {'Variable_name': 'sync_binlog', 'Value': '1'},
-        {'Variable_name': 'version', 'Value': '8.4.9'},
-    ]
+    query_results = {
+        "SHOW GLOBAL VARIABLES LIKE 'log_bin'": [
+            {'Variable_name': 'log_bin', 'Value': 'ON'},
+        ],
+        'SHOW GLOBAL VARIABLES': [
+            {'Variable_name': 'log_bin', 'Value': 'ON'},
+            {'Variable_name': 'binlog_format', 'Value': 'ROW'},
+            {'Variable_name': 'max_binlog_size', 'Value': '1048576'},
+            {'Variable_name': 'sync_binlog', 'Value': '1'},
+            {'Variable_name': 'version', 'Value': '8.4.9'},
+        ],
+    }
+
+    def execute_side_effect(query):
+        cursor.fetchall.return_value = query_results[query]
+
+    cursor.execute.side_effect = execute_side_effect
 
     info = MySQL_Binlog_Info(MagicMock(), cursor, 'mysql', '8.4.9')
 
     result = info.get_info(['settings'])
 
-    cursor.execute.assert_called_once_with('SHOW GLOBAL VARIABLES')
+    assert cursor.execute.call_args_list[0].args == ("SHOW GLOBAL VARIABLES LIKE 'log_bin'",)
+    assert cursor.execute.call_args_list[1].args == ('SHOW GLOBAL VARIABLES',)
     assert result == {
         'settings': {
             'log_bin': 'ON',
@@ -77,6 +93,9 @@ def test_get_info_settings_returns_only_binlog_related_variables():
 
 def test_get_info_uses_mariadb_gtid_fallback_when_missing_from_status():
     query_results = {
+        "SHOW GLOBAL VARIABLES LIKE 'log_bin'": [
+            {'Variable_name': 'log_bin', 'Value': 'ON'}
+        ],
         'SHOW BINLOG STATUS': [
             {'File': 'mariadb-bin.000001', 'Position': '789'}
         ],
@@ -107,6 +126,9 @@ def test_get_info_uses_mariadb_gtid_fallback_when_missing_from_status():
 
 def test_get_info_exclusion_filter_omits_requested_subset():
     query_results = {
+        "SHOW GLOBAL VARIABLES LIKE 'log_bin'": [
+            {'Variable_name': 'log_bin', 'Value': 'ON'}
+        ],
         'SHOW BINARY LOG STATUS': [
             {'File': 'binlog.000003', 'Position': '456', 'Executed_Gtid_Set': 'uuid:1-9'}
         ],
@@ -140,3 +162,22 @@ def test_get_info_exclusion_filter_omits_requested_subset():
             'size': 123,
         },
     }
+
+
+def test_get_info_fails_when_binary_logging_is_disabled():
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [
+        {'Variable_name': 'log_bin', 'Value': 'OFF'},
+    ]
+
+    module = MagicMock()
+    module.fail_json.side_effect = RuntimeError
+
+    info = MySQL_Binlog_Info(module, cursor, 'mysql', '8.4.9')
+
+    with pytest.raises(RuntimeError):
+        info.get_info(['settings'])
+
+    module.fail_json.assert_called_once_with(
+        msg='Binary logging is disabled (log_bin=OFF), mysql_binlog_info cannot be used.'
+    )

--- a/tests/unit/plugins/modules/test_mysql_binlog_info.py
+++ b/tests/unit/plugins/modules/test_mysql_binlog_info.py
@@ -79,8 +79,8 @@ def test_get_info_settings_returns_only_binlog_related_variables():
 
     result = info.get_info(['settings'])
 
-    assert cursor.execute.call_args_list[0].args == ("SHOW GLOBAL VARIABLES LIKE 'log_bin'",)
-    assert cursor.execute.call_args_list[1].args == ('SHOW GLOBAL VARIABLES',)
+    assert cursor.execute.call_args_list[0][0] == ("SHOW GLOBAL VARIABLES LIKE 'log_bin'",)
+    assert cursor.execute.call_args_list[1][0] == ('SHOW GLOBAL VARIABLES',)
     assert result == {
         'settings': {
             'log_bin': 'ON',


### PR DESCRIPTION
#### SUMMARY
- add a new read-only `mysql_binlog_info` module for inspecting binary log status, files, totals, and selected binlog settings
- normalize current binlog status across MySQL and MariaDB, including MariaDB GTID fallback behavior

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- `TESTING.md`
- `meta/runtime.yml`
- `plugins/modules/mysql_binlog_info.py`
- `tests/integration/targets/test_mysql_binlog_info/defaults/main.yml`
- `tests/integration/targets/test_mysql_binlog_info/meta/main.yml`
- `tests/integration/targets/test_mysql_binlog_info/tasks/main.yml`
- `tests/unit/plugins/modules/test_mysql_binlog_info.py`

#### ADDITIONAL INFORMATION
- the module is intentionally read-only; mutable binlog settings remain with `mysql_variables`
- Code was created with the help for GPT5.4 using Cursor with Human in the loop and manual tests.
- Impleemnts #803 partially