### PR TITLE
feat(mysql_clone): add mysql clone module

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Every voice is important and every idea is valuable. If you have something on yo
 ## Included content
 
 - **Modules**:
+  - [mysql_clone](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_clone_module.html)
   - [mysql_db](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_db_module.html)
   - [mysql_info](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_info_module.html)
   - [mysql_query](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_query_module.html)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -2,6 +2,7 @@
 requires_ansible: '>=2.16.0'
 action_groups:
   all:
+    - mysql_clone
     - mysql_db
     - mysql_binlog_info
     - mysql_info

--- a/plugins/modules/mysql_clone.py
+++ b/plugins/modules/mysql_clone.py
@@ -41,6 +41,7 @@ options:
   donor_password:
     description:
     - Password used by the recipient to connect to the donor for clone.
+    - The password is sent to MySQL as part of the C(CLONE INSTANCE FROM ...) statement.
     type: str
     required: true
   require_ssl:
@@ -192,6 +193,19 @@ def get_redacted_query(query, params):
 
 def is_terminal_state(state):
     return state in TERMINAL_STATES
+
+
+def should_wait_after_execute_error(error_message):
+    if error_message is None:
+        return False
+
+    if 'Restart server failed' in error_message:
+        return True
+
+    if error_message.startswith('(3707,'):
+        return True
+
+    return False
 
 
 def _close_connection(cursor, connection):
@@ -361,6 +375,11 @@ def main():
             cursor.execute(query, params)
         except Exception as exc:
             execute_error = to_native(exc)
+            if not should_wait_after_execute_error(execute_error):
+                module.fail_json(
+                    msg='Clone failed to start. %s' % execute_error,
+                    query=redacted_query,
+                )
     finally:
         _close_connection(cursor, connection)
 

--- a/plugins/modules/mysql_clone.py
+++ b/plugins/modules/mysql_clone.py
@@ -79,6 +79,10 @@ attributes:
     details:
       - The module is not idempotent because each successful invocation starts a new clone operation.
 
