### PR TITLE
Add mysql_resource_group modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Every voice is important and every idea is valuable. If you have something on yo
   - [mysql_info](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_info_module.html)
   - [mysql_query](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_query_module.html)
   - [mysql_replication](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_replication_module.html)
+  - [mysql_resource_group](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_resource_group_module.html)
+  - [mysql_resource_group_info](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_resource_group_info_module.html)
   - [mysql_role](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_role_module.html)
   - [mysql_user](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_user_module.html)
   - [mysql_variables](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_variables_module.html)

--- a/TESTING.md
+++ b/TESTING.md
@@ -89,6 +89,7 @@ The Makefile accept the following options
   - Choices:
     - "test_mysql_binlog_info"
     - "test_mysql_db"
+    - "test_mysql_resource_group"
     - "test_mysql_info"
     - "test_mysql_query"
     - "test_mysql_replication"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -7,6 +7,8 @@ action_groups:
     - mysql_info
     - mysql_query
     - mysql_replication
+    - mysql_resource_group
+    - mysql_resource_group_info
     - mysql_role
     - mysql_user
     - mysql_variables

--- a/plugins/module_utils/resource_group.py
+++ b/plugins/module_utils/resource_group.py
@@ -1,0 +1,131 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    get_server_implementation,
+    get_server_version,
+)
+
+
+def get_server_version_tuple(cursor):
+    version = get_server_version(cursor).split('-', 1)[0]
+    version_tuple = []
+
+    for part in version.split('.'):
+        digits = ''.join(char for char in part if char.isdigit())
+        if not digits:
+            break
+        version_tuple.append(int(digits))
+
+    while len(version_tuple) < 3:
+        version_tuple.append(0)
+
+    return tuple(version_tuple[:3])
+
+
+def ensure_resource_groups_supported(module, cursor):
+    if get_server_implementation(cursor) != 'mysql':
+        module.fail_json(msg='Resource groups are supported only by MySQL 8.0 or later.')
+
+    if get_server_version_tuple(cursor) < (8, 0, 0):
+        module.fail_json(msg='Resource groups are supported only by MySQL 8.0 or later.')
+
+    try:
+        cursor.execute("SELECT RESOURCE_GROUP_NAME FROM INFORMATION_SCHEMA.RESOURCE_GROUPS LIMIT 1")
+        cursor.fetchall()
+    except Exception as e:
+        module.fail_json(msg='Resource groups are not supported by the server: %s' % to_native(e))
+
+
+def normalize_vcpu_ids(vcpu_ids):
+    if vcpu_ids is None:
+        return None
+    if isinstance(vcpu_ids, bytes):
+        vcpu_ids = vcpu_ids.decode('utf-8')
+
+    cpus = set()
+
+    for raw_item in vcpu_ids.split(','):
+        item = raw_item.strip()
+        if not item:
+            raise ValueError('vcpu_ids contains an empty element')
+
+        if '-' in item:
+            bounds = item.split('-', 1)
+            if len(bounds) != 2 or not bounds[0] or not bounds[1]:
+                raise ValueError('vcpu_ids contains an invalid range: %s' % item)
+            start = int(bounds[0])
+            end = int(bounds[1])
+            if start > end:
+                raise ValueError('vcpu_ids contains a descending range: %s' % item)
+            cpus.update(range(start, end + 1))
+        else:
+            cpus.add(int(item))
+
+    normalized = []
+    sorted_cpus = sorted(cpus)
+    range_start = None
+    range_end = None
+
+    for cpu in sorted_cpus:
+        if range_start is None:
+            range_start = cpu
+            range_end = cpu
+            continue
+
+        if cpu == range_end + 1:
+            range_end = cpu
+            continue
+
+        normalized.append(_format_cpu_range(range_start, range_end))
+        range_start = cpu
+        range_end = cpu
+
+    if range_start is not None:
+        normalized.append(_format_cpu_range(range_start, range_end))
+
+    return ','.join(normalized)
+
+
+def _format_cpu_range(start, end):
+    if start == end:
+        return str(start)
+    return '%s-%s' % (start, end)
+
+
+def normalize_resource_group_enabled(value):
+    if isinstance(value, bool):
+        return value
+    return str(value).upper() in ('YES', '1', 'ON', 'TRUE', 'ENABLE', 'ENABLED')
+
+
+def normalize_resource_group_row(row):
+    return {
+        'name': row['RESOURCE_GROUP_NAME'],
+        'resource_group_type': row['RESOURCE_GROUP_TYPE'],
+        'enabled': normalize_resource_group_enabled(row['RESOURCE_GROUP_ENABLED']),
+        'vcpu_ids': normalize_vcpu_ids(row['VCPU_IDS']),
+        'thread_priority': int(row['THREAD_PRIORITY']),
+    }
+
+
+def validate_resource_group_type(resource_group_type):
+    normalized_type = resource_group_type.upper()
+    if normalized_type not in ('SYSTEM', 'USER'):
+        raise ValueError('resource_group_type must be SYSTEM or USER')
+    return normalized_type
+
+
+def validate_thread_priority(resource_group_type, thread_priority):
+    if thread_priority < -20 or thread_priority > 19:
+        raise ValueError('thread_priority must be between -20 and 19')
+
+    if resource_group_type == 'SYSTEM' and thread_priority > 0:
+        raise ValueError('thread_priority must be between -20 and 0 for SYSTEM resource groups')
+
+    if resource_group_type == 'USER' and thread_priority < 0:
+        raise ValueError('thread_priority must be between 0 and 19 for USER resource groups')
+
+    return thread_priority

--- a/plugins/modules/mysql_resource_group.py
+++ b/plugins/modules/mysql_resource_group.py
@@ -40,7 +40,6 @@ options:
       - The value is immutable after creation.
     type: str
     choices: [SYSTEM, USER]
-    version_added: '5.1.0'
   vcpu_ids:
     description:
       - CPU affinity in native MySQL syntax.

--- a/plugins/modules/mysql_resource_group.py
+++ b/plugins/modules/mysql_resource_group.py
@@ -53,7 +53,6 @@ options:
       - Must be between C(0) and C(19) for C(USER) resource groups.
       - When omitted for an existing resource group, the current value is left unchanged.
     type: int
-    version_added: '5.1.0'
   enabled:
     description:
       - Whether the resource group should be enabled.

--- a/plugins/modules/mysql_resource_group.py
+++ b/plugins/modules/mysql_resource_group.py
@@ -58,7 +58,6 @@ options:
       - Whether the resource group should be enabled.
       - When omitted for an existing resource group, the current value is left unchanged.
     type: bool
-    version_added: '5.1.0'
   force:
     description:
       - If C(true), use C(FORCE) when dropping a resource group.

