### PR TITLE
Add mysql_slow_log module for slow query log management

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Every voice is important and every idea is valuable. If you have something on yo
   - [mysql_query](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_query_module.html)
   - [mysql_replication](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_replication_module.html)
   - [mysql_role](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_role_module.html)
+  - [mysql_slow_log](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_slow_log_module.html)
   - [mysql_user](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_user_module.html)
   - [mysql_variables](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_variables_module.html)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -93,6 +93,7 @@ The Makefile accept the following options
     - "test_mysql_query"
     - "test_mysql_replication"
     - "test_mysql_role"
+    - "test_mysql_slow_log"
     - "test_mysql_user"
     - "test_mysql_variables"
   - Description: If omitted, all test targets will run. But you can limit the tests to a single target to speed up your tests.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -8,5 +8,6 @@ action_groups:
     - mysql_query
     - mysql_replication
     - mysql_role
+    - mysql_slow_log
     - mysql_user
     - mysql_variables

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -27,7 +27,6 @@ options:
     description:
       - Enable or disable the slow query log.
     type: bool
-    version_added: '5.1.0'
   long_query_time:
     description:
       - Log queries that run longer than this number of seconds.

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -43,7 +43,6 @@ options:
       - NONE
       - FILE,TABLE
       - TABLE,FILE
-    version_added: '5.1.0'
   log_queries_not_using_indexes:
     description:
       - Whether to log queries that do not use indexes.

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -31,7 +31,6 @@ options:
     description:
       - Log queries that run longer than this number of seconds.
     type: float
-    version_added: '5.1.0'
   log_output:
     description:
       - Output destination for the slow query log.

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -18,7 +18,7 @@ description:
   - Supports enabling the slow query log, setting thresholds and output, and rotating file-based slow logs.
 
 author:
-  - Ron Gershburg (@rgershbu)
+  - Ron Gershburg (@ronger4)
 
 version_added: '5.1.0'
 