+seealso:
+  - module: ansible.mysql.mysql_variables
+  - module: ansible.mysql.mysql_replication
+
 extends_documentation_fragment:
 - ansible.mysql.mysql
 '''
@@ -333,8 +337,8 @@ def main():
         supports_check_mode=True,
     )
 
-    if module.params['donor_port'] < 0 or module.params['donor_port'] > 65535:
-        module.fail_json(msg='donor_port must be a valid unix port number (0-65535)')
+    if module.params['donor_port'] < 1 or module.params['donor_port'] > 65535:
+        module.fail_json(msg='donor_port must be a valid unix port number (1-65535)')
 
     if module.params['wait_timeout'] <= 0:
         module.fail_json(msg='wait_timeout must be greater than 0')

--- a/plugins/modules/mysql_clone.py
+++ b/plugins/modules/mysql_clone.py
@@ -22,6 +22,8 @@ description:
 author:
 - Ron Gershburg (@rgershbu)
 
+version_added: '5.1.0'
+
 options:
   donor_host:
     description:

--- a/plugins/modules/mysql_clone.py
+++ b/plugins/modules/mysql_clone.py
@@ -1,0 +1,394 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: mysql_clone
+
+short_description: Clone a MySQL instance from a donor server
+
+description:
+- Starts a MySQL remote clone operation on the recipient server and waits until the clone reaches a terminal state.
+- Validates MySQL Clone plugin prerequisites on the recipient server but does not install or manage the plugin.
+- The module is limited to MySQL Clone plugin behavior and fails on MariaDB.
+
+author:
+- Ron Gershburg (@rgershbu)
+
+options:
+  donor_host:
+    description:
+    - Hostname or IP address of the donor MySQL server.
+    type: str
+    required: true
+  donor_port:
+    description:
+    - TCP port of the donor MySQL server.
+    type: int
+    default: 3306
+  donor_user:
+    description:
+    - User account used by the recipient to connect to the donor for clone.
+    type: str
+    required: true
+  donor_password:
+    description:
+    - Password used by the recipient to connect to the donor for clone.
+    type: str
+    required: true
+  require_ssl:
+    description:
+    - Whether to append C(REQUIRE SSL) or C(REQUIRE NO SSL) to the clone statement.
+    - If omitted, no SSL clause is added and MySQL server defaults apply.
+    type: bool
+  wait_timeout:
+    description:
+    - Maximum number of seconds to wait for the recipient to reconnect and the clone to reach a terminal state.
+    type: int
+    default: 1800
+  poll_interval:
+    description:
+    - Number of seconds to wait between reconnect and status polling attempts.
+    type: int
+    default: 5
+
+notes:
+  - MySQL Clone plugin must already be installed and active on the recipient server.
+  - Recipient-side clone variables such as C(clone_valid_donor_list) must be configured before running the module.
+  - The module is not idempotent. Running it again starts a new clone operation if MySQL accepts it.
+  - In check mode the module validates static prerequisites and reports that clone would be started, but does not execute clone.
+  - MariaDB is not supported. Use backup and replication workflows instead.
+
+attributes:
+  check_mode:
+    support: partial
+    details:
+      - In check mode the module does not start clone, but it still validates static recipient-side prerequisites.
+  idempotent:
+    support: partial
+    details:
+      - The module is not idempotent because each successful invocation starts a new clone operation.
+
+extends_documentation_fragment:
+- ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Configure recipient donor allow-list separately
+  ansible.mysql.mysql_variables:
+    variable: clone_valid_donor_list
+    value: "192.0.2.10:3306"
+    mode: persist
+
+- name: Start clone and wait for completion
+  ansible.mysql.mysql_clone:
+    donor_host: 192.0.2.10
+    donor_port: 3306
+    donor_user: clone_user
+    donor_password: supersecret
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Preview clone action in check mode
+  check_mode: true
+  ansible.mysql.mysql_clone:
+    donor_host: 192.0.2.10
+    donor_user: clone_user
+    donor_password: supersecret
+    login_unix_socket: /run/mysqld/mysqld.sock
+'''
+
+RETURN = r'''
+query:
+  description: Clone statement executed or predicted, with the password redacted.
+  returned: always
+  type: str
+  sample: "CLONE INSTANCE FROM 'clone_user'@'192.0.2.10':3306 IDENTIFIED BY '********'"
+clone_status:
+  description: Final row from C(performance_schema.clone_status) for the current or last clone operation.
+  returned: on success or on clone failure after status was collected
+  type: dict
+clone_progress:
+  description: Rows from C(performance_schema.clone_progress) collected when the clone reaches a terminal state.
+  returned: on success or on clone failure after status was collected
+  type: list
+  elements: dict
+'''
+
+import time
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    get_server_implementation,
+    get_server_version,
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils.version import LooseVersion
+
+
+PLUGIN_QUERY = (
+    "SELECT PLUGIN_STATUS AS plugin_status "
+    "FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'clone'"
+)
+CLONE_STATUS_QUERY = "SELECT * FROM performance_schema.clone_status"
+CLONE_PROGRESS_QUERY = "SELECT * FROM performance_schema.clone_progress"
+TERMINAL_STATES = frozenset(('Completed', 'Failed'))
+
+
+def validate_clone_support(module, server_implementation, server_version):
+    if server_implementation != 'mysql':
+        module.fail_json(msg='MariaDB is not supported by mysql_clone.')
+
+    if LooseVersion(server_version) < LooseVersion('8.0.17'):
+        module.fail_json(msg='mysql_clone requires MySQL 8.0.17 or newer.')
+
+
+def build_clone_query(donor_host, donor_port, donor_user, donor_password, require_ssl=None):
+    query = 'CLONE INSTANCE FROM %s@%s:%s IDENTIFIED BY %s'
+    params = (donor_user, donor_host, donor_port, donor_password)
+
+    if require_ssl is True:
+        query += ' REQUIRE SSL'
+    elif require_ssl is False:
+        query += ' REQUIRE NO SSL'
+
+    return query, params
+
+
+def _quote_sql_value(value):
+    if isinstance(value, bool):
+        return '1' if value else '0'
+
+    if isinstance(value, int):
+        return str(value)
+
+    return "'%s'" % str(value).replace("'", "''")
+
+
+def get_redacted_query(query, params):
+    redacted_params = list(params)
+    if len(redacted_params) >= 4:
+        redacted_params[3] = '********'
+
+    pieces = query.split('%s')
+    formatted = []
+    for idx, piece in enumerate(pieces[:-1]):
+        formatted.append(piece)
+        formatted.append(_quote_sql_value(redacted_params[idx]))
+    formatted.append(pieces[-1])
+    return ''.join(formatted)
+
+
+def is_terminal_state(state):
+    return state in TERMINAL_STATES
+
+
+def _close_connection(cursor, connection):
+    try:
+        if cursor is not None:
+            cursor.close()
+    except Exception:
+        pass
+
+    try:
+        if connection is not None:
+            connection.close()
+    except Exception:
+        pass
+
+
+def _connect(module):
+    return mysql_connect(
+        module,
+        module.params['login_user'],
+        module.params['login_password'],
+        module.params['config_file'],
+        module.params['client_cert'],
+        module.params['client_key'],
+        module.params['ca_cert'],
+        'mysql',
+        cursor_class='DictCursor',
+        connect_timeout=module.params['connect_timeout'],
+        check_hostname=module.params['check_hostname'],
+    )
+
+
+def ensure_clone_plugin_active(module, cursor):
+    cursor.execute(PLUGIN_QUERY)
+    result = cursor.fetchone()
+    if not result or result.get('plugin_status') != 'ACTIVE':
+        module.fail_json(msg='MySQL Clone plugin is not active on the recipient server.')
+
+
+def validate_donor_allowed(module, cursor, donor_host, donor_port):
+    cursor.execute("SHOW GLOBAL VARIABLES LIKE 'clone_valid_donor_list'")
+    rows = cursor.fetchall()
+    if not rows:
+        module.fail_json(msg='clone_valid_donor_list is not available on the recipient server.')
+
+    allowed_value = rows[0].get('Value') or ''
+    allowed_donors = [item.strip() for item in allowed_value.split(',') if item.strip()]
+    donor = '%s:%s' % (donor_host, donor_port)
+    if donor not in allowed_donors:
+        module.fail_json(msg='Recipient clone_valid_donor_list must contain %s.' % donor)
+
+
+def fetch_clone_status(cursor):
+    cursor.execute(CLONE_STATUS_QUERY)
+    rows = cursor.fetchall()
+    if not rows:
+        return None
+    return dict(rows[0])
+
+
+def fetch_clone_progress(cursor):
+    cursor.execute(CLONE_PROGRESS_QUERY)
+    return [dict(row) for row in cursor.fetchall()]
+
+
+def ensure_clone_not_running(module, status):
+    if status and status.get('STATE') == 'In Progress':
+        module.fail_json(msg='A clone operation is already in progress on the recipient server.')
+
+
+def wait_for_clone_completion(module, execute_error=None):
+    timeout_at = time.time() + module.params['wait_timeout']
+    last_status = None
+    last_progress = []
+    last_error = None
+
+    while time.time() <= timeout_at:
+        cursor = None
+        connection = None
+        try:
+            cursor, connection = _connect(module)
+            last_status = fetch_clone_status(cursor)
+            last_progress = fetch_clone_progress(cursor)
+            if last_status and is_terminal_state(last_status.get('STATE')):
+                return last_status, last_progress
+        except Exception as exc:
+            last_error = to_native(exc)
+        finally:
+            _close_connection(cursor, connection)
+
+        time.sleep(module.params['poll_interval'])
+
+    if last_status is not None:
+        module.fail_json(
+            msg='Timed out while waiting for clone to reach a terminal state.',
+            clone_status=last_status,
+            clone_progress=last_progress,
+        )
+
+    if last_error is not None:
+        message = 'Timed out while reconnecting to the recipient server: %s' % last_error
+        if execute_error:
+            message += ' Original clone execution result: %s' % execute_error
+        module.fail_json(msg=message)
+
+    module.fail_json(msg='Timed out while waiting for clone status to become available.')
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        donor_host=dict(type='str', required=True),
+        donor_port=dict(type='int', default=3306),
+        donor_user=dict(type='str', required=True),
+        donor_password=dict(type='str', required=True, no_log=True),
+        require_ssl=dict(type='bool', default=None),
+        wait_timeout=dict(type='int', default=1800),
+        poll_interval=dict(type='int', default=5),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    if module.params['donor_port'] < 0 or module.params['donor_port'] > 65535:
+        module.fail_json(msg='donor_port must be a valid unix port number (0-65535)')
+
+    if module.params['wait_timeout'] <= 0:
+        module.fail_json(msg='wait_timeout must be greater than 0')
+
+    if module.params['poll_interval'] <= 0:
+        module.fail_json(msg='poll_interval must be greater than 0')
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    query, params = build_clone_query(
+        module.params['donor_host'],
+        module.params['donor_port'],
+        module.params['donor_user'],
+        module.params['donor_password'],
+        module.params['require_ssl'],
+    )
+    redacted_query = get_redacted_query(query, params)
+
+    cursor = None
+    connection = None
+    try:
+        cursor, connection = _connect(module)
+        server_implementation = get_server_implementation(cursor)
+        server_version = get_server_version(cursor)
+        validate_clone_support(module, server_implementation, server_version)
+        ensure_clone_plugin_active(module, cursor)
+        validate_donor_allowed(module, cursor, module.params['donor_host'], module.params['donor_port'])
+        ensure_clone_not_running(module, fetch_clone_status(cursor))
+
+        if module.check_mode:
+            module.exit_json(
+                changed=True,
+                query=redacted_query,
+                msg='Clone would be started.',
+            )
+
+        execute_error = None
+        try:
+            cursor.execute(query, params)
+        except Exception as exc:
+            execute_error = to_native(exc)
+    finally:
+        _close_connection(cursor, connection)
+
+    status, progress = wait_for_clone_completion(module, execute_error=execute_error)
+    state = status.get('STATE')
+
+    if state == 'Completed':
+        module.exit_json(
+            changed=True,
+            msg='Clone completed successfully.',
+            query=redacted_query,
+            clone_status=status,
+            clone_progress=progress,
+        )
+
+    message = 'Clone failed.'
+    if status.get('ERROR_MESSAGE'):
+        message = '%s %s' % (message, status['ERROR_MESSAGE'])
+    elif execute_error:
+        message = '%s %s' % (message, execute_error)
+
+    module.fail_json(
+        msg=message.strip(),
+        query=redacted_query,
+        clone_status=status,
+        clone_progress=progress,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/test_mysql_clone/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_clone/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# defaults file for test_mysql_clone
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307
+mysql_replica1_port: 3308
+
+clone_test_db: clone_test_db
+clone_test_table: clone_test_table
+clone_test_value: clone-finished
+clone_user_name: clone_user
+clone_user_password: clone-password-123

--- a/tests/integration/targets/test_mysql_clone/meta/main.yml
+++ b/tests/integration/targets/test_mysql_clone/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_clone/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_clone/tasks/main.yml
@@ -187,6 +187,25 @@
           - clone_preview is changed
           - clone_preview.msg == 'Clone would be started.'
           - "'********' in clone_preview.query"
+          - "'REQUIRE SSL' not in clone_preview.query"
+          - "'REQUIRE NO SSL' not in clone_preview.query"
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Verify recipient database is unchanged after check mode
+      ansible.mysql.mysql_query:
+        <<: *standalone_params
+        query: "SHOW DATABASES LIKE '{{ clone_test_db }}'"
+      register: standalone_check_mode_db
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Assert recipient database is absent after check mode
+      ansible.builtin.assert:
+        that:
+          - standalone_check_mode_db.query_result[0] | length == 0
       when:
         - db_engine == 'mysql'
         - clone_plugin_ready | default(false) | bool
@@ -198,6 +217,7 @@
         donor_port: '{{ mysql_primary_port }}'
         donor_user: '{{ clone_user_name }}'
         donor_password: '{{ clone_user_password }}'
+        require_ssl: true
         wait_timeout: 300
         poll_interval: 2
       register: clone_result
@@ -212,6 +232,9 @@
           - clone_result is changed
           - clone_result.clone_status.STATE == 'Completed'
           - clone_result.clone_progress | length > 0
+          - "'REQUIRE SSL' in clone_result.query"
+          - "'STAGE' in clone_result.clone_progress[0]"
+          - "'STATE' in clone_result.clone_progress[0]"
           - clone_result.msg == 'Clone completed successfully.'
       when:
         - db_engine == 'mysql'
@@ -230,6 +253,53 @@
       ansible.builtin.assert:
         that:
           - standalone_cloned_data.query_result[0][0].value == clone_test_value
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Re-run clone to confirm non-idempotent behavior
+      ansible.mysql.mysql_clone:
+        <<: *standalone_params
+        donor_host: '{{ mysql_host }}'
+        donor_port: '{{ mysql_primary_port }}'
+        donor_user: '{{ clone_user_name }}'
+        donor_password: '{{ clone_user_password }}'
+        require_ssl: true
+        wait_timeout: 300
+        poll_interval: 2
+      register: clone_rerun_result
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Assert clone rerun result
+      ansible.builtin.assert:
+        that:
+          - clone_rerun_result is succeeded
+          - clone_rerun_result is changed
+          - clone_rerun_result.clone_status.STATE == 'Completed'
+          - clone_rerun_result.clone_progress | length > 0
+          - "'REQUIRE SSL' in clone_rerun_result.query"
+          - "'STAGE' in clone_rerun_result.clone_progress[0]"
+          - "'STATE' in clone_rerun_result.clone_progress[0]"
+          - clone_rerun_result.msg == 'Clone completed successfully.'
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Verify cloned data still exists after rerun
+      ansible.mysql.mysql_query:
+        <<: *standalone_params
+        query: "SELECT value FROM {{ clone_test_db }}.{{ clone_test_table }}"
+      register: standalone_cloned_data_after_rerun
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Assert cloned row exists after rerun
+      ansible.builtin.assert:
+        that:
+          - standalone_cloned_data_after_rerun.query_result[0][0].value == clone_test_value
       when:
         - db_engine == 'mysql'
         - clone_plugin_ready | default(false) | bool

--- a/tests/integration/targets/test_mysql_clone/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_clone/tasks/main.yml
@@ -1,0 +1,235 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: MySQL clone | Run integration checks
+  vars:
+    primary_params: &primary_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+    standalone_bootstrap_params: &standalone_bootstrap_params
+      login_user: root
+      login_unix_socket: '{{ standalone_socket }}'
+      config_file: ''
+    standalone_params: &standalone_params
+      login_user: root
+      login_password: '{{ mysql_password }}'
+      login_unix_socket: '{{ standalone_socket }}'
+      config_file: ''
+    clone_plugin_query: "SELECT PLUGIN_STATUS AS plugin_status FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'clone'"
+  block:
+    - name: MySQL clone | Assert MariaDB unsupported
+      ansible.mysql.mysql_clone:
+        <<: *primary_params
+        donor_host: '{{ mysql_host }}'
+        donor_port: '{{ mysql_primary_port }}'
+        donor_user: '{{ clone_user_name }}'
+        donor_password: '{{ clone_user_password }}'
+      register: result
+      ignore_errors: true
+      when: db_engine == 'mariadb'
+
+    - name: MySQL clone | Assert MariaDB failure message
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - result.msg == 'MariaDB is not supported by mysql_clone.'
+      when: db_engine == 'mariadb'
+
+    - name: MySQL clone | Prepare donor dataset
+      ansible.mysql.mysql_query:
+        <<: *primary_params
+        query:
+          - "DROP DATABASE IF EXISTS {{ clone_test_db }}"
+          - "CREATE DATABASE {{ clone_test_db }}"
+          - "CREATE TABLE {{ clone_test_db }}.{{ clone_test_table }} (value VARCHAR(64))"
+          - "INSERT INTO {{ clone_test_db }}.{{ clone_test_table }} VALUES ('{{ clone_test_value }}')"
+      when: db_engine == 'mysql'
+
+    - name: MySQL clone | Check clone plugin on primary
+      ansible.mysql.mysql_query:
+        <<: *primary_params
+        query: "{{ clone_plugin_query }}"
+      register: primary_clone_plugin
+      when: db_engine == 'mysql'
+
+    - name: MySQL clone | Set standalone recipient variables
+      ansible.builtin.set_fact:
+        standalone_server_package: mysql-server
+        standalone_service_name: mysql
+        standalone_socket: /var/run/mysqld/mysqld.sock
+      when: db_engine == 'mysql'
+
+    - name: MySQL clone | Install standalone recipient package
+      ansible.builtin.apt:
+        name: '{{ standalone_server_package }}'
+        state: present
+      when: db_engine == 'mysql'
+
+    - name: MySQL clone | Ensure standalone recipient service is started
+      ansible.builtin.service:
+        name: '{{ standalone_service_name }}'
+        state: started
+      when: db_engine == 'mysql'
+
+    - name: MySQL clone | Wait for standalone recipient socket
+      ansible.builtin.wait_for:
+        path: '{{ standalone_socket }}'
+        state: present
+        timeout: 60
+      when: db_engine == 'mysql'
+
+    - name: MySQL clone | Bootstrap standalone root password to match donor
+      ansible.mysql.mysql_query:
+        <<: *standalone_bootstrap_params
+        query: "ALTER USER IF EXISTS 'root'@'localhost' IDENTIFIED BY '{{ mysql_password }}'"
+      when: db_engine == 'mysql'
+
+    - name: MySQL clone | Install clone plugin on primary if needed
+      ansible.mysql.mysql_query:
+        <<: *primary_params
+        query: "INSTALL PLUGIN clone SONAME 'mysql_clone.so'"
+      register: primary_clone_plugin_install
+      ignore_errors: true
+      when:
+        - db_engine == 'mysql'
+        - primary_clone_plugin.query_result[0] | length == 0
+
+    - name: MySQL clone | Re-check clone plugin on primary
+      ansible.mysql.mysql_query:
+        <<: *primary_params
+        query: "{{ clone_plugin_query }}"
+      register: primary_clone_plugin
+      when: db_engine == 'mysql'
+
+    - name: MySQL clone | Check clone plugin on standalone recipient
+      ansible.mysql.mysql_query:
+        <<: *standalone_params
+        query: "{{ clone_plugin_query }}"
+      register: standalone_clone_plugin
+      when: db_engine == 'mysql'
+
+    - name: MySQL clone | Install clone plugin on standalone recipient if needed
+      ansible.mysql.mysql_query:
+        <<: *standalone_params
+        query: "INSTALL PLUGIN clone SONAME 'mysql_clone.so'"
+      register: standalone_clone_plugin_install
+      ignore_errors: true
+      when:
+        - db_engine == 'mysql'
+        - standalone_clone_plugin.query_result[0] | length == 0
+
+    - name: MySQL clone | Re-check clone plugin on standalone recipient
+      ansible.mysql.mysql_query:
+        <<: *standalone_params
+        query: "{{ clone_plugin_query }}"
+      register: standalone_clone_plugin
+      when: db_engine == 'mysql'
+
+    - name: MySQL clone | Determine if clone plugin is active on donor and recipient
+      ansible.builtin.set_fact:
+        clone_plugin_ready: >-
+          {{
+            primary_clone_plugin.query_result[0] | length == 1 and
+            primary_clone_plugin.query_result[0][0].plugin_status == 'ACTIVE' and
+            standalone_clone_plugin.query_result[0] | length == 1 and
+            standalone_clone_plugin.query_result[0][0].plugin_status == 'ACTIVE'
+          }}
+      when: db_engine == 'mysql'
+
+    - name: MySQL clone | Create donor clone user
+      ansible.mysql.mysql_query:
+        <<: *primary_params
+        query:
+          - >-
+            CREATE USER IF NOT EXISTS
+            '{{ clone_user_name }}'@'%'
+            IDENTIFIED BY '{{ clone_user_password }}'
+          - >-
+            GRANT BACKUP_ADMIN ON *.*
+            TO '{{ clone_user_name }}'@'%'
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Configure recipient donor allow-list
+      ansible.mysql.mysql_variables:
+        <<: *standalone_params
+        variable: clone_valid_donor_list
+        value: '{{ mysql_host }}:{{ mysql_primary_port }}'
+        mode: persist
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Preview clone in check mode
+      check_mode: true
+      ansible.mysql.mysql_clone:
+        <<: *standalone_params
+        donor_host: '{{ mysql_host }}'
+        donor_port: '{{ mysql_primary_port }}'
+        donor_user: '{{ clone_user_name }}'
+        donor_password: '{{ clone_user_password }}'
+        wait_timeout: 300
+        poll_interval: 2
+      register: clone_preview
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Assert check mode result
+      ansible.builtin.assert:
+        that:
+          - clone_preview is changed
+          - clone_preview.msg == 'Clone would be started.'
+          - "'********' in clone_preview.query"
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Run clone and wait for completion
+      ansible.mysql.mysql_clone:
+        <<: *standalone_params
+        donor_host: '{{ mysql_host }}'
+        donor_port: '{{ mysql_primary_port }}'
+        donor_user: '{{ clone_user_name }}'
+        donor_password: '{{ clone_user_password }}'
+        wait_timeout: 300
+        poll_interval: 2
+      register: clone_result
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Assert completed clone result
+      ansible.builtin.assert:
+        that:
+          - clone_result is succeeded
+          - clone_result is changed
+          - clone_result.clone_status.STATE == 'Completed'
+          - clone_result.clone_progress | length > 0
+          - clone_result.msg == 'Clone completed successfully.'
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Verify cloned data on standalone recipient
+      ansible.mysql.mysql_query:
+        <<: *standalone_params
+        query: "SELECT value FROM {{ clone_test_db }}.{{ clone_test_table }}"
+      register: standalone_cloned_data
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool
+
+    - name: MySQL clone | Assert cloned row exists
+      ansible.builtin.assert:
+        that:
+          - standalone_cloned_data.query_result[0][0].value == clone_test_value
+      when:
+        - db_engine == 'mysql'
+        - clone_plugin_ready | default(false) | bool

--- a/tests/unit/plugins/modules/test_mysql_clone.py
+++ b/tests/unit/plugins/modules/test_mysql_clone.py
@@ -12,6 +12,7 @@ from ansible_collections.ansible.mysql.plugins.modules.mysql_clone import (
     get_redacted_query,
     is_terminal_state,
     main,
+    should_wait_after_execute_error,
     validate_donor_allowed,
     validate_clone_support,
     wait_for_clone_completion,
@@ -41,8 +42,8 @@ class DummyCursor(object):
         self.fetchall_results = list(fetchall_results or [])
         self.executed = []
 
-    def execute(self, query):
-        self.executed.append(query)
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
 
     def fetchone(self):
         if self.fetchone_results:
@@ -61,6 +62,17 @@ class DummyCursor(object):
 class DummyConnection(object):
     def close(self):
         return None
+
+
+class FailingCloneCursor(DummyCursor):
+    def __init__(self, error_message):
+        super(FailingCloneCursor, self).__init__()
+        self.error_message = error_message
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+        if query.startswith('CLONE INSTANCE FROM'):
+            raise RuntimeError(self.error_message)
 
 
 @pytest.mark.parametrize(
@@ -124,6 +136,19 @@ def test_get_redacted_query_masks_password():
 )
 def test_is_terminal_state(state, output):
     assert is_terminal_state(state) is output
+
+
+@pytest.mark.parametrize(
+    'error_message,output',
+    [
+        ("(3707, 'Restart server failed (mysqld is not managed by supervisor process).')", True),
+        ("(1045, 'Access denied for user')", False),
+        ('syntax error near CLONE', False),
+        (None, False),
+    ]
+)
+def test_should_wait_after_execute_error(error_message, output):
+    assert should_wait_after_execute_error(error_message) is output
 
 
 def test_ensure_clone_plugin_active_fails_when_plugin_missing():
@@ -270,3 +295,135 @@ def test_main_returns_predictive_result_in_check_mode(monkeypatch):
     assert result['query'] == (
         "CLONE INSTANCE FROM 'clone_user'@'192.0.2.10':3307 IDENTIFIED BY '********' REQUIRE SSL"
     )
+
+
+def test_main_fails_immediately_for_fatal_execute_error(monkeypatch):
+    module = DummyModule()
+    module.params.update({
+        'login_user': 'root',
+        'login_password': 'secret',
+        'config_file': '~/.my.cnf',
+        'client_cert': None,
+        'client_key': None,
+        'ca_cert': None,
+        'check_hostname': None,
+        'connect_timeout': 30,
+        'wait_timeout': 30,
+        'poll_interval': 5,
+        'donor_host': '192.0.2.10',
+        'donor_port': 3307,
+        'donor_user': 'clone_user',
+        'donor_password': 'supersecret',
+        'require_ssl': None,
+    })
+    cursor = FailingCloneCursor("(1045, 'Access denied for user')")
+    connection = DummyConnection()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone._connect',
+        lambda _module: (cursor, connection),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_implementation',
+        lambda _cursor: 'mysql',
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_version',
+        lambda _cursor: '8.0.17',
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.ensure_clone_plugin_active',
+        lambda _module, _cursor: None,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.validate_donor_allowed',
+        lambda _module, _cursor, _host, _port: None,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.ensure_clone_not_running',
+        lambda _module, _status: None,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.wait_for_clone_completion',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError('wait should not be called')),
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == "Clone failed to start. (1045, 'Access denied for user')"
+
+
+def test_main_waits_after_expected_restart_error(monkeypatch):
+    module = DummyModule()
+    module.params.update({
+        'login_user': 'root',
+        'login_password': 'secret',
+        'config_file': '~/.my.cnf',
+        'client_cert': None,
+        'client_key': None,
+        'ca_cert': None,
+        'check_hostname': None,
+        'connect_timeout': 30,
+        'wait_timeout': 30,
+        'poll_interval': 5,
+        'donor_host': '192.0.2.10',
+        'donor_port': 3307,
+        'donor_user': 'clone_user',
+        'donor_password': 'supersecret',
+        'require_ssl': None,
+    })
+    cursor = FailingCloneCursor("(3707, 'Restart server failed (mysqld is not managed by supervisor process).')")
+    connection = DummyConnection()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone._connect',
+        lambda _module: (cursor, connection),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_implementation',
+        lambda _cursor: 'mysql',
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_version',
+        lambda _cursor: '8.0.17',
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.ensure_clone_plugin_active',
+        lambda _module, _cursor: None,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.validate_donor_allowed',
+        lambda _module, _cursor, _host, _port: None,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.ensure_clone_not_running',
+        lambda _module, _status: None,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.wait_for_clone_completion',
+        lambda *_args, **_kwargs: ({'STATE': 'Completed'}, [{'STAGE': 'RESTART', 'STATE': 'Completed'}]),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+    assert result['msg'] == 'Clone completed successfully.'

--- a/tests/unit/plugins/modules/test_mysql_clone.py
+++ b/tests/unit/plugins/modules/test_mysql_clone.py
@@ -1,0 +1,272 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.ansible.mysql.plugins.modules.mysql_clone import (
+    build_clone_query,
+    ensure_clone_not_running,
+    ensure_clone_plugin_active,
+    get_redacted_query,
+    is_terminal_state,
+    main,
+    validate_donor_allowed,
+    validate_clone_support,
+    wait_for_clone_completion,
+)
+
+
+class DummyModule(object):
+    def __init__(self):
+        self.msg = None
+        self.params = {
+            'wait_timeout': 30,
+            'poll_interval': 0,
+        }
+        self.check_mode = False
+
+    def fail_json(self, msg=None, **kwargs):
+        self.msg = msg
+        raise RuntimeError(msg)
+
+    def exit_json(self, **kwargs):
+        raise SystemExit(kwargs)
+
+
+class DummyCursor(object):
+    def __init__(self, fetchone_results=None, fetchall_results=None):
+        self.fetchone_results = list(fetchone_results or [])
+        self.fetchall_results = list(fetchall_results or [])
+        self.executed = []
+
+    def execute(self, query):
+        self.executed.append(query)
+
+    def fetchone(self):
+        if self.fetchone_results:
+            return self.fetchone_results.pop(0)
+        return None
+
+    def fetchall(self):
+        if self.fetchall_results:
+            return self.fetchall_results.pop(0)
+        return []
+
+    def close(self):
+        return None
+
+
+class DummyConnection(object):
+    def close(self):
+        return None
+
+
+@pytest.mark.parametrize(
+    'server_implementation,server_version,error_message',
+    [
+        ('mariadb', '11.8.7', 'MariaDB is not supported by mysql_clone.'),
+        ('mysql', '8.0.16', 'mysql_clone requires MySQL 8.0.17 or newer.'),
+    ]
+)
+def test_validate_clone_support_fails_for_unsupported_server(server_implementation, server_version, error_message):
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError) as exc:
+        validate_clone_support(module, server_implementation, server_version)
+
+    assert str(exc.value) == error_message
+    assert module.msg == error_message
+
+
+def test_validate_clone_support_accepts_supported_mysql():
+    module = DummyModule()
+
+    validate_clone_support(module, 'mysql', '8.0.17')
+
+
+def test_build_clone_query_returns_expected_sql_and_params():
+    query, params = build_clone_query(
+        donor_host='192.0.2.10',
+        donor_port=3307,
+        donor_user='clone_user',
+        donor_password='secret',
+        require_ssl=True,
+    )
+
+    assert query == 'CLONE INSTANCE FROM %s@%s:%s IDENTIFIED BY %s REQUIRE SSL'
+    assert params == ('clone_user', '192.0.2.10', 3307, 'secret')
+
+
+def test_get_redacted_query_masks_password():
+    query, params = build_clone_query(
+        donor_host='192.0.2.10',
+        donor_port=3307,
+        donor_user='clone_user',
+        donor_password='secret',
+    )
+
+    assert get_redacted_query(query, params) == (
+        "CLONE INSTANCE FROM 'clone_user'@'192.0.2.10':3307 IDENTIFIED BY '********'"
+    )
+
+
+@pytest.mark.parametrize(
+    'state,output',
+    [
+        ('Completed', True),
+        ('Failed', True),
+        ('In Progress', False),
+        ('Not Started', False),
+        (None, False),
+    ]
+)
+def test_is_terminal_state(state, output):
+    assert is_terminal_state(state) is output
+
+
+def test_ensure_clone_plugin_active_fails_when_plugin_missing():
+    module = DummyModule()
+    cursor = DummyCursor(fetchone_results=[None])
+
+    with pytest.raises(RuntimeError) as exc:
+        ensure_clone_plugin_active(module, cursor)
+
+    assert str(exc.value) == 'MySQL Clone plugin is not active on the recipient server.'
+
+
+def test_validate_donor_allowed_accepts_matching_host_and_port():
+    module = DummyModule()
+    cursor = DummyCursor(fetchall_results=[[{'Value': '192.0.2.10:3307,198.51.100.20:3306'}]])
+
+    validate_donor_allowed(module, cursor, '192.0.2.10', 3307)
+
+
+def test_validate_donor_allowed_fails_when_donor_missing():
+    module = DummyModule()
+    cursor = DummyCursor(fetchall_results=[[{'Value': '198.51.100.20:3306'}]])
+
+    with pytest.raises(RuntimeError) as exc:
+        validate_donor_allowed(module, cursor, '192.0.2.10', 3307)
+
+    assert str(exc.value) == 'Recipient clone_valid_donor_list must contain 192.0.2.10:3307.'
+
+
+def test_ensure_clone_not_running_fails_for_in_progress_clone():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError) as exc:
+        ensure_clone_not_running(module, {'STATE': 'In Progress'})
+
+    assert str(exc.value) == 'A clone operation is already in progress on the recipient server.'
+
+
+def test_wait_for_clone_completion_handles_reconnects(monkeypatch):
+    module = DummyModule()
+    reconnect_cursor = DummyCursor(
+        fetchall_results=[
+            [{'STATE': 'In Progress'}],
+            [],
+            [{'STATE': 'Completed', 'ERROR_MESSAGE': ''}],
+            [{'STAGE': 'FILE COPY', 'STATE': 'Completed'}],
+        ]
+    )
+    connection = DummyConnection()
+    connect_results = iter([
+        RuntimeError('connection lost'),
+        (reconnect_cursor, connection),
+        (reconnect_cursor, connection),
+    ])
+    time_values = iter([0, 1, 2, 3])
+
+    def fake_connect(_module):
+        result = next(connect_results)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone._connect',
+        fake_connect,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.time.sleep',
+        lambda _: None,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.time.time',
+        lambda: next(time_values),
+    )
+
+    status, progress = wait_for_clone_completion(module)
+
+    assert status['STATE'] == 'Completed'
+    assert progress == [{'STAGE': 'FILE COPY', 'STATE': 'Completed'}]
+
+
+def test_main_returns_predictive_result_in_check_mode(monkeypatch):
+    module = DummyModule()
+    module.check_mode = True
+    module.params.update({
+        'login_user': 'root',
+        'login_password': 'secret',
+        'config_file': '~/.my.cnf',
+        'client_cert': None,
+        'client_key': None,
+        'ca_cert': None,
+        'check_hostname': None,
+        'connect_timeout': 30,
+        'wait_timeout': 30,
+        'poll_interval': 5,
+        'donor_host': '192.0.2.10',
+        'donor_port': 3307,
+        'donor_user': 'clone_user',
+        'donor_password': 'supersecret',
+        'require_ssl': True,
+    })
+    cursor = DummyCursor()
+    connection = DummyConnection()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone._connect',
+        lambda _module: (cursor, connection),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_implementation',
+        lambda _cursor: 'mysql',
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_version',
+        lambda _cursor: '8.0.17',
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.ensure_clone_plugin_active',
+        lambda _module, _cursor: None,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.validate_donor_allowed',
+        lambda _module, _cursor, _host, _port: None,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.ensure_clone_not_running',
+        lambda _module, _status: None,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+    assert result['msg'] == 'Clone would be started.'
+    assert result['query'] == (
+        "CLONE INSTANCE FROM 'clone_user'@'192.0.2.10':3307 IDENTIFIED BY '********' REQUIRE SSL"
+    )