--- a/plugins/modules/mysql_resource_group.py
+++ b/plugins/modules/mysql_resource_group.py
@@ -1,0 +1,424 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible community
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_resource_group
+
+short_description: Add, update, or remove MySQL resource groups
+
+description:
+  - Add, update, or remove MySQL resource groups.
+  - Resource groups are supported by MySQL 8.0 or later.
+
+version_added: '5.1.0'
+
+options:
+  name:
+    description:
+      - Name of the resource group to manage.
+    type: str
+    required: true
+  state:
+    description:
+      - If C(present), creates the resource group when it does not exist.
+      - If C(present), updates mutable attributes when the resource group already exists.
+      - If C(absent), removes the resource group.
+    type: str
+    choices: [absent, present]
+    default: present
+  resource_group_type:
+    description:
+      - Resource group type.
+      - Required when creating a new resource group.
+      - The value is immutable after creation.
+    type: str
+    choices: [SYSTEM, USER]
+    version_added: '5.1.0'
+  vcpu_ids:
+    description:
+      - CPU affinity in native MySQL syntax.
+      - Examples include C(0-3) and C(0-3,8,10-12).
+      - When omitted for an existing resource group, the current value is left unchanged.
+    type: str
+    version_added: '5.1.0'
+  thread_priority:
+    description:
+      - Thread priority to set for the resource group.
+      - Must be between C(-20) and C(0) for C(SYSTEM) resource groups.
+      - Must be between C(0) and C(19) for C(USER) resource groups.
+      - When omitted for an existing resource group, the current value is left unchanged.
+    type: int
+    version_added: '5.1.0'
+  enabled:
+    description:
+      - Whether the resource group should be enabled.
+      - When omitted for an existing resource group, the current value is left unchanged.
+    type: bool
+    version_added: '5.1.0'
+  force:
+    description:
+      - If C(true), use C(FORCE) when dropping a resource group.
+      - This only applies when O(state=absent).
+    type: bool
+    default: false
+    version_added: '5.1.0'
+
+notes:
+  - This module supports MySQL 8.0 or later only.
+  - Resource groups are not available on MariaDB.
+  - MySQL documents resource groups as unavailable when the thread pool plugin is installed.
+  - Thread-priority behavior can depend on server platform and operating-system capabilities.
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+seealso:
+  - module: ansible.mysql.mysql_resource_group_info
+  - name: MySQL CREATE RESOURCE GROUP reference
+    description: Complete reference of the CREATE RESOURCE GROUP command documentation.
+    link: https://dev.mysql.com/doc/refman/8.4/en/create-resource-group.html
+  - name: MySQL ALTER RESOURCE GROUP reference
+    description: Complete reference of the ALTER RESOURCE GROUP command documentation.
+    link: https://dev.mysql.com/doc/refman/8.4/en/alter-resource-group.html
+  - name: MySQL DROP RESOURCE GROUP reference
+    description: Complete reference of the DROP RESOURCE GROUP command documentation.
+    link: https://dev.mysql.com/doc/refman/8.4/en/drop-resource-group.html
+
+author:
+  - Ron Gershburg (@rgershbu)
+
+
+extends_documentation_fragment:
+  - ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+# If you encounter the "Please explicitly state intended protocol" error,
+# use the login_unix_socket argument
+- name: Create a reporting resource group
+  ansible.mysql.mysql_resource_group:
+    name: reporting
+    resource_group_type: USER
+    vcpu_ids: 4-7
+    thread_priority: 5
+    enabled: true
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Disable a resource group
+  ansible.mysql.mysql_resource_group:
+    name: reporting
+    state: present
+    enabled: false
+
+- name: Drop a resource group and reassign running threads
+  ansible.mysql.mysql_resource_group:
+    name: reporting
+    state: absent
+    force: true
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed queries.
+  returned: when changed
+  type: list
+  sample: ["CREATE RESOURCE GROUP `reporting` TYPE = USER VCPU = 4-7 THREAD_PRIORITY = 5 ENABLE"]
+resource_group:
+  description: Normalized representation of the resource group after module execution.
+  returned: when O(state=present)
+  type: dict
+  contains:
+    name:
+      description: Resource group name.
+      type: str
+      sample: reporting
+    resource_group_type:
+      description: Resource group type.
+      type: str
+      sample: USER
+    enabled:
+      description: Whether the resource group is enabled.
+      type: bool
+      sample: true
+    vcpu_ids:
+      description: Normalized CPU affinity.
+      type: str
+      sample: 4-7
+    thread_priority:
+      description: Resource-group thread priority.
+      type: int
+      sample: 5
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+from ansible_collections.ansible.mysql.plugins.module_utils.database import mysql_quote_identifier
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils.resource_group import (
+    ensure_resource_groups_supported,
+    normalize_resource_group_enabled as normalize_enabled,
+    normalize_resource_group_row,
+    normalize_vcpu_ids,
+    validate_resource_group_type,
+    validate_thread_priority,
+)
+
+DEFAULT_RESOURCE_GROUPS = ('SYS_default', 'USR_default')
+RESOURCE_GROUP_QUERY = (
+    'SELECT RESOURCE_GROUP_NAME, RESOURCE_GROUP_TYPE, RESOURCE_GROUP_ENABLED, VCPU_IDS, THREAD_PRIORITY '
+    'FROM INFORMATION_SCHEMA.RESOURCE_GROUPS WHERE RESOURCE_GROUP_NAME = %s'
+)
+
+
+def build_create_query(name, resource_group_type, vcpu_ids=None, thread_priority=None, enabled=None):
+    resource_group_type = validate_resource_group_type(resource_group_type)
+    query = [
+        'CREATE RESOURCE GROUP %s' % mysql_quote_identifier(name, 'role'),
+        'TYPE = %s' % resource_group_type,
+    ]
+
+    if vcpu_ids is not None:
+        query.append('VCPU = %s' % normalize_vcpu_ids(vcpu_ids))
+
+    if thread_priority is not None:
+        query.append('THREAD_PRIORITY = %s' % validate_thread_priority(resource_group_type, thread_priority))
+
+    if enabled is True:
+        query.append('ENABLE')
+    elif enabled is False:
+        query.append('DISABLE')
+
+    return ' '.join(query)
+
+
+def build_alter_query(name, current, resource_group_type=None, vcpu_ids=None, thread_priority=None, enabled=None):
+    if resource_group_type is not None:
+        desired_type = validate_resource_group_type(resource_group_type)
+        if current['resource_group_type'] != desired_type:
+            raise ValueError('resource_group_type is immutable after creation')
+
+    changes = []
+
+    if vcpu_ids is not None:
+        normalized_vcpu_ids = normalize_vcpu_ids(vcpu_ids)
+        if current['vcpu_ids'] != normalized_vcpu_ids:
+            changes.append('VCPU = %s' % normalized_vcpu_ids)
+
+    if thread_priority is not None:
+        normalized_priority = validate_thread_priority(current['resource_group_type'], thread_priority)
+        if current['thread_priority'] != normalized_priority:
+            changes.append('THREAD_PRIORITY = %s' % normalized_priority)
+
+    if enabled is not None:
+        normalized_enabled = normalize_enabled(enabled)
+        if current['enabled'] != normalized_enabled:
+            changes.append('ENABLE' if normalized_enabled else 'DISABLE')
+
+    if not changes:
+        return None
+
+    return 'ALTER RESOURCE GROUP %s %s' % (mysql_quote_identifier(name, 'role'), ' '.join(changes))
+
+
+def build_drop_query(name, force=False):
+    query = 'DROP RESOURCE GROUP %s' % mysql_quote_identifier(name, 'role')
+    if force:
+        query += ' FORCE'
+    return query
+
+
+def get_resource_group(cursor, name):
+    cursor.execute(RESOURCE_GROUP_QUERY, (name,))
+    row = cursor.fetchone()
+    if not row:
+        return None
+    return normalize_resource_group_row(row)
+
+
+def execute_query(cursor, query):
+    cursor.execute(query)
+    cursor.fetchall()
+
+
+def fail_if_default_resource_group(module, name):
+    if name in DEFAULT_RESOURCE_GROUPS:
+        module.fail_json(msg='Default resource groups cannot be altered or dropped: %s' % name)
+
+
+def fail_if_effective_thread_priority_differs(module, requested_thread_priority, current, queries):
+    if requested_thread_priority is None:
+        return
+
+    if current['thread_priority'] != requested_thread_priority:
+        module.fail_json(
+            msg=('thread_priority %s could not be applied; server reported %s. '
+                 'The server may ignore thread priorities on this platform.'
+                 % (requested_thread_priority, current['thread_priority'])),
+            changed=True,
+            queries=queries,
+            resource_group=current,
+        )
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        name=dict(type='str', required=True),
+        state=dict(type='str', choices=['absent', 'present'], default='present'),
+        resource_group_type=dict(type='str', choices=['SYSTEM', 'USER']),
+        vcpu_ids=dict(type='str'),
+        thread_priority=dict(type='int'),
+        enabled=dict(type='bool'),
+        force=dict(type='bool', default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    name = module.params['name']
+    state = module.params['state']
+    resource_group_type = module.params['resource_group_type']
+    vcpu_ids = module.params['vcpu_ids']
+    thread_priority = module.params['thread_priority']
+    enabled = module.params['enabled']
+    force = module.params['force']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    config_file = module.params['config_file']
+    ssl_cert = module.params['client_cert']
+    ssl_key = module.params['client_key']
+    ssl_ca = module.params['ca_cert']
+    connect_timeout = module.params['connect_timeout']
+    check_hostname = module.params['check_hostname']
+
+    try:
+        cursor, db_conn = mysql_connect(
+            module,
+            login_user,
+            login_password,
+            config_file,
+            ssl_cert,
+            ssl_key,
+            ssl_ca,
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+            cursor_class='DictCursor',
+            autocommit=True,
+        )
+    except Exception as e:
+        module.fail_json(msg='unable to connect to database: %s' % to_native(e))
+
+    ensure_resource_groups_supported(module, cursor)
+
+    current = get_resource_group(cursor, name)
+    queries = []
+
+    try:
+        if resource_group_type is not None:
+            resource_group_type = validate_resource_group_type(resource_group_type)
+        if vcpu_ids is not None:
+            vcpu_ids = normalize_vcpu_ids(vcpu_ids)
+    except ValueError as e:
+        module.fail_json(msg=to_native(e))
+
+    if state == 'absent':
+        if current is None:
+            module.exit_json(changed=False)
+
+        fail_if_default_resource_group(module, name)
+        query = build_drop_query(name, force)
+        queries.append(query)
+
+        if module.check_mode:
+            module.exit_json(changed=True, queries=queries)
+
+        try:
+            execute_query(cursor, query)
+        except Exception as e:
+            module.fail_json(msg=to_native(e))
+
+        module.exit_json(changed=True, queries=queries)
+
+    if current is None:
+        if resource_group_type is None:
+            module.fail_json(msg='resource_group_type is required when creating a resource group')
+
+        try:
+            if thread_priority is not None:
+                validate_thread_priority(resource_group_type, thread_priority)
+        except ValueError as e:
+            module.fail_json(msg=to_native(e))
+
+        query = build_create_query(name, resource_group_type, vcpu_ids, thread_priority, enabled)
+        queries.append(query)
+
+        if module.check_mode:
+            module.exit_json(
+                changed=True,
+                queries=queries,
+                resource_group={
+                    'name': name,
+                    'resource_group_type': resource_group_type,
+                    'enabled': True if enabled is None else enabled,
+                    'vcpu_ids': vcpu_ids,
+                    'thread_priority': 0 if thread_priority is None else thread_priority,
+                },
+            )
+
+        try:
+            execute_query(cursor, query)
+        except Exception as e:
+            module.fail_json(msg=to_native(e))
+
+        current = get_resource_group(cursor, name)
+        fail_if_effective_thread_priority_differs(module, thread_priority, current, queries)
+        module.exit_json(changed=True, queries=queries, resource_group=current)
+
+    try:
+        if thread_priority is not None:
+            validate_thread_priority(current['resource_group_type'], thread_priority)
+        query = build_alter_query(name, current, resource_group_type, vcpu_ids, thread_priority, enabled)
+    except ValueError as e:
+        module.fail_json(msg=to_native(e))
+
+    if query is None:
+        module.exit_json(changed=False, resource_group=current)
+
+    fail_if_default_resource_group(module, name)
+    queries.append(query)
+
+    if module.check_mode:
+        module.exit_json(changed=True, queries=queries, resource_group=current)
+
+    try:
+        execute_query(cursor, query)
+    except Exception as e:
+        module.fail_json(msg=to_native(e))
+
+    current = get_resource_group(cursor, name)
+    fail_if_effective_thread_priority_differs(module, thread_priority, current, queries)
+    module.exit_json(changed=True, queries=queries, resource_group=current)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_resource_group.py
+++ b/plugins/modules/mysql_resource_group.py
@@ -64,7 +64,6 @@ options:
       - This only applies when O(state=absent).
     type: bool
     default: false
-    version_added: '5.1.0'
 
 notes:
   - This module supports MySQL 8.0 or later only.

--- a/plugins/modules/mysql_resource_group.py
+++ b/plugins/modules/mysql_resource_group.py
@@ -90,7 +90,7 @@ seealso:
     link: https://dev.mysql.com/doc/refman/8.4/en/drop-resource-group.html
 
 author:
-  - Ron Gershburg (@rgershbu)
+  - Ron Gershburg (@ronger4)
 
 
 extends_documentation_fragment:
@@ -180,15 +180,22 @@ RESOURCE_GROUP_QUERY = (
 )
 
 
+def normalize_resource_group_inputs(resource_group_type=None, vcpu_ids=None):
+    if resource_group_type is not None:
+        resource_group_type = validate_resource_group_type(resource_group_type)
+    if vcpu_ids is not None:
+        vcpu_ids = normalize_vcpu_ids(vcpu_ids)
+    return resource_group_type, vcpu_ids
+
+
 def build_create_query(name, resource_group_type, vcpu_ids=None, thread_priority=None, enabled=None):
-    resource_group_type = validate_resource_group_type(resource_group_type)
     query = [
         'CREATE RESOURCE GROUP %s' % mysql_quote_identifier(name, 'role'),
         'TYPE = %s' % resource_group_type,
     ]
 
     if vcpu_ids is not None:
-        query.append('VCPU = %s' % normalize_vcpu_ids(vcpu_ids))
+        query.append('VCPU = %s' % vcpu_ids)
 
     if thread_priority is not None:
         query.append('THREAD_PRIORITY = %s' % validate_thread_priority(resource_group_type, thread_priority))
@@ -203,16 +210,14 @@ def build_create_query(name, resource_group_type, vcpu_ids=None, thread_priority
 
 def build_alter_query(name, current, resource_group_type=None, vcpu_ids=None, thread_priority=None, enabled=None):
     if resource_group_type is not None:
-        desired_type = validate_resource_group_type(resource_group_type)
-        if current['resource_group_type'] != desired_type:
+        if current['resource_group_type'] != resource_group_type:
             raise ValueError('resource_group_type is immutable after creation')
 
     changes = []
 
     if vcpu_ids is not None:
-        normalized_vcpu_ids = normalize_vcpu_ids(vcpu_ids)
-        if current['vcpu_ids'] != normalized_vcpu_ids:
-            changes.append('VCPU = %s' % normalized_vcpu_ids)
+        if current['vcpu_ids'] != vcpu_ids:
+            changes.append('VCPU = %s' % vcpu_ids)
 
     if thread_priority is not None:
         normalized_priority = validate_thread_priority(current['resource_group_type'], thread_priority)
@@ -247,7 +252,6 @@ def get_resource_group(cursor, name):
 
 def execute_query(cursor, query):
     cursor.execute(query)
-    cursor.fetchall()
 
 
 def fail_if_default_resource_group(module, name):
@@ -329,10 +333,7 @@ def main():
     queries = []
 
     try:
-        if resource_group_type is not None:
-            resource_group_type = validate_resource_group_type(resource_group_type)
-        if vcpu_ids is not None:
-            vcpu_ids = normalize_vcpu_ids(vcpu_ids)
+        resource_group_type, vcpu_ids = normalize_resource_group_inputs(resource_group_type, vcpu_ids)
     except ValueError as e:
         module.fail_json(msg=to_native(e))
 

--- a/plugins/modules/mysql_resource_group.py
+++ b/plugins/modules/mysql_resource_group.py
@@ -46,7 +46,6 @@ options:
       - Examples include C(0-3) and C(0-3,8,10-12).
       - When omitted for an existing resource group, the current value is left unchanged.
     type: str
-    version_added: '5.1.0'
   thread_priority:
     description:
       - Thread priority to set for the resource group.

--- a/plugins/modules/mysql_resource_group_info.py
+++ b/plugins/modules/mysql_resource_group_info.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible community
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_resource_group_info
+
+short_description: Gather information about MySQL resource groups
+
+description:
+  - Gather information about MySQL resource groups.
+  - Resource groups are supported by MySQL 8.0 or later.
+
+version_added: '5.1.0'
+
+options:
+  name:
+    description:
+      - Limit the collected information to a single resource group name.
+    type: str
+    version_added: '5.1.0'
+
+notes:
+  - This module supports MySQL 8.0 or later only.
+  - Resource groups are not available on MariaDB.
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+seealso:
+  - module: ansible.mysql.mysql_resource_group
+  - name: INFORMATION_SCHEMA RESOURCE_GROUPS reference
+    description: Complete reference of the INFORMATION_SCHEMA RESOURCE_GROUPS table documentation.
+    link: https://dev.mysql.com/doc/refman/8.4/en/information-schema-resource-groups-table.html
+
+author:
+  - Ron Gershburg (@rgershbu)
+
+extends_documentation_fragment:
+  - ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+# If you encounter the "Please explicitly state intended protocol" error,
+# use the login_unix_socket argument
+- name: Gather all resource groups
+  ansible.mysql.mysql_resource_group_info:
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Gather a single resource group
+  ansible.mysql.mysql_resource_group_info:
+    name: reporting
+'''
+
+RETURN = r'''
+resource_groups:
+  description: List of normalized resource groups.
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    name:
+      description: Resource group name.
+      type: str
+      sample: reporting
+    resource_group_type:
+      description: Resource group type.
+      type: str
+      sample: USER
+    enabled:
+      description: Whether the resource group is enabled.
+      type: bool
+      sample: true
+    vcpu_ids:
+      description: Normalized CPU affinity.
+      type: str
+      sample: 4-7
+    thread_priority:
+      description: Resource-group thread priority.
+      type: int
+      sample: 5
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils.resource_group import (
+    ensure_resource_groups_supported,
+    normalize_resource_group_row,
+)
+
+
+class MySQLResourceGroupsInfo(object):
+    def __init__(self, cursor):
+        self.cursor = cursor
+
+    def get_info(self, name=None):
+        query = (
+            'SELECT RESOURCE_GROUP_NAME, RESOURCE_GROUP_TYPE, RESOURCE_GROUP_ENABLED, VCPU_IDS, THREAD_PRIORITY '
+            'FROM INFORMATION_SCHEMA.RESOURCE_GROUPS'
+        )
+        params = None
+
+        if name:
+            query += ' WHERE RESOURCE_GROUP_NAME = %s'
+            params = (name,)
+
+        query += ' ORDER BY RESOURCE_GROUP_NAME'
+
+        if params:
+            self.cursor.execute(query, params)
+        else:
+            self.cursor.execute(query)
+
+        return {
+            'resource_groups': [normalize_resource_group_row(row) for row in self.cursor.fetchall()]
+        }
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        name=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    config_file = module.params['config_file']
+    ssl_cert = module.params['client_cert']
+    ssl_key = module.params['client_key']
+    ssl_ca = module.params['ca_cert']
+    connect_timeout = module.params['connect_timeout']
+    check_hostname = module.params['check_hostname']
+    name = module.params['name']
+
+    try:
+        cursor, db_conn = mysql_connect(
+            module,
+            login_user,
+            login_password,
+            config_file,
+            ssl_cert,
+            ssl_key,
+            ssl_ca,
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+            cursor_class='DictCursor',
+        )
+    except Exception as e:
+        module.fail_json(msg='unable to connect to database: %s' % to_native(e))
+
+    ensure_resource_groups_supported(module, cursor)
+    info = MySQLResourceGroupsInfo(cursor)
+
+    module.exit_json(changed=False, **info.get_info(name))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_resource_group_info.py
+++ b/plugins/modules/mysql_resource_group_info.py
@@ -24,7 +24,6 @@ options:
     description:
       - Limit the collected information to a single resource group name.
     type: str
-    version_added: '5.1.0'
 
 notes:
   - This module supports MySQL 8.0 or later only.

--- a/plugins/modules/mysql_resource_group_info.py
+++ b/plugins/modules/mysql_resource_group_info.py
@@ -42,7 +42,7 @@ seealso:
     link: https://dev.mysql.com/doc/refman/8.4/en/information-schema-resource-groups-table.html
 
 author:
-  - Ron Gershburg (@rgershbu)
+  - Ron Gershburg (@ronger4)
 
 extends_documentation_fragment:
   - ansible.mysql.mysql
@@ -103,31 +103,27 @@ from ansible_collections.ansible.mysql.plugins.module_utils.resource_group impor
 )
 
 
-class MySQLResourceGroupsInfo(object):
-    def __init__(self, cursor):
-        self.cursor = cursor
+def get_resource_groups_info(cursor, name=None):
+    query = (
+        'SELECT RESOURCE_GROUP_NAME, RESOURCE_GROUP_TYPE, RESOURCE_GROUP_ENABLED, VCPU_IDS, THREAD_PRIORITY '
+        'FROM INFORMATION_SCHEMA.RESOURCE_GROUPS'
+    )
+    params = None
 
-    def get_info(self, name=None):
-        query = (
-            'SELECT RESOURCE_GROUP_NAME, RESOURCE_GROUP_TYPE, RESOURCE_GROUP_ENABLED, VCPU_IDS, THREAD_PRIORITY '
-            'FROM INFORMATION_SCHEMA.RESOURCE_GROUPS'
-        )
-        params = None
+    if name:
+        query += ' WHERE RESOURCE_GROUP_NAME = %s'
+        params = (name,)
 
-        if name:
-            query += ' WHERE RESOURCE_GROUP_NAME = %s'
-            params = (name,)
+    query += ' ORDER BY RESOURCE_GROUP_NAME'
 
-        query += ' ORDER BY RESOURCE_GROUP_NAME'
+    if params:
+        cursor.execute(query, params)
+    else:
+        cursor.execute(query)
 
-        if params:
-            self.cursor.execute(query, params)
-        else:
-            self.cursor.execute(query)
-
-        return {
-            'resource_groups': [normalize_resource_group_row(row) for row in self.cursor.fetchall()]
-        }
+    return {
+        'resource_groups': [normalize_resource_group_row(row) for row in cursor.fetchall()]
+    }
 
 
 def main():
@@ -171,9 +167,7 @@ def main():
         module.fail_json(msg='unable to connect to database: %s' % to_native(e))
 
     ensure_resource_groups_supported(module, cursor)
-    info = MySQLResourceGroupsInfo(cursor)
-
-    module.exit_json(changed=False, **info.get_info(name))
+    module.exit_json(changed=False, **get_resource_groups_info(cursor, name))
 
 
 if __name__ == '__main__':

--- a/tests/integration/targets/test_mysql_resource_group/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_resource_group/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_resource_group/meta/main.yml
+++ b/tests/integration/targets/test_mysql_resource_group/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_resource_group/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_resource_group/tasks/main.yml
@@ -1,0 +1,402 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: Resource group | Run tests
+  vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+    resource_group_name: ansible_reporting
+
+  block:
+    - name: Resource group | Expect module to fail on unsupported servers
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: present
+      register: result
+      ignore_errors: true
+      when: db_engine != 'mysql' or db_version is version('8.0', '<')
+
+    - name: Resource group | Assert unsupported-server failure
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Resource groups are supported only by MySQL 8.0 or later.' in result.msg"
+      when: db_engine != 'mysql' or db_version is version('8.0', '<')
+
+    - name: Resource group | USER check mode rejects negative thread priority
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: invalid_priority_group
+        state: present
+        resource_group_type: USER
+        thread_priority: -1
+      check_mode: true
+      register: result
+      ignore_errors: true
+      when: db_engine == 'mysql' and db_version is version('8.0', '>=')
+
+    - name: Resource group | Assert USER negative thread priority failure
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'thread_priority must be between 0 and 19 for USER resource groups' in result.msg"
+      when: db_engine == 'mysql' and db_version is version('8.0', '>=')
+
+    - name: Resource group | Skip supported-server tests
+      ansible.builtin.meta: end_play
+      when: db_engine != 'mysql' or db_version is version('8.0', '<')
+
+    - name: Resource group | Read default USER resource group CPU affinity
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT VCPU_IDS
+          FROM INFORMATION_SCHEMA.RESOURCE_GROUPS
+          WHERE RESOURCE_GROUP_NAME = 'USR_default'
+      register: default_group
+
+    - name: Resource group | Set CPU facts
+      ansible.builtin.set_fact:
+        available_vcpu_ids: "{{ default_group.query_result[0][0]['VCPU_IDS'] | regex_search('\\d+(?:-\\d+)?(?:,\\d+(?:-\\d+)?)*') }}"
+        first_vcpu: "{{ default_group.query_result[0][0]['VCPU_IDS'] | regex_search('\\d+') }}"
+
+    - name: Resource group | Ensure resource group is absent
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: absent
+
+    - name: Resource group | Create in check mode
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: present
+        resource_group_type: USER
+        vcpu_ids: '{{ first_vcpu }}'
+        enabled: false
+      check_mode: true
+      register: result
+
+    - name: Resource group | Assert create check mode result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 1
+          - "'CREATE RESOURCE GROUP' in result.queries[0]"
+          - result.resource_group.name == resource_group_name
+          - result.resource_group.resource_group_type == 'USER'
+          - result.resource_group.enabled == false
+          - result.resource_group.vcpu_ids == first_vcpu
+          - result.resource_group.thread_priority == 0
+
+    - name: Resource group | Verify resource group does not exist after check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT RESOURCE_GROUP_NAME
+          FROM INFORMATION_SCHEMA.RESOURCE_GROUPS
+          WHERE RESOURCE_GROUP_NAME = '{{ resource_group_name }}'
+      register: result
+
+    - name: Resource group | Assert resource group absent after check mode
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 0
+
+    - name: Resource group | Create resource group
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: present
+        resource_group_type: USER
+        vcpu_ids: '{{ first_vcpu }}'
+        enabled: false
+      register: result
+
+    - name: Resource group | Assert create result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.resource_group.name == resource_group_name
+          - result.resource_group.resource_group_type == 'USER'
+          - result.resource_group.enabled == false
+          - result.resource_group.vcpu_ids == first_vcpu
+          - result.resource_group.thread_priority == 0
+
+    - name: Resource group | Gather all resource groups after create
+      ansible.mysql.mysql_resource_group_info:
+        <<: *mysql_params
+      register: result
+
+    - name: Resource group | Assert all-groups info after create
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - (result.resource_groups | selectattr('name', 'equalto', resource_group_name) | list | length) == 1
+
+    - name: Resource group | Capture resource group from all-groups info
+      ansible.builtin.set_fact:
+        gathered_resource_group: "{{ (result.resource_groups | selectattr('name', 'equalto', resource_group_name) | list | first) }}"
+
+    - name: Resource group | Assert normalized info object after create
+      ansible.builtin.assert:
+        that:
+          - gathered_resource_group.resource_group_type == 'USER'
+          - gathered_resource_group.enabled == false
+          - gathered_resource_group.vcpu_ids == first_vcpu
+          - gathered_resource_group.thread_priority == 0
+
+    - name: Resource group | Gather single resource group after create
+      ansible.mysql.mysql_resource_group_info:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+      register: result
+
+    - name: Resource group | Assert single-group info after create
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.resource_groups | length == 1
+          - result.resource_groups[0].name == resource_group_name
+          - result.resource_groups[0].resource_group_type == 'USER'
+          - result.resource_groups[0].enabled == false
+          - result.resource_groups[0].vcpu_ids == first_vcpu
+          - result.resource_groups[0].thread_priority == 0
+
+    - name: Resource group | Gather missing resource group
+      ansible.mysql.mysql_resource_group_info:
+        <<: *mysql_params
+        name: missing_group
+      register: result
+
+    - name: Resource group | Assert missing-group info result
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.resource_groups | length == 0
+
+    - name: Resource group | Verify created resource group
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT RESOURCE_GROUP_ENABLED, VCPU_IDS, THREAD_PRIORITY
+          FROM INFORMATION_SCHEMA.RESOURCE_GROUPS
+          WHERE RESOURCE_GROUP_NAME = '{{ resource_group_name }}'
+      register: result
+
+    - name: Resource group | Assert created resource group state
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 1
+          - not (result.query_result[0][0]['RESOURCE_GROUP_ENABLED'] | bool)
+          - (result.query_result[0][0]['VCPU_IDS'] | regex_search('\\d+(?:-\\d+)?(?:,\\d+(?:-\\d+)?)*')) == first_vcpu
+          - result.query_result[0][0]['THREAD_PRIORITY'] == 0
+
+    - name: Resource group | Re-apply same definition in check mode
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: present
+        resource_group_type: USER
+        vcpu_ids: '{{ first_vcpu }}'
+        enabled: false
+      check_mode: true
+      register: result
+
+    - name: Resource group | Assert idempotent check mode
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+
+    - name: Resource group | Re-apply same definition
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: present
+        resource_group_type: USER
+        vcpu_ids: '{{ first_vcpu }}'
+        enabled: false
+      register: result
+
+    - name: Resource group | Assert idempotent apply
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+
+    - name: Resource group | Alter in check mode
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: present
+        resource_group_type: USER
+        vcpu_ids: '{{ available_vcpu_ids }}'
+        enabled: true
+      check_mode: true
+      register: result
+
+    - name: Resource group | Assert alter check mode result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 1
+          - "'ALTER RESOURCE GROUP' in result.queries[0]"
+
+    - name: Resource group | Verify alter check mode did not change state
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT RESOURCE_GROUP_ENABLED, VCPU_IDS, THREAD_PRIORITY
+          FROM INFORMATION_SCHEMA.RESOURCE_GROUPS
+          WHERE RESOURCE_GROUP_NAME = '{{ resource_group_name }}'
+      register: result
+
+    - name: Resource group | Assert alter check mode kept previous state
+      ansible.builtin.assert:
+        that:
+          - not (result.query_result[0][0]['RESOURCE_GROUP_ENABLED'] | bool)
+          - (result.query_result[0][0]['VCPU_IDS'] | regex_search('\\d+(?:-\\d+)?(?:,\\d+(?:-\\d+)?)*')) == first_vcpu
+          - result.query_result[0][0]['THREAD_PRIORITY'] == 0
+
+    - name: Resource group | Alter resource group
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: present
+        resource_group_type: USER
+        vcpu_ids: '{{ available_vcpu_ids }}'
+        enabled: true
+      register: result
+
+    - name: Resource group | Assert alter result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.resource_group.enabled == true
+          - result.resource_group.vcpu_ids == available_vcpu_ids
+          - result.resource_group.thread_priority == 0
+
+    - name: Resource group | Gather single resource group after alter
+      ansible.mysql.mysql_resource_group_info:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+      register: result
+
+    - name: Resource group | Assert single-group info after alter
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.resource_groups | length == 1
+          - result.resource_groups[0].name == resource_group_name
+          - result.resource_groups[0].enabled == true
+          - result.resource_groups[0].vcpu_ids == available_vcpu_ids
+          - result.resource_groups[0].thread_priority == 0
+
+    - name: Resource group | Verify altered resource group
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT RESOURCE_GROUP_ENABLED, VCPU_IDS, THREAD_PRIORITY
+          FROM INFORMATION_SCHEMA.RESOURCE_GROUPS
+          WHERE RESOURCE_GROUP_NAME = '{{ resource_group_name }}'
+      register: result
+
+    - name: Resource group | Assert altered resource group state
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['RESOURCE_GROUP_ENABLED'] | bool
+          - (result.query_result[0][0]['VCPU_IDS'] | regex_search('\\d+(?:-\\d+)?(?:,\\d+(?:-\\d+)?)*')) == available_vcpu_ids
+          - result.query_result[0][0]['THREAD_PRIORITY'] == 0
+
+    - name: Resource group | Attempt to set nonzero thread priority
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: present
+        thread_priority: 10
+      register: result
+      ignore_errors: true
+
+    - name: Resource group | Assert nonzero thread priority behavior
+      ansible.builtin.assert:
+        that:
+          - >
+            (result is succeeded and result.resource_group.thread_priority == 10)
+            or
+            (result is failed and 'could not be applied' in result.msg)
+
+    - name: Resource group | Fail on immutable type change
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: present
+        resource_group_type: SYSTEM
+      register: result
+      ignore_errors: true
+
+    - name: Resource group | Assert immutable-type failure
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'resource_group_type is immutable after creation' in result.msg"
+
+    - name: Resource group | Remove in check mode
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: absent
+      check_mode: true
+      register: result
+
+    - name: Resource group | Assert absent check mode result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries[0] == ('DROP RESOURCE GROUP `' ~ resource_group_name ~ '`')
+
+    - name: Resource group | Verify resource group exists after absent check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT RESOURCE_GROUP_NAME
+          FROM INFORMATION_SCHEMA.RESOURCE_GROUPS
+          WHERE RESOURCE_GROUP_NAME = '{{ resource_group_name }}'
+      register: result
+
+    - name: Resource group | Assert resource group still exists after absent check mode
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 1
+
+    - name: Resource group | Remove resource group
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: absent
+      register: result
+
+    - name: Resource group | Assert absent result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries[0] == ('DROP RESOURCE GROUP `' ~ resource_group_name ~ '`')
+
+    - name: Resource group | Verify resource group is absent
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT RESOURCE_GROUP_NAME
+          FROM INFORMATION_SCHEMA.RESOURCE_GROUPS
+          WHERE RESOURCE_GROUP_NAME = '{{ resource_group_name }}'
+      register: result
+
+    - name: Resource group | Assert resource group absent
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 0

--- a/tests/integration/targets/test_mysql_resource_group/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_resource_group/tasks/main.yml
@@ -12,6 +12,7 @@
       login_host: '{{ mysql_host }}'
       login_port: '{{ mysql_primary_port }}'
     resource_group_name: ansible_reporting
+    system_resource_group_name: ansible_system_reporting
 
   block:
     - name: Resource group | Expect module to fail on unsupported servers
@@ -72,6 +73,65 @@
         <<: *mysql_params
         name: '{{ resource_group_name }}'
         state: absent
+
+    - name: Resource group | Ensure SYSTEM resource group is absent
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ system_resource_group_name }}'
+        state: absent
+
+    - name: Resource group | Fail create without resource_group_type
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: present
+      register: result
+      ignore_errors: true
+
+    - name: Resource group | Assert missing-type failure
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'resource_group_type is required when creating a resource group' in result.msg"
+
+    - name: Resource group | Create SYSTEM resource group in check mode
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ system_resource_group_name }}'
+        state: present
+        resource_group_type: SYSTEM
+        vcpu_ids: '{{ first_vcpu }}'
+        thread_priority: -1
+        enabled: false
+      check_mode: true
+      register: result
+
+    - name: Resource group | Assert SYSTEM create check mode result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 1
+          - "'CREATE RESOURCE GROUP' in result.queries[0]"
+          - "'TYPE = SYSTEM' in result.queries[0]"
+          - result.resource_group.name == system_resource_group_name
+          - result.resource_group.resource_group_type == 'SYSTEM'
+          - result.resource_group.enabled == false
+          - result.resource_group.vcpu_ids == first_vcpu
+          - result.resource_group.thread_priority == -1
+
+    - name: Resource group | Verify SYSTEM resource group does not exist after check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT RESOURCE_GROUP_NAME
+          FROM INFORMATION_SCHEMA.RESOURCE_GROUPS
+          WHERE RESOURCE_GROUP_NAME = '{{ system_resource_group_name }}'
+      register: result
+
+    - name: Resource group | Assert SYSTEM resource group absent after check mode
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 0
 
     - name: Resource group | Create in check mode
       ansible.mysql.mysql_resource_group:
@@ -351,6 +411,7 @@
         <<: *mysql_params
         name: '{{ resource_group_name }}'
         state: absent
+        force: true
       check_mode: true
       register: result
 
@@ -358,7 +419,7 @@
       ansible.builtin.assert:
         that:
           - result is changed
-          - result.queries[0] == ('DROP RESOURCE GROUP `' ~ resource_group_name ~ '`')
+          - result.queries[0] == ('DROP RESOURCE GROUP `' ~ resource_group_name ~ '` FORCE')
 
     - name: Resource group | Verify resource group exists after absent check mode
       ansible.mysql.mysql_query:
@@ -400,3 +461,15 @@
       ansible.builtin.assert:
         that:
           - result.rowcount[0] == 0
+
+    - name: Resource group | Re-remove resource group
+      ansible.mysql.mysql_resource_group:
+        <<: *mysql_params
+        name: '{{ resource_group_name }}'
+        state: absent
+      register: result
+
+    - name: Resource group | Assert absent idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed

--- a/tests/unit/plugins/module_utils/test_resource_group.py
+++ b/tests/unit/plugins/module_utils/test_resource_group.py
@@ -2,11 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
-
 import pytest
 
 from ansible_collections.ansible.mysql.plugins.module_utils.resource_group import (

--- a/tests/unit/plugins/module_utils/test_resource_group.py
+++ b/tests/unit/plugins/module_utils/test_resource_group.py
@@ -1,0 +1,92 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+import pytest
+
+from ansible_collections.ansible.mysql.plugins.module_utils.resource_group import (
+    get_server_version_tuple,
+    normalize_resource_group_enabled,
+    normalize_resource_group_row,
+    normalize_vcpu_ids,
+    validate_resource_group_type,
+    validate_thread_priority,
+)
+from ..utils import dummy_cursor_class
+
+
+@pytest.mark.parametrize(
+    'server_version,expected',
+    [
+        ('8.0.38', (8, 0, 38)),
+        ('8.4.9-commercial', (8, 4, 9)),
+        ('9.7.0-foo', (9, 7, 0)),
+    ]
+)
+def test_get_server_version_tuple(server_version, expected):
+    cursor = dummy_cursor_class(server_version, 'dict')
+    assert get_server_version_tuple(cursor) == expected
+
+
+@pytest.mark.parametrize(
+    'input_,output',
+    [
+        ('0-3,9,10', '0-3,9-10'),
+        ('9,10,0,1,2,3', '0-3,9-10'),
+        ('3,2,1,0', '0-3'),
+        ('0', '0'),
+        (b'0-15', '0-15'),
+        (None, None),
+    ]
+)
+def test_normalize_vcpu_ids(input_, output):
+    assert normalize_vcpu_ids(input_) == output
+
+
+@pytest.mark.parametrize(
+    'input_,expected',
+    [
+        (True, True),
+        (False, False),
+        ('YES', True),
+        ('0', False),
+        (1, True),
+    ]
+)
+def test_normalize_resource_group_enabled(input_, expected):
+    assert normalize_resource_group_enabled(input_) == expected
+
+
+def test_normalize_resource_group_row():
+    row = {
+        'RESOURCE_GROUP_NAME': 'reporting',
+        'RESOURCE_GROUP_TYPE': 'USER',
+        'RESOURCE_GROUP_ENABLED': 1,
+        'VCPU_IDS': b'3,2,1,0',
+        'THREAD_PRIORITY': 5,
+    }
+
+    assert normalize_resource_group_row(row) == {
+        'name': 'reporting',
+        'resource_group_type': 'USER',
+        'enabled': True,
+        'vcpu_ids': '0-3',
+        'thread_priority': 5,
+    }
+
+
+@pytest.mark.parametrize(
+    'resource_group_type,thread_priority',
+    [
+        ('USER', -1),
+        ('SYSTEM', 1),
+    ]
+)
+def test_validate_thread_priority_rejects_type_specific_invalid_values(resource_group_type, thread_priority):
+    with pytest.raises(ValueError):
+        validate_thread_priority(validate_resource_group_type(resource_group_type), thread_priority)

--- a/tests/unit/plugins/modules/test_mysql_resource_group.py
+++ b/tests/unit/plugins/modules/test_mysql_resource_group.py
@@ -4,37 +4,59 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 from ansible_collections.ansible.mysql.plugins.modules.mysql_resource_group import (
     build_alter_query,
     build_create_query,
-    normalize_vcpu_ids,
+    build_drop_query,
+    execute_query,
+    normalize_resource_group_inputs,
 )
 
 
 @pytest.mark.parametrize(
-    'input_,output',
+    'resource_group_type,vcpu_ids,expected',
     [
-        ('0-3,9,10', '0-3,9-10'),
-        ('9,10,0,1,2,3', '0-3,9-10'),
-        ('3,2,1,0', '0-3'),
-        ('0', '0'),
-        (b'0-15', '0-15'),
-        (None, None),
+        ('user', '3,2,1,0', ('USER', '0-3')),
+        (None, None, (None, None)),
     ]
 )
-def test_normalize_vcpu_ids(input_, output):
-    assert normalize_vcpu_ids(input_) == output
+def test_normalize_resource_group_inputs(resource_group_type, vcpu_ids, expected):
+    assert normalize_resource_group_inputs(resource_group_type, vcpu_ids) == expected
 
 
 def test_build_create_query():
     assert build_create_query(
         'reporting',
         'USER',
-        vcpu_ids='3,2,1,0',
+        vcpu_ids='0-3',
         thread_priority=5,
         enabled=False,
     ) == "CREATE RESOURCE GROUP `reporting` TYPE = USER VCPU = 0-3 THREAD_PRIORITY = 5 DISABLE"
+
+
+@pytest.mark.parametrize(
+    'force,expected',
+    [
+        (False, "DROP RESOURCE GROUP `reporting`"),
+        (True, "DROP RESOURCE GROUP `reporting` FORCE"),
+    ]
+)
+def test_build_drop_query(force, expected):
+    assert build_drop_query('reporting', force=force) == expected
+
+
+def test_execute_query_does_not_fetch_after_execute():
+    cursor = MagicMock()
+
+    execute_query(cursor, 'DROP RESOURCE GROUP `reporting`')
+
+    cursor.execute.assert_called_once_with('DROP RESOURCE GROUP `reporting`')
+    cursor.fetchall.assert_not_called()
 
 
 def test_build_alter_query_returns_none_when_nothing_changes():
@@ -50,7 +72,7 @@ def test_build_alter_query_returns_none_when_nothing_changes():
         'reporting',
         current,
         resource_group_type='USER',
-        vcpu_ids='3,2,1,0',
+        vcpu_ids='0-3',
         thread_priority=5,
         enabled=True,
     ) is None
