### PR TITLE
ci: drop MySQL 8.0.38 from test matrix (EOL April 2026)

### DIFF
--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -63,11 +63,11 @@ Integration tests live under `tests/integration/targets/<module_name>/`. Each ta
 The project provides a Makefile (documented in `TESTING.md`) that handles spinning up a primary database and two replicas in Podman containers. This is the recommended way to run integration tests locally:
 
 ```bash
-# Run all targets against MySQL 8.0.38 with pymysql 1.0.2
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2"
+# Run all targets against MySQL 8.4.9 with pymysql 1.0.2
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.4.9" connector_name="pymysql" connector_version="1.0.2"
 
 # Run a single target
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.4.9" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
 
 # MariaDB example
 make ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="11.8.7" connector_name="pymysql" connector_version="1.0.2"

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -35,7 +35,6 @@ jobs:
           - mysql
           - mariadb
         db_engine_version:
-          - '8.0.38'
           - '8.4.9'
           - '9.7.0'
           - '10.11.8'
@@ -73,28 +72,16 @@ jobs:
             db_engine_version: '11.8.7'
 
           - db_engine_name: mariadb
-            db_engine_version: '8.0.38'
-
-          - db_engine_name: mariadb
             db_engine_version: '8.4.9'
 
           - db_engine_name: mariadb
             db_engine_version: '9.7.0'
 
-          - db_engine_version: '8.0.38'
-            ansible: stable-2.17
-
           - db_engine_version: '10.11.8'
             ansible: stable-2.17
 
-          - db_engine_version: '8.0.38'
-            ansible: stable-2.21
-
           - db_engine_version: '10.11.8'
             ansible: stable-2.21
-
-          - db_engine_version: '8.0.38'
-            ansible: devel
 
           - db_engine_version: '10.11.8'
             ansible: devel
@@ -164,9 +151,7 @@ jobs:
         run: |
           db_ver="${{ matrix.db_engine_version }}"
           maj="${db_ver%.*.*}"
-          maj_min="${db_ver%.*}"
-          min="${maj_min#*.}"
-          if [[ "${{ matrix.db_engine_name }}" == "mysql" && "$maj" -eq 8 && "$min" -ge 2 ]]; then
+          if [[ "${{ matrix.db_engine_name }}" == "mysql" && "$maj" -eq 8 ]]; then
             prima_conf='[mysqld]\\nserver-id=1\\nlog-bin=/var/lib/mysql/primary-bin\\nmysql-native-password=1'
             repl1_conf='[mysqld]\\nserver-id=2\\nlog-bin=/var/lib/mysql/replica1-bin\\nmysql-native-password=1'
             repl2_conf='[mysqld]\\nserver-id=3\\nlog-bin=/var/lib/mysql/replica2-bin\\nmysql-native-password=1'

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,7 @@ test-integration:
 	# Setup replication and restart containers using the same subshell to keep variables alive
 	db_ver=$(db_engine_version); \
 	maj="$${db_ver%.*.*}"; \
-	maj_min="$${db_ver%.*}"; \
-	min="$${maj_min#*.}"; \
-	if [[ "$(db_engine_name)" == "mysql" && "$$maj" -eq 8 && "$$min" -ge 2 ]]; then \
+	if [[ "$(db_engine_name)" == "mysql" && "$$maj" -eq 8 ]]; then \
 		prima_conf='[mysqld]\\nserver-id=1\\nlog-bin=/var/lib/mysql/primary-bin\\nmysql-native-password=1'; \
 		repl1_conf='[mysqld]\\nserver-id=2\\nlog-bin=/var/lib/mysql/replica1-bin\\nmysql-native-password=1'; \
 		repl2_conf='[mysqld]\\nserver-id=3\\nlog-bin=/var/lib/mysql/replica2-bin\\nmysql-native-password=1'; \

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Here is the table for the support timeline:
 
 For MariaDB, only Long Term releases are tested. When multiple LTS are available, we test the oldest and the newest only. Usually breaking changes introduced in the versions in between are also present in the latest version.
 
-- mysql 8.0.38
 - mysql 8.4.9
 - mysql 9.7.0
 - mariadb:10.11 (collection version >= 3.10.0)

--- a/TESTING.md
+++ b/TESTING.md
@@ -64,7 +64,6 @@ The Makefile accept the following options
 - `db_engine_version`
   - Mandatory: true
   - Choices:
-    - "8.0.38" <- mysql
     - "8.4.9" <- mysql
     - "9.7.0" <- mysql
     - "10.11.8" <- mariadb
@@ -113,14 +112,14 @@ tests will overwrite the 3 databases containers so no need to kill them in advan
 
 ```sh
 # Run all targets
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2"
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.4.9" connector_name="pymysql" connector_version="1.0.2"
 
 # A single target
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.4.9" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
 
 # Keep databases and ansible tests containers alives
 # A single target and continue on errors
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.4.9" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
 
 # If your system has an usupported version of Python:
 make local_python_version="3.10" ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="11.8.7" connector_name="pymysql" connector_version="1.0.2"

--- a/changelogs/fragments/drop-mysql-8.0-ci.yml
+++ b/changelogs/fragments/drop-mysql-8.0-ci.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - CI - MySQL 8.0.38 has been removed from the CI test matrix because
+    MySQL 8.0 reached End of Life in April 2026. The collection still
+    supports MySQL 8.0 at runtime through version-conditional code paths.


### PR DESCRIPTION
MySQL 8.0 reached End of Life in April 2026. Remove it from the CI matrix, update documentation examples to use 8.4.9, and simplify the mysql-native-password replication config condition. Version-conditional code paths in modules and integration tests are preserved for runtime backward compatibility.

##### SUMMARY
MySQL 8.0 reached End of Life in April 2026. In README, we state that we support two LTS versions of MySQL.
Remove it from the CI matrix, update documentation examples to use 8.4.9, and simplify the mysql-native-password replication config condition. Version-conditional code paths in modules and integration tests are preserved for runtime backward compatibility.