--- a/tests/unit/plugins/modules/test_mysql_clone.py
+++ b/tests/unit/plugins/modules/test_mysql_clone.py
@@ -353,7 +353,7 @@ def test_main_fails_immediately_for_fatal_execute_error(monkeypatch):
     )
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.wait_for_clone_completion',
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError('wait should not be called')),
+        lambda *_args, **_kwargs: (unused_value for unused_value in ()).throw(AssertionError('wait should not be called')),
     )
 
     with pytest.raises(RuntimeError) as exc:

--- a/tests/unit/plugins/modules/test_mysql_clone.py
+++ b/tests/unit/plugins/modules/test_mysql_clone.py
@@ -75,6 +75,14 @@ class FailingCloneCursor(DummyCursor):
             raise RuntimeError(self.error_message)
 
 
+def assert_wait_not_called(*args, **kwargs):
+    raise AssertionError('wait should not be called')
+
+
+def assert_connect_not_called(_module):
+    raise AssertionError('connect should not be called')
+
+
 @pytest.mark.parametrize(
     'server_implementation,server_version,error_message',
     [
@@ -98,16 +106,24 @@ def test_validate_clone_support_accepts_supported_mysql():
     validate_clone_support(module, 'mysql', '8.0.17')
 
 
-def test_build_clone_query_returns_expected_sql_and_params():
+@pytest.mark.parametrize(
+    'require_ssl,expected_suffix',
+    [
+        (True, ' REQUIRE SSL'),
+        (False, ' REQUIRE NO SSL'),
+        (None, ''),
+    ]
+)
+def test_build_clone_query_returns_expected_sql_and_params(require_ssl, expected_suffix):
     query, params = build_clone_query(
         donor_host='192.0.2.10',
         donor_port=3307,
         donor_user='clone_user',
         donor_password='secret',
-        require_ssl=True,
+        require_ssl=require_ssl,
     )
 
-    assert query == 'CLONE INSTANCE FROM %s@%s:%s IDENTIFIED BY %s REQUIRE SSL'
+    assert query == 'CLONE INSTANCE FROM %s@%s:%s IDENTIFIED BY %s' + expected_suffix
     assert params == ('clone_user', '192.0.2.10', 3307, 'secret')
 
 
@@ -161,6 +177,13 @@ def test_ensure_clone_plugin_active_fails_when_plugin_missing():
     assert str(exc.value) == 'MySQL Clone plugin is not active on the recipient server.'
 
 
+def test_ensure_clone_plugin_active_accepts_active_plugin():
+    module = DummyModule()
+    cursor = DummyCursor(fetchone_results=[{'plugin_status': 'ACTIVE'}])
+
+    ensure_clone_plugin_active(module, cursor)
+
+
 def test_validate_donor_allowed_accepts_matching_host_and_port():
     module = DummyModule()
     cursor = DummyCursor(fetchall_results=[[{'Value': '192.0.2.10:3307,198.51.100.20:3306'}]])
@@ -176,6 +199,23 @@ def test_validate_donor_allowed_fails_when_donor_missing():
         validate_donor_allowed(module, cursor, '192.0.2.10', 3307)
 
     assert str(exc.value) == 'Recipient clone_valid_donor_list must contain 192.0.2.10:3307.'
+
+
+@pytest.mark.parametrize(
+    'rows,error_message',
+    [
+        ([], 'clone_valid_donor_list is not available on the recipient server.'),
+        ([{'Value': ''}], 'Recipient clone_valid_donor_list must contain 192.0.2.10:3307.'),
+    ]
+)
+def test_validate_donor_allowed_handles_missing_or_empty_allow_list(rows, error_message):
+    module = DummyModule()
+    cursor = DummyCursor(fetchall_results=[rows])
+
+    with pytest.raises(RuntimeError) as exc:
+        validate_donor_allowed(module, cursor, '192.0.2.10', 3307)
+
+    assert str(exc.value) == error_message
 
 
 def test_ensure_clone_not_running_fails_for_in_progress_clone():
@@ -297,6 +337,45 @@ def test_main_returns_predictive_result_in_check_mode(monkeypatch):
     )
 
 
+def test_main_rejects_port_zero(monkeypatch):
+    module = DummyModule()
+    module.params.update({
+        'login_user': 'root',
+        'login_password': 'secret',
+        'config_file': '~/.my.cnf',
+        'client_cert': None,
+        'client_key': None,
+        'ca_cert': None,
+        'check_hostname': None,
+        'connect_timeout': 30,
+        'wait_timeout': 30,
+        'poll_interval': 5,
+        'donor_host': '192.0.2.10',
+        'donor_port': 0,
+        'donor_user': 'clone_user',
+        'donor_password': 'supersecret',
+        'require_ssl': None,
+    })
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_clone._connect',
+        assert_connect_not_called,
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == 'donor_port must be a valid unix port number (1-65535)'
+
+
 def test_main_fails_immediately_for_fatal_execute_error(monkeypatch):
     module = DummyModule()
     module.params.update({
@@ -353,7 +432,7 @@ def test_main_fails_immediately_for_fatal_execute_error(monkeypatch):
     )
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.wait_for_clone_completion',
-        lambda *_args, **_kwargs: (unused_value for unused_value in ()).throw(AssertionError('wait should not be called')),
+        assert_wait_not_called,
     )
 
     with pytest.raises(RuntimeError) as exc:


### PR DESCRIPTION
#### SUMMARY
- add a new `ansible.mysql.mysql_clone` module for MySQL Clone plugin operations that validates prerequisites, starts the clone, and waits for terminal completion
- add unit and integration coverage for clone support, including MariaDB rejection and predictive check mode behavior
- run the happy-path integration against a managed standalone mysql service because clone restarts the recipient instance and requires a supervised service to come back cleanly

#### ISSUE TYPE
- Feature Pull Request

#### COMPONENT NAME
- `plugins/modules/mysql_clone.py`
- `tests/unit/plugins/modules/test_mysql_clone.py`
- `tests/integration/targets/test_mysql_clone/defaults/main.yml`
- `tests/integration/targets/test_mysql_clone/meta/main.yml`
- `tests/integration/targets/test_mysql_clone/tasks/main.yml`
- `meta/runtime.yml`

#### ADDITIONAL INFORMATION
- verified with `ansible-test sanity` and `ansible-test units` for `mysql_clone`
- verified with focused MySQL integration runs for `test_mysql_clone`
- the integration target installs the Clone plugin only as test fixture setup; the module itself only validates plugin availability
- test_mysql_clone starts a standalone mysql-server service on the test host because the Clone plugin restarts the recipient MySQL instance as part of a successful clone. The default replica test containers run mysqld as a raw container process without a supervisor, which causes restart to fail (Restart server failed (mysqld is not managed by supervisor process)). Using a managed service gives the recipient a restartable MySQL instance, so the integration test can verify a real successful clone to Completed instead of accepting a timeout.
- MariaDB is not supported by this module because mysql_clone is a thin wrapper around MySQL’s native Clone plugin (CLONE INSTANCE FROM, clone plugin checks, and clone status tables in performance_schema). MariaDB does not expose an equivalent native feature in its official server docs. Supporting MariaDB would require a separate backup/provisioning implementation, likely around external tools such as mariadb-backup
- Used GPT5.4 with human in the loop and manual tests.