@@ -69,7 +91,7 @@ def test_build_alter_query_updates_only_changed_fields():
         'reporting',
         current,
         resource_group_type='USER',
-        vcpu_ids='4,5,6,7',
+        vcpu_ids='4-7',
         thread_priority=10,
         enabled=False,
     ) == "ALTER RESOURCE GROUP `reporting` VCPU = 4-7 THREAD_PRIORITY = 10 DISABLE"

--- a/tests/unit/plugins/modules/test_mysql_resource_group.py
+++ b/tests/unit/plugins/modules/test_mysql_resource_group.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.ansible.mysql.plugins.modules.mysql_resource_group import (
+    build_alter_query,
+    build_create_query,
+    normalize_vcpu_ids,
+)
+
+
+@pytest.mark.parametrize(
+    'input_,output',
+    [
+        ('0-3,9,10', '0-3,9-10'),
+        ('9,10,0,1,2,3', '0-3,9-10'),
+        ('3,2,1,0', '0-3'),
+        ('0', '0'),
+        (b'0-15', '0-15'),
+        (None, None),
+    ]
+)
+def test_normalize_vcpu_ids(input_, output):
+    assert normalize_vcpu_ids(input_) == output
+
+
+def test_build_create_query():
+    assert build_create_query(
+        'reporting',
+        'USER',
+        vcpu_ids='3,2,1,0',
+        thread_priority=5,
+        enabled=False,
+    ) == "CREATE RESOURCE GROUP `reporting` TYPE = USER VCPU = 0-3 THREAD_PRIORITY = 5 DISABLE"
+
+
+def test_build_alter_query_returns_none_when_nothing_changes():
+    current = {
+        'name': 'reporting',
+        'resource_group_type': 'USER',
+        'vcpu_ids': '0-3',
+        'thread_priority': 5,
+        'enabled': True,
+    }
+
+    assert build_alter_query(
+        'reporting',
+        current,
+        resource_group_type='USER',
+        vcpu_ids='3,2,1,0',
+        thread_priority=5,
+        enabled=True,
+    ) is None
+
+
+def test_build_alter_query_updates_only_changed_fields():
+    current = {
+        'name': 'reporting',
+        'resource_group_type': 'USER',
+        'vcpu_ids': '0-3',
+        'thread_priority': 0,
+        'enabled': True,
+    }
+
+    assert build_alter_query(
+        'reporting',
+        current,
+        resource_group_type='USER',
+        vcpu_ids='4,5,6,7',
+        thread_priority=10,
+        enabled=False,
+    ) == "ALTER RESOURCE GROUP `reporting` VCPU = 4-7 THREAD_PRIORITY = 10 DISABLE"
+
+
+def test_build_alter_query_fails_on_resource_group_type_change():
+    current = {
+        'name': 'reporting',
+        'resource_group_type': 'USER',
+        'vcpu_ids': '0-3',
+        'thread_priority': 0,
+        'enabled': True,
+    }
+
+    with pytest.raises(ValueError, match='resource_group_type is immutable'):
+        build_alter_query(
+            'reporting',
+            current,
+            resource_group_type='SYSTEM',
+        )
+
+
+def test_build_create_query_allows_system_negative_priority():
+    assert build_create_query(
+        'system_group',
+        'SYSTEM',
+        thread_priority=-5,
+    ) == "CREATE RESOURCE GROUP `system_group` TYPE = SYSTEM THREAD_PRIORITY = -5"