@@ -86,7 +86,7 @@ EXAMPLES = r'''
 - name: Enable slow query logging to a file with a one second threshold
   ansible.mysql.mysql_slow_log:
     login_user: root
-    login_unix_socket: /run/mysqld/mysqld.sock
+    login_password: rootpass
     enabled: true
     long_query_time: 1
     log_output: FILE
@@ -148,12 +148,12 @@ def typedvalue(value):
 
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except ValueError:
         pass
 
     try:
         return float(value)
-    except (TypeError, ValueError):
+    except ValueError:
         pass
 
     return value

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -1,0 +1,402 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_slow_log
+
+short_description: Manage MySQL or MariaDB slow query log settings
+
+description:
+  - Manage MySQL or MariaDB slow query log runtime settings.
+  - Supports enabling the slow query log, setting thresholds and output, and rotating file-based slow logs.
+
+author:
+  - Ron Gershburg (@rgershbu)
+
+version_added: '5.1.0'
+
+options:
+  enabled:
+    description:
+      - Enable or disable the slow query log.
+    type: bool
+    version_added: '5.1.0'
+  long_query_time:
+    description:
+      - Log queries that run longer than this number of seconds.
+    type: float
+    version_added: '5.1.0'
+  log_output:
+    description:
+      - Output destination for the slow query log.
+      - Use C(FILE,TABLE) to log to both destinations.
+      - The module normalizes C(TABLE,FILE) to C(FILE,TABLE).
+    type: str
+    choices:
+      - FILE
+      - TABLE
+      - NONE
+      - FILE,TABLE
+      - TABLE,FILE
+    version_added: '5.1.0'
+  log_queries_not_using_indexes:
+    description:
+      - Whether to log queries that do not use indexes.
+    type: bool
+    version_added: '5.1.0'
+  min_examined_row_limit:
+    description:
+      - Log only queries that examine at least this many rows.
+    type: int
+    version_added: '5.1.0'
+  flush:
+    description:
+      - Rotate the slow query log by executing C(FLUSH SLOW LOGS).
+      - This requires the effective C(log_output) to include C(FILE).
+      - This action is not idempotent and always reports a change when requested.
+    type: bool
+    default: false
+    version_added: '5.1.0'
+
+notes:
+  - Compatible with MariaDB or MySQL.
+  - The module manages global runtime slow-log settings only.
+  - The C(flush) action requires the server privilege needed to execute C(FLUSH SLOW LOGS).
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: partial
+    details:
+      - Setting changes are idempotent.
+      - When O(flush=true) is requested, the module always reports a change.
+
+seealso:
+  - module: ansible.mysql.mysql_info
+  - module: ansible.mysql.mysql_query
+  - module: ansible.mysql.mysql_variables
+
+extends_documentation_fragment:
+  - ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Enable slow query logging to a file with a one second threshold
+  ansible.mysql.mysql_slow_log:
+    login_user: root
+    login_unix_socket: /run/mysqld/mysqld.sock
+    enabled: true
+    long_query_time: 1
+    log_output: FILE
+    min_examined_row_limit: 100
+
+- name: Enable verbose slow query logging in development
+  ansible.mysql.mysql_slow_log:
+    login_user: root
+    login_password: rootpass
+    enabled: true
+    long_query_time: 0.5
+    log_output: TABLE
+    log_queries_not_using_indexes: true
+
+- name: Rotate a file-based slow query log
+  ansible.mysql.mysql_slow_log:
+    login_user: root
+    login_password: rootpass
+    flush: true
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed queries which modified DB state.
+  returned: always
+  type: list
+  sample:
+    - SET GLOBAL `slow_query_log` = ON
+    - FLUSH SLOW LOGS
+settings:
+  description: Effective slow query log settings after applying requested changes.
+  returned: always
+  type: dict
+  sample:
+    enabled: 'ON'
+    long_query_time: 1.0
+    log_output: FILE
+    log_queries_not_using_indexes: 'OFF'
+    min_examined_row_limit: 100
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.ansible.mysql.plugins.module_utils.database import mysql_quote_identifier
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    get_server_implementation,
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+
+
+def typedvalue(value):
+    """Convert value to number whenever possible, return the same value otherwise."""
+    if isinstance(value, (bool, int, float)):
+        return value
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        pass
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        pass
+
+    return value
+
+
+def get_variable(cursor, mysqlvar):
+    cursor.execute("SHOW GLOBAL VARIABLES WHERE Variable_name = %s", (mysqlvar,))
+    mysqlvar_val = cursor.fetchall()
+    if len(mysqlvar_val) == 1:
+        return mysqlvar_val[0][1]
+    else:
+        return None
+
+
+def set_variable(cursor, mysqlvar, value, executed_queries):
+    query = "SET GLOBAL %s = " % mysql_quote_identifier(mysqlvar, 'vars')
+    try:
+        cursor.execute(query + "%s", (value,))
+        executed_queries.append(query + "%s" % value)
+        cursor.fetchall()
+        result = True
+    except Exception as e:
+        result = to_native(e)
+
+    return result
+
+
+def convert_bool_setting_value_wanted(val):
+    """Convert 0/1/on/off values to the ON/OFF representation used by the server."""
+    if isinstance(val, str):
+        val = val.upper()
+
+    if val in ('ON', '1', 1, True):
+        val = 'ON'
+    elif val in ('OFF', '0', 0, False):
+        val = 'OFF'
+
+    return val
+
+
+class MySQLSlowLog(object):
+    VARIABLE_CANDIDATES = {
+        'enabled': {
+            'mysql': ('slow_query_log',),
+            'mariadb': ('log_slow_query', 'slow_query_log'),
+        },
+        'long_query_time': {
+            'mysql': ('long_query_time',),
+            'mariadb': ('log_slow_query_time', 'long_query_time'),
+        },
+        'log_output': {
+            'mysql': ('log_output',),
+            'mariadb': ('log_output',),
+        },
+        'log_queries_not_using_indexes': {
+            'mysql': ('log_queries_not_using_indexes',),
+            'mariadb': ('log_queries_not_using_indexes',),
+        },
+        'min_examined_row_limit': {
+            'mysql': ('min_examined_row_limit',),
+            'mariadb': ('log_slow_min_examined_row_limit', 'min_examined_row_limit'),
+        },
+    }
+
+    def __init__(self, module, cursor, server_implementation):
+        self.module = module
+        self.cursor = cursor
+        self.server_implementation = server_implementation
+        self.variable_names = {}
+
+    def configure(self, desired_settings, flush=False, check_mode=False):
+        current_settings = self.get_current_settings()
+        effective_settings = current_settings.copy()
+        planned_changes = []
+
+        for setting_name, value in desired_settings.items():
+            if value is None:
+                continue
+
+            normalized_value = self.normalize_value(setting_name, value)
+            effective_settings[setting_name] = normalized_value
+
+            if normalized_value != current_settings[setting_name]:
+                planned_changes.append((setting_name, self.variable_names[setting_name], normalized_value))
+
+        if flush:
+            self.validate_flush(effective_settings['log_output'])
+
+        changed = bool(planned_changes) or flush
+        queries = []
+
+        if check_mode:
+            for _setting_name, variable_name, value in planned_changes:
+                queries.append(self.format_set_query(variable_name, value))
+
+            if flush:
+                queries.append('FLUSH SLOW LOGS')
+
+            return dict(changed=changed, queries=queries, settings=effective_settings)
+
+        for _setting_name, variable_name, value in planned_changes:
+            result = set_variable(self.cursor, variable_name, value, queries)
+            if result is not True:
+                self.module.fail_json(msg=result, changed=False)
+
+        if flush:
+            try:
+                self.cursor.execute('FLUSH SLOW LOGS')
+                self.cursor.fetchall()
+            except Exception as e:
+                self.module.fail_json(msg="Cannot execute SQL 'FLUSH SLOW LOGS': %s" % to_native(e))
+            queries.append('FLUSH SLOW LOGS')
+
+        return dict(changed=changed, queries=queries, settings=effective_settings)
+
+    def get_current_settings(self):
+        settings = {}
+
+        for setting_name in self.VARIABLE_CANDIDATES:
+            variable_name, value = self.read_setting(setting_name)
+            self.variable_names[setting_name] = variable_name
+            settings[setting_name] = self.normalize_value(setting_name, value)
+
+        return settings
+
+    def read_setting(self, setting_name):
+        for variable_name in self.VARIABLE_CANDIDATES[setting_name][self.server_implementation]:
+            value = get_variable(self.cursor, variable_name)
+            if value is not None:
+                return variable_name, value
+
+        self.module.fail_json(
+            msg='Slow log setting "%s" is not available on this server.' % setting_name,
+            changed=False,
+        )
+
+    def normalize_value(self, setting_name, value):
+        if setting_name in ('enabled', 'log_queries_not_using_indexes'):
+            return convert_bool_setting_value_wanted(value)
+        if setting_name == 'log_output':
+            return self.normalize_log_output(value)
+        return typedvalue(value)
+
+    def normalize_log_output(self, value):
+        output_parts = []
+        for part in str(value).split(','):
+            part = part.strip().upper()
+            if part and part not in output_parts:
+                output_parts.append(part)
+
+        allowed_values = ('FILE', 'TABLE', 'NONE')
+        if not output_parts or any(part not in allowed_values for part in output_parts):
+            self.module.fail_json(msg='log_output must be FILE, TABLE, NONE, or FILE,TABLE')
+
+        if 'NONE' in output_parts and len(output_parts) > 1:
+            self.module.fail_json(msg='log_output cannot combine NONE with other values')
+
+        if set(output_parts) == set(['FILE', 'TABLE']):
+            return 'FILE,TABLE'
+
+        return output_parts[0]
+
+    def validate_flush(self, log_output):
+        if 'FILE' not in log_output.split(','):
+            self.module.fail_json(msg='flush requires FILE log_output')
+
+    @staticmethod
+    def format_set_query(variable_name, value):
+        return "SET GLOBAL `%s` = %s" % (variable_name, value)
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        enabled=dict(type='bool'),
+        long_query_time=dict(type='float'),
+        log_output=dict(type='str', choices=['FILE', 'TABLE', 'NONE', 'FILE,TABLE', 'TABLE,FILE']),
+        log_queries_not_using_indexes=dict(type='bool'),
+        min_examined_row_limit=dict(type='int'),
+        flush=dict(type='bool', default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    connect_timeout = module.params['connect_timeout']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    ssl_cert = module.params['client_cert']
+    ssl_key = module.params['client_key']
+    ssl_ca = module.params['ca_cert']
+    check_hostname = module.params['check_hostname']
+    config_file = module.params['config_file']
+
+    try:
+        cursor, _db_conn = mysql_connect(
+            module,
+            login_user,
+            login_password,
+            config_file,
+            ssl_cert,
+            ssl_key,
+            ssl_ca,
+            'mysql',
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+        )
+    except Exception as e:
+        module.fail_json(
+            msg="unable to connect to database, check login_user and "
+                "login_password are correct or %s has the credentials. "
+                "Exception message: %s" % (config_file, to_native(e))
+        )
+
+    desired_settings = {
+        'enabled': module.params['enabled'],
+        'long_query_time': module.params['long_query_time'],
+        'log_output': module.params['log_output'],
+        'log_queries_not_using_indexes': module.params['log_queries_not_using_indexes'],
+        'min_examined_row_limit': module.params['min_examined_row_limit'],
+    }
+
+    slow_log = MySQLSlowLog(module, cursor, get_server_implementation(cursor))
+
+    module.exit_json(
+        **slow_log.configure(
+            desired_settings,
+            flush=module.params['flush'],
+            check_mode=module.check_mode,
+        )
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -48,7 +48,6 @@ options:
     description:
       - Whether to log queries that do not use indexes.
     type: bool
-    version_added: '5.1.0'
   min_examined_row_limit:
     description:
       - Log only queries that examine at least this many rows.

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -58,7 +58,6 @@ options:
       - This action is not idempotent and always reports a change when requested.
     type: bool
     default: false
-    version_added: '5.1.0'
 
 notes:
   - Compatible with MariaDB or MySQL.

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -54,7 +54,7 @@ options:
   flush:
     description:
       - Rotate the slow query log by executing C(FLUSH SLOW LOGS).
-      - This requires the effective C(log_output) to include C(FILE).
+      - This requires the effective O(log_output) to include V(FILE).
       - This action is not idempotent and always reports a change when requested.
     type: bool
     default: false

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -34,8 +34,8 @@ options:
   log_output:
     description:
       - Output destination for the slow query log.
-      - Use C(FILE,TABLE) to log to both destinations.
-      - The module normalizes C(TABLE,FILE) to C(FILE,TABLE).
+      - Use V(FILE,TABLE) to log to both destinations.
+      - The module normalizes V(TABLE,FILE) to V(FILE,TABLE).
     type: str
     choices:
       - FILE

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -51,7 +51,6 @@ options:
     description:
       - Log only queries that examine at least this many rows.
     type: int
-    version_added: '5.1.0'
   flush:
     description:
       - Rotate the slow query log by executing C(FLUSH SLOW LOGS).

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -62,7 +62,7 @@ options:
 notes:
   - Compatible with MariaDB or MySQL.
   - The module manages global runtime slow-log settings only.
-  - The C(flush) action requires the server privilege needed to execute C(FLUSH SLOW LOGS).
+  - The O(flush) action requires the server privilege needed to execute C(FLUSH SLOW LOGS).
 
 attributes:
   check_mode:

--- a/tests/integration/targets/test_mysql_slow_log/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_slow_log/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for test_mysql_slow_log
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_slow_log/meta/main.yml
+++ b/tests/integration/targets/test_mysql_slow_log/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_slow_log/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_slow_log/tasks/main.yml
@@ -1,0 +1,218 @@
+---
+
+- name: MySQL slow log | Run integration checks
+  vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+    - name: MySQL slow log | Set variable names for MySQL
+      ansible.builtin.set_fact:
+        slow_log_enabled_var: slow_query_log
+        slow_log_time_var: long_query_time
+        slow_log_rows_var: min_examined_row_limit
+      when: db_engine == 'mysql'
+
+    - name: MySQL slow log | Set variable names for MariaDB
+      ansible.builtin.set_fact:
+        slow_log_enabled_var: log_slow_query
+        slow_log_time_var: log_slow_query_time
+        slow_log_rows_var: log_slow_min_examined_row_limit
+      when: db_engine == 'mariadb'
+
+    - name: MySQL slow log | Set baseline settings
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        enabled: false
+        long_query_time: 10
+        log_output: TABLE
+        log_queries_not_using_indexes: false
+        min_examined_row_limit: 0
+
+    - name: MySQL slow log | Query baseline settings
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_enabled_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_time_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_output'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_queries_not_using_indexes'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_rows_var }}'"
+      register: slow_log_baseline
+
+    - name: MySQL slow log | Assert baseline settings
+      ansible.builtin.assert:
+        that:
+          - slow_log_baseline.query_result[0][0].Value in ['OFF', '0']
+          - slow_log_baseline.query_result[1][0].Value | float == 10.0
+          - slow_log_baseline.query_result[2][0].Value == 'TABLE'
+          - slow_log_baseline.query_result[3][0].Value in ['OFF', '0']
+          - slow_log_baseline.query_result[4][0].Value | int == 0
+
+    - name: MySQL slow log | Configure settings in check mode
+      check_mode: true
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        enabled: true
+        long_query_time: 0.5
+        log_output: 'FILE,TABLE'
+        log_queries_not_using_indexes: true
+        min_examined_row_limit: 10
+      register: slow_log_check
+
+    - name: MySQL slow log | Assert check mode result
+      ansible.builtin.assert:
+        that:
+          - slow_log_check is changed
+          - slow_log_check.queries == expected_queries
+      vars:
+        expected_queries:
+          - "SET GLOBAL `{{ slow_log_enabled_var }}` = ON"
+          - "SET GLOBAL `{{ slow_log_time_var }}` = 0.5"
+          - "SET GLOBAL `log_output` = FILE,TABLE"
+          - "SET GLOBAL `log_queries_not_using_indexes` = ON"
+          - "SET GLOBAL `{{ slow_log_rows_var }}` = 10"
+
+    - name: MySQL slow log | Verify check mode left baseline settings unchanged
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_enabled_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_time_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_output'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_queries_not_using_indexes'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_rows_var }}'"
+      register: slow_log_check_state
+
+    - name: MySQL slow log | Assert check mode did not change state
+      ansible.builtin.assert:
+        that:
+          - slow_log_check_state.query_result[0][0].Value in ['OFF', '0']
+          - slow_log_check_state.query_result[1][0].Value | float == 10.0
+          - slow_log_check_state.query_result[2][0].Value == 'TABLE'
+          - slow_log_check_state.query_result[3][0].Value in ['OFF', '0']
+          - slow_log_check_state.query_result[4][0].Value | int == 0
+
+    - name: MySQL slow log | Configure settings
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        enabled: true
+        long_query_time: 0.5
+        log_output: 'FILE,TABLE'
+        log_queries_not_using_indexes: true
+        min_examined_row_limit: 10
+      register: slow_log_result
+
+    - name: MySQL slow log | Assert apply result
+      ansible.builtin.assert:
+        that:
+          - slow_log_result is changed
+          - slow_log_result.queries == expected_queries
+      vars:
+        expected_queries:
+          - "SET GLOBAL `{{ slow_log_enabled_var }}` = ON"
+          - "SET GLOBAL `{{ slow_log_time_var }}` = 0.5"
+          - "SET GLOBAL `log_output` = FILE,TABLE"
+          - "SET GLOBAL `log_queries_not_using_indexes` = ON"
+          - "SET GLOBAL `{{ slow_log_rows_var }}` = 10"
+
+    - name: MySQL slow log | Query applied settings
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_enabled_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_time_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_output'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_queries_not_using_indexes'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_rows_var }}'"
+      register: slow_log_state
+
+    - name: MySQL slow log | Assert applied settings
+      ansible.builtin.assert:
+        that:
+          - slow_log_state.query_result[0][0].Value in ['ON', '1']
+          - slow_log_state.query_result[1][0].Value | float == 0.5
+          - slow_log_state.query_result[2][0].Value | replace(' ', '') in ['FILE,TABLE', 'TABLE,FILE']
+          - slow_log_state.query_result[3][0].Value in ['ON', '1']
+          - slow_log_state.query_result[4][0].Value | int == 10
+
+    - name: MySQL slow log | Re-run configuration for idempotency
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        enabled: true
+        long_query_time: 0.5
+        log_output: 'TABLE,FILE'
+        log_queries_not_using_indexes: true
+        min_examined_row_limit: 10
+      register: slow_log_idempotency
+
+    - name: MySQL slow log | Assert idempotency
+      ansible.builtin.assert:
+        that:
+          - slow_log_idempotency is not changed
+          - slow_log_idempotency.queries == []
+
+    - name: MySQL slow log | Flush in check mode
+      check_mode: true
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        flush: true
+      register: slow_log_flush_check
+
+    - name: MySQL slow log | Assert flush check mode result
+      ansible.builtin.assert:
+        that:
+          - slow_log_flush_check is changed
+          - slow_log_flush_check.queries == ['FLUSH SLOW LOGS']
+
+    - name: MySQL slow log | Flush slow log
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        flush: true
+      register: slow_log_flush
+
+    - name: MySQL slow log | Assert flush result
+      ansible.builtin.assert:
+        that:
+          - slow_log_flush is changed
+          - slow_log_flush.queries == ['FLUSH SLOW LOGS']
+
+    - name: MySQL slow log | Set table-only output
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        log_output: TABLE
+      register: table_only_result
+
+    - name: MySQL slow log | Assert table-only output was applied
+      ansible.builtin.assert:
+        that:
+          - table_only_result is changed
+          - table_only_result.queries == ["SET GLOBAL `log_output` = TABLE"]
+
+    - name: MySQL slow log | Verify table-only output
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE 'log_output'"
+      register: table_only_state
+
+    - name: MySQL slow log | Assert table-only output state
+      ansible.builtin.assert:
+        that:
+          - table_only_state.query_result[0][0].Value == 'TABLE'
+
+    - name: MySQL slow log | Flush should fail with table-only output
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        flush: true
+      register: table_flush_failure
+      ignore_errors: true
+
+    - name: MySQL slow log | Assert table-only flush failure
+      ansible.builtin.assert:
+        that:
+          - table_flush_failure is failed
+          - "'flush requires FILE log_output' in table_flush_failure.msg"

--- a/tests/integration/targets/test_mysql_slow_log/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_slow_log/tasks/main.yml
@@ -52,6 +52,181 @@
           - slow_log_baseline.query_result[3][0].Value in ['OFF', '0']
           - slow_log_baseline.query_result[4][0].Value | int == 0
 
+    - name: MySQL slow log | Apply standalone FILE example settings
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        enabled: true
+        long_query_time: 1
+        log_output: FILE
+        min_examined_row_limit: 100
+      register: slow_log_file_example
+
+    - name: MySQL slow log | Assert standalone FILE example result
+      ansible.builtin.assert:
+        that:
+          - slow_log_file_example is changed
+          - slow_log_file_example.queries == expected_queries
+      vars:
+        expected_queries:
+          - "SET GLOBAL `{{ slow_log_enabled_var }}` = ON"
+          - "SET GLOBAL `{{ slow_log_time_var }}` = 1.0"
+          - "SET GLOBAL `log_output` = FILE"
+          - "SET GLOBAL `{{ slow_log_rows_var }}` = 100"
+
+    - name: MySQL slow log | Query standalone FILE example settings
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_enabled_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_time_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_output'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_queries_not_using_indexes'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_rows_var }}'"
+      register: slow_log_file_example_state
+
+    - name: MySQL slow log | Assert standalone FILE example settings
+      ansible.builtin.assert:
+        that:
+          - slow_log_file_example_state.query_result[0][0].Value in ['ON', '1']
+          - slow_log_file_example_state.query_result[1][0].Value | float == 1.0
+          - slow_log_file_example_state.query_result[2][0].Value == 'FILE'
+          - slow_log_file_example_state.query_result[3][0].Value in ['OFF', '0']
+          - slow_log_file_example_state.query_result[4][0].Value | int == 100
+
+    - name: MySQL slow log | Restore baseline after FILE example
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        enabled: false
+        long_query_time: 10
+        log_output: TABLE
+        log_queries_not_using_indexes: false
+        min_examined_row_limit: 0
+      register: slow_log_restore_after_file_example
+
+    - name: MySQL slow log | Assert baseline restore after FILE example
+      ansible.builtin.assert:
+        that:
+          - slow_log_restore_after_file_example is changed
+          - slow_log_restore_after_file_example.queries == expected_queries
+      vars:
+        expected_queries:
+          - "SET GLOBAL `{{ slow_log_enabled_var }}` = OFF"
+          - "SET GLOBAL `{{ slow_log_time_var }}` = 10.0"
+          - "SET GLOBAL `log_output` = TABLE"
+          - "SET GLOBAL `{{ slow_log_rows_var }}` = 0"
+
+    - name: MySQL slow log | Apply standalone TABLE example settings
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        enabled: true
+        long_query_time: 0.5
+        log_output: TABLE
+        log_queries_not_using_indexes: true
+      register: slow_log_table_example
+
+    - name: MySQL slow log | Assert standalone TABLE example result
+      ansible.builtin.assert:
+        that:
+          - slow_log_table_example is changed
+          - slow_log_table_example.queries == expected_queries
+      vars:
+        expected_queries:
+          - "SET GLOBAL `{{ slow_log_enabled_var }}` = ON"
+          - "SET GLOBAL `{{ slow_log_time_var }}` = 0.5"
+          - "SET GLOBAL `log_queries_not_using_indexes` = ON"
+
+    - name: MySQL slow log | Query standalone TABLE example settings
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_enabled_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_time_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_output'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_queries_not_using_indexes'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_rows_var }}'"
+      register: slow_log_table_example_state
+
+    - name: MySQL slow log | Assert standalone TABLE example settings
+      ansible.builtin.assert:
+        that:
+          - slow_log_table_example_state.query_result[0][0].Value in ['ON', '1']
+          - slow_log_table_example_state.query_result[1][0].Value | float == 0.5
+          - slow_log_table_example_state.query_result[2][0].Value == 'TABLE'
+          - slow_log_table_example_state.query_result[3][0].Value in ['ON', '1']
+          - slow_log_table_example_state.query_result[4][0].Value | int == 0
+
+    - name: MySQL slow log | Disable slow log after enabling it
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        enabled: false
+      register: slow_log_disable
+
+    - name: MySQL slow log | Assert disable result
+      ansible.builtin.assert:
+        that:
+          - slow_log_disable is changed
+          - slow_log_disable.queries == ["SET GLOBAL `{{ slow_log_enabled_var }}` = OFF"]
+
+    - name: MySQL slow log | Query disabled slow log settings
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_enabled_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_time_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_output'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_queries_not_using_indexes'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_rows_var }}'"
+      register: slow_log_disabled_state
+
+    - name: MySQL slow log | Assert disabled slow log settings
+      ansible.builtin.assert:
+        that:
+          - slow_log_disabled_state.query_result[0][0].Value in ['OFF', '0']
+          - slow_log_disabled_state.query_result[1][0].Value | float == 0.5
+          - slow_log_disabled_state.query_result[2][0].Value == 'TABLE'
+          - slow_log_disabled_state.query_result[3][0].Value in ['ON', '1']
+          - slow_log_disabled_state.query_result[4][0].Value | int == 0
+
+    - name: MySQL slow log | Restore baseline settings
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        enabled: false
+        long_query_time: 10
+        log_output: TABLE
+        log_queries_not_using_indexes: false
+        min_examined_row_limit: 0
+      register: slow_log_restore_baseline
+
+    - name: MySQL slow log | Assert baseline restore result
+      ansible.builtin.assert:
+        that:
+          - slow_log_restore_baseline is changed
+          - slow_log_restore_baseline.queries == expected_queries
+      vars:
+        expected_queries:
+          - "SET GLOBAL `{{ slow_log_time_var }}` = 10.0"
+          - "SET GLOBAL `log_queries_not_using_indexes` = OFF"
+
+    - name: MySQL slow log | Query restored baseline settings
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_enabled_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_time_var }}'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_output'"
+          - "SHOW GLOBAL VARIABLES LIKE 'log_queries_not_using_indexes'"
+          - "SHOW GLOBAL VARIABLES LIKE '{{ slow_log_rows_var }}'"
+      register: slow_log_restored_baseline
+
+    - name: MySQL slow log | Assert restored baseline settings
+      ansible.builtin.assert:
+        that:
+          - slow_log_restored_baseline.query_result[0][0].Value in ['OFF', '0']
+          - slow_log_restored_baseline.query_result[1][0].Value | float == 10.0
+          - slow_log_restored_baseline.query_result[2][0].Value == 'TABLE'
+          - slow_log_restored_baseline.query_result[3][0].Value in ['OFF', '0']
+          - slow_log_restored_baseline.query_result[4][0].Value | int == 0
+
     - name: MySQL slow log | Configure settings in check mode
       check_mode: true
       ansible.mysql.mysql_slow_log:
@@ -216,3 +391,39 @@
         that:
           - table_flush_failure is failed
           - "'flush requires FILE log_output' in table_flush_failure.msg"
+
+    - name: MySQL slow log | Set no slow log output
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        log_output: NONE
+      register: no_output_result
+
+    - name: MySQL slow log | Assert no slow log output result
+      ansible.builtin.assert:
+        that:
+          - no_output_result is changed
+          - no_output_result.queries == ["SET GLOBAL `log_output` = NONE"]
+
+    - name: MySQL slow log | Verify no slow log output
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE 'log_output'"
+      register: no_output_state
+
+    - name: MySQL slow log | Assert no slow log output state
+      ansible.builtin.assert:
+        that:
+          - no_output_state.query_result[0][0].Value == 'NONE'
+
+    - name: MySQL slow log | Re-run no slow log output for idempotency
+      ansible.mysql.mysql_slow_log:
+        <<: *mysql_params
+        log_output: NONE
+      register: no_output_idempotency
+
+    - name: MySQL slow log | Assert no slow log output idempotency
+      ansible.builtin.assert:
+        that:
+          - no_output_idempotency is not changed
+          - no_output_idempotency.queries == []

--- a/tests/unit/plugins/modules/test_mysql_slow_log.py
+++ b/tests/unit/plugins/modules/test_mysql_slow_log.py
@@ -5,7 +5,7 @@ __metaclass__ = type
 
 import pytest
 
-from ansible_collections.ansible.mysql.plugins.modules.mysql_slow_log import MySQLSlowLog
+from ansible_collections.ansible.mysql.plugins.modules.mysql_slow_log import MySQLSlowLog, typedvalue
 
 
 class FakeCursor(object):
@@ -44,6 +44,40 @@ class FakeCursor(object):
 class ModuleStub(object):
     def fail_json(self, **kwargs):
         raise RuntimeError(kwargs['msg'])
+
+
+def test_typedvalue_raises_type_error_for_none():
+    with pytest.raises(TypeError):
+        typedvalue(None)
+
+
+@pytest.mark.parametrize('value', ['', 'invalid'])
+def test_normalize_log_output_rejects_empty_and_invalid_values(value):
+    slow_log = MySQLSlowLog(ModuleStub(), FakeCursor({}), 'mysql')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        slow_log.normalize_log_output(value)
+
+    assert str(exc_info.value) == 'log_output must be FILE, TABLE, NONE, or FILE,TABLE'
+
+
+@pytest.mark.parametrize('value', ['NONE,FILE', 'TABLE,NONE'])
+def test_normalize_log_output_rejects_none_combined_with_other_values(value):
+    slow_log = MySQLSlowLog(ModuleStub(), FakeCursor({}), 'mysql')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        slow_log.normalize_log_output(value)
+
+    assert str(exc_info.value) == 'log_output cannot combine NONE with other values'
+
+
+def test_read_setting_fails_when_variable_is_not_available():
+    slow_log = MySQLSlowLog(ModuleStub(), FakeCursor({}), 'mysql')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        slow_log.read_setting('log_output')
+
+    assert str(exc_info.value) == 'Slow log setting "log_output" is not available on this server.'
 
 
 def test_configure_returns_unchanged_when_settings_already_match():

--- a/tests/unit/plugins/modules/test_mysql_slow_log.py
+++ b/tests/unit/plugins/modules/test_mysql_slow_log.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.ansible.mysql.plugins.modules.mysql_slow_log import MySQLSlowLog
+
+
+class FakeCursor(object):
+    def __init__(self, variables):
+        self.variables = variables.copy()
+        self.executed = []
+        self._rows = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+        if query == "SHOW GLOBAL VARIABLES WHERE Variable_name = %s":
+            variable_name = params[0]
+            if variable_name in self.variables:
+                self._rows = [(variable_name, self.variables[variable_name])]
+            else:
+                self._rows = []
+            return
+
+        if query.startswith("SET GLOBAL "):
+            variable_name = query.split('`')[1]
+            self.variables[variable_name] = params[0]
+            self._rows = []
+            return
+
+        if query == "FLUSH SLOW LOGS":
+            self._rows = []
+            return
+
+        raise AssertionError('Unexpected query: %s' % query)
+
+    def fetchall(self):
+        return list(self._rows)
+
+
+class ModuleStub(object):
+    def fail_json(self, **kwargs):
+        raise RuntimeError(kwargs['msg'])
+
+
+def test_configure_returns_unchanged_when_settings_already_match():
+    cursor = FakeCursor({
+        'slow_query_log': 'ON',
+        'long_query_time': '2.0',
+        'log_output': 'FILE',
+        'log_queries_not_using_indexes': 'OFF',
+        'min_examined_row_limit': '100',
+    })
+
+    slow_log = MySQLSlowLog(ModuleStub(), cursor, 'mysql')
+
+    result = slow_log.configure({
+        'enabled': True,
+        'long_query_time': 2.0,
+        'log_output': 'FILE',
+        'log_queries_not_using_indexes': False,
+        'min_examined_row_limit': 100,
+    })
+
+    assert result['changed'] is False
+    assert result['queries'] == []
+    assert result['settings'] == {
+        'enabled': 'ON',
+        'long_query_time': 2.0,
+        'log_output': 'FILE',
+        'log_queries_not_using_indexes': 'OFF',
+        'min_examined_row_limit': 100,
+    }
+
+
+def test_configure_in_check_mode_predicts_changes_without_writes():
+    cursor = FakeCursor({
+        'slow_query_log': 'OFF',
+        'long_query_time': '10',
+        'log_output': 'TABLE',
+        'log_queries_not_using_indexes': 'OFF',
+        'min_examined_row_limit': '0',
+    })
+
+    slow_log = MySQLSlowLog(ModuleStub(), cursor, 'mysql')
+
+    result = slow_log.configure({
+        'enabled': True,
+        'log_output': 'FILE',
+    }, flush=True, check_mode=True)
+
+    assert result['changed'] is True
+    assert result['queries'] == [
+        "SET GLOBAL `slow_query_log` = ON",
+        "SET GLOBAL `log_output` = FILE",
+        "FLUSH SLOW LOGS",
+    ]
+    assert cursor.variables['slow_query_log'] == 'OFF'
+    assert cursor.variables['log_output'] == 'TABLE'
+    assert not any(query.startswith('SET GLOBAL ') for query, _params in cursor.executed)
+    assert not any(query == 'FLUSH SLOW LOGS' for query, _params in cursor.executed)
+
+
+def test_configure_fails_when_flush_is_requested_without_file_output():
+    cursor = FakeCursor({
+        'slow_query_log': 'ON',
+        'long_query_time': '2',
+        'log_output': 'TABLE',
+        'log_queries_not_using_indexes': 'OFF',
+        'min_examined_row_limit': '100',
+    })
+
+    slow_log = MySQLSlowLog(ModuleStub(), cursor, 'mysql')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        slow_log.configure({}, flush=True)
+
+    assert 'flush requires FILE log_output' in str(exc_info.value)
+
+
+def test_configure_uses_mariadb_aliases():
+    cursor = FakeCursor({
+        'log_slow_query': 'ON',
+        'log_slow_query_time': '1.5',
+        'log_output': 'FILE,TABLE',
+        'log_queries_not_using_indexes': 'ON',
+        'log_slow_min_examined_row_limit': '25',
+    })
+
+    slow_log = MySQLSlowLog(ModuleStub(), cursor, 'mariadb')
+
+    result = slow_log.configure({
+        'enabled': True,
+        'long_query_time': 1.5,
+        'log_output': 'TABLE,FILE',
+        'log_queries_not_using_indexes': True,
+        'min_examined_row_limit': 25,
+    })
+
+    assert result['changed'] is False
+    assert result['settings'] == {
+        'enabled': 'ON',
+        'long_query_time': 1.5,
+        'log_output': 'FILE,TABLE',
+        'log_queries_not_using_indexes': 'ON',
+        'min_examined_row_limit': 25,
+    }
+
+
+def test_configure_appends_flush_after_setting_queries():
+    cursor = FakeCursor({
+        'slow_query_log': 'OFF',
+        'long_query_time': '2',
+        'log_output': 'FILE',
+        'log_queries_not_using_indexes': 'OFF',
+        'min_examined_row_limit': '100',
+    })
+
+    slow_log = MySQLSlowLog(ModuleStub(), cursor, 'mysql')
+
+    result = slow_log.configure({
+        'enabled': True,
+    }, flush=True)
+
+    assert result['changed'] is True
+    assert result['queries'] == [
+        "SET GLOBAL `slow_query_log` = ON",
+        "FLUSH SLOW LOGS",
+    ]
+    assert cursor.variables['slow_query_log'] == 'ON'
+
+
+def test_configure_treats_string_boolean_values_as_idempotent():
+    cursor = FakeCursor({
+        'slow_query_log': '1',
+        'long_query_time': '2',
+        'log_output': 'FILE',
+        'log_queries_not_using_indexes': '0',
+        'min_examined_row_limit': '100',
+    })
+
+    slow_log = MySQLSlowLog(ModuleStub(), cursor, 'mysql')
+
+    result = slow_log.configure({
+        'enabled': True,
+        'log_queries_not_using_indexes': False,
+    })
+
+    assert result['changed'] is False
+    assert result['queries'] == []
+    assert result['settings']['enabled'] == 'ON'
+    assert result['settings']['log_queries_not_using_indexes'] == 'OFF'


### PR DESCRIPTION
#### SUMMARY
- add the new `mysql_slow_log` module to manage MySQL and MariaDB slow query log runtime settings
- support enabling and tuning slow logging, file-based slow log rotation, full check mode, and idempotent setting updates
- add unit and integration coverage plus collection metadata updates for the new module

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/mysql_slow_log.py
- tests/unit/plugins/modules/test_mysql_slow_log.py
- tests/integration/targets/test_mysql_slow_log/meta/main.yml
- tests/integration/targets/test_mysql_slow_log/defaults/main.yml
- tests/integration/targets/test_mysql_slow_log/tasks/main.yml
- meta/runtime.yml
- README.md
- TESTING.md

#### ADDITIONAL INFORMATION
- Written with the help of GPT5.4 with human in the loop and manual testing
- I know @eRadical suggested to keep it as part of variable settings but since this is an easy abstraction I think there is a benefit for it as a module. If there is no objection