--- a/tests/unit/plugins/modules/test_mysql_resource_group_info.py
+++ b/tests/unit/plugins/modules/test_mysql_resource_group_info.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+from ansible_collections.ansible.mysql.plugins.modules.mysql_resource_group_info import MySQLResourceGroupsInfo
+
+
+def test_get_info_returns_normalized_resource_groups():
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [
+        {
+            'RESOURCE_GROUP_NAME': 'USR_default',
+            'RESOURCE_GROUP_TYPE': 'USER',
+            'RESOURCE_GROUP_ENABLED': 'YES',
+            'VCPU_IDS': '0-3',
+            'THREAD_PRIORITY': 0,
+        },
+        {
+            'RESOURCE_GROUP_NAME': 'reporting',
+            'RESOURCE_GROUP_TYPE': 'USER',
+            'RESOURCE_GROUP_ENABLED': 'NO',
+            'VCPU_IDS': '3,2,1,0',
+            'THREAD_PRIORITY': 5,
+        },
+    ]
+
+    info = MySQLResourceGroupsInfo(cursor)
+
+    assert info.get_info() == {
+        'resource_groups': [
+            {
+                'name': 'USR_default',
+                'resource_group_type': 'USER',
+                'enabled': True,
+                'vcpu_ids': '0-3',
+                'thread_priority': 0,
+            },
+            {
+                'name': 'reporting',
+                'resource_group_type': 'USER',
+                'enabled': False,
+                'vcpu_ids': '0-3',
+                'thread_priority': 5,
+            },
+        ]
+    }
+    cursor.execute.assert_called_once_with(
+        'SELECT RESOURCE_GROUP_NAME, RESOURCE_GROUP_TYPE, RESOURCE_GROUP_ENABLED, VCPU_IDS, THREAD_PRIORITY '
+        'FROM INFORMATION_SCHEMA.RESOURCE_GROUPS ORDER BY RESOURCE_GROUP_NAME'
+    )
+
+
+def test_get_info_filters_by_name():
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [
+        {
+            'RESOURCE_GROUP_NAME': 'reporting',
+            'RESOURCE_GROUP_TYPE': 'USER',
+            'RESOURCE_GROUP_ENABLED': 'NO',
+            'VCPU_IDS': '7,6,5,4',
+            'THREAD_PRIORITY': 10,
+        }
+    ]
+
+    info = MySQLResourceGroupsInfo(cursor)
+
+    assert info.get_info(name='reporting') == {
+        'resource_groups': [
+            {
+                'name': 'reporting',
+                'resource_group_type': 'USER',
+                'enabled': False,
+                'vcpu_ids': '4-7',
+                'thread_priority': 10,
+            }
+        ]
+    }
+    cursor.execute.assert_called_once_with(
+        'SELECT RESOURCE_GROUP_NAME, RESOURCE_GROUP_TYPE, RESOURCE_GROUP_ENABLED, VCPU_IDS, THREAD_PRIORITY '
+        'FROM INFORMATION_SCHEMA.RESOURCE_GROUPS WHERE RESOURCE_GROUP_NAME = %s ORDER BY RESOURCE_GROUP_NAME',
+        ('reporting',)
+    )

--- a/tests/unit/plugins/modules/test_mysql_resource_group_info.py
+++ b/tests/unit/plugins/modules/test_mysql_resource_group_info.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from mock import MagicMock
 
-from ansible_collections.ansible.mysql.plugins.modules.mysql_resource_group_info import MySQLResourceGroupsInfo
+from ansible_collections.ansible.mysql.plugins.modules.mysql_resource_group_info import get_resource_groups_info
 
 
 def test_get_info_returns_normalized_resource_groups():
@@ -30,9 +30,7 @@ def test_get_info_returns_normalized_resource_groups():
         },
     ]
 
-    info = MySQLResourceGroupsInfo(cursor)
-
-    assert info.get_info() == {
+    assert get_resource_groups_info(cursor) == {
         'resource_groups': [
             {
                 'name': 'USR_default',
@@ -68,9 +66,7 @@ def test_get_info_filters_by_name():
         }
     ]
 
-    info = MySQLResourceGroupsInfo(cursor)
-
-    assert info.get_info(name='reporting') == {
+    assert get_resource_groups_info(cursor, name='reporting') == {
         'resource_groups': [
             {
                 'name': 'reporting',


### PR DESCRIPTION
#### SUMMARY
- add `mysql_resource_group` to manage MySQL 8.0 resource groups with create, update, delete, check mode, and idempotent state handling
- add `mysql_resource_group_info` to gather normalized resource-group definitions
- add shared utility helpers plus unit/integration coverage and collection metadata/testing updates

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- TESTING.md
- meta/runtime.yml
- plugins/module_utils/resource_group.py
- plugins/modules/mysql_resource_group.py
- plugins/modules/mysql_resource_group_info.py
- tests/integration/targets/test_mysql_resource_group/defaults/main.yml
- tests/integration/targets/test_mysql_resource_group/meta/main.yml
- tests/integration/targets/test_mysql_resource_group/tasks/main.yml
- tests/unit/plugins/module_utils/test_resource_group.py
- tests/unit/plugins/modules/test_mysql_resource_group.py
- tests/unit/plugins/modules/test_mysql_resource_group_info.py

#### ADDITIONAL INFORMATION
- supports MySQL 8.0+ only; resource groups remain unsupported on MariaDB
- includes unit tests for shared helpers and module query builders
- includes integration coverage for create, alter, absent, info lookups, idempotency, check mode, and type-specific thread priority validation
- Created with the help of GPT5.4 with Human in the loop and manual testing
