### PR TITLE
ci: drop PyMySQL 0.9.3 and 1.0.2 from test matrix

### DIFF
--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -63,14 +63,14 @@ Integration tests live under `tests/integration/targets/<module_name>/`. Each ta
 The project provides a Makefile (documented in `TESTING.md`) that handles spinning up a primary database and two replicas in Podman containers. This is the recommended way to run integration tests locally:
 
 ```bash
-# Run all targets against MySQL 8.0.38 with pymysql 1.0.2
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2"
+# Run all targets against MySQL 8.4.9 with pymysql 1.1.1
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.1.1"
 
 # Run a single target
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.1.1" target="test_mysql_info"
 
 # MariaDB example
-make ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="11.8.7" connector_name="pymysql" connector_version="1.0.2"
+make ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="11.8.7" connector_name="pymysql" connector_version="1.1.1"
 ```
 
 Key Makefile options: `db_engine_name` (mysql/mariadb), `db_engine_version`, `connector_name` (pymysql), `connector_version`, `target` (single test target), `keep_containers_alive=1` (for debugging), `continue_on_errors=1`. See `TESTING.md` for the full list of supported versions and options.

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -43,8 +43,7 @@ jobs:
         connector_name:
           - pymysql
         connector_version:
-          - '0.9.3'
-          - '1.0.2'
+          - '0.10.1'
           - '1.1.1'
 
         include:

--- a/README.md
+++ b/README.md
@@ -118,10 +118,8 @@ For MariaDB, only Long Term releases are tested. When multiple LTS are available
 
 ### Database connectors
 
-- pymysql 0.9.3
-- pymysql 0.10.1 (for RHEL8 context)
-- pymysql 1.0.2 (collection version >= 3.6.1)
-- pymysql 1.1.1 (collection version >= 3.10.0)
+- pymysql 0.10.1
+- pymysql 1.1.1
 
 ## External requirements
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -80,9 +80,7 @@ The Makefile accept the following options
 - `connector_version`
   - Mandatory: true
   - Choices:
-    - "0.9.3" <- pymysql
     - "0.10.1" <- pymysql
-    - "1.0.2" <- pymysql
     - "1.1.1" <- pymysql
   - Description: The version of the python package of the connector to use. This value is used to filter tests meant for other connectors.
 
@@ -113,17 +111,17 @@ tests will overwrite the 3 databases containers so no need to kill them in advan
 
 ```sh
 # Run all targets
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2"
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.1.1"
 
 # A single target
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_info"
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.1.1" target="test_mysql_info"
 
 # Keep databases and ansible tests containers alives
 # A single target and continue on errors
-make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.0.2" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
+make ansible="stable-2.17" db_engine_name="mysql" db_engine_version="8.0.38" connector_name="pymysql" connector_version="1.1.1" target="test_mysql_query" keep_containers_alive=1 continue_on_errors=1
 
 # If your system has an usupported version of Python:
-make local_python_version="3.10" ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="11.8.7" connector_name="pymysql" connector_version="1.0.2"
+make local_python_version="3.10" ansible="stable-2.17" db_engine_name="mariadb" db_engine_version="11.8.7" connector_name="pymysql" connector_version="1.1.1"
 ```
 
 

--- a/changelogs/fragments/trim-pymysql-ci-versions.yml
+++ b/changelogs/fragments/trim-pymysql-ci-versions.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - >-
+    CI - PyMySQL 0.9.3 and 1.0.2 have been removed from the CI test matrix.
+    PyMySQL 0.9.3 is unmaintained and has an unfixed CVE-2024-36039.
+    PyMySQL 1.0.2 is redundant with 1.1.1 as both cover the same code path.
+    PyMySQL 0.10.1 has been promoted to the main test matrix
+    (https://github.com/ansible-collections/ansible.mysql/pull/XXX).

--- a/changelogs/fragments/trim-pymysql-ci-versions.yml
+++ b/changelogs/fragments/trim-pymysql-ci-versions.yml
@@ -3,5 +3,4 @@ minor_changes:
     CI - PyMySQL 0.9.3 and 1.0.2 have been removed from the CI test matrix.
     PyMySQL 0.9.3 is unmaintained and has an unfixed CVE-2024-36039.
     PyMySQL 1.0.2 is redundant with 1.1.1 as both cover the same code path.
-    PyMySQL 0.10.1 has been promoted to the main test matrix
-    (https://github.com/ansible-collections/ansible.mysql/pull/XXX).
+    PyMySQL 0.10.1 has been promoted to the main test matrix.

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -299,7 +299,7 @@ connector_version:
   returned: always
   type: str
   sample:
-  - "1.0.2"
+  - "1.1.1"
   version_added: '3.6.0'
 '''
 

--- a/plugins/modules/mysql_query.py
+++ b/plugins/modules/mysql_query.py
@@ -27,8 +27,7 @@ options:
       escaped as C(%%).
     - Note that if you use the C(IF EXISTS/IF NOT EXISTS) clauses in your query
       and C(mysqlclient) or C(PyMySQL 0.10.0+) connectors, the module will report
-      that the state has been changed even if it has not. If it is important in your
-      workflow, use the C(PyMySQL 0.9.3) connector instead.
+      that the state has been changed even if it has not.
     type: raw
     required: true
   positional_args:

--- a/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/config_overrides_defaults.yml
@@ -15,39 +15,18 @@
 
 - name: Config overrides | Add blank line
   shell: 'echo "" >> {{ config_file }}'
-  when:
-    - >
-      connector_name != 'pymysql'
-      or (
-        connector_name == 'pymysql'
-        and connector_version is version('0.9.3', '>=')
-      )
 
 - name: Config overrides | Create include_dir
   file:
     path: '{{ include_dir }}'
     state: directory
     mode: '0777'
-  when:
-    - >
-      connector_name != 'pymysql'
-      or (
-        connector_name == 'pymysql'
-        and connector_version is version('0.9.3', '>=')
-      )
 
 - name: Config overrides | Add include_dir
   lineinfile:
     path: '{{ config_file }}'
     line: '!includedir {{ include_dir }}'
     insertafter: EOF
-  when:
-    - >
-      connector_name != 'pymysql'
-      or (
-        connector_name == 'pymysql'
-        and connector_version is version('0.9.3', '>=')
-      )
 
 - name: Config overrides | Create database using fake port to connect to, must fail
   mysql_db:

--- a/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/mysql_query_initial.yml
@@ -394,25 +394,12 @@
     register: result
 
   # Issue https://github.com/ansible-collections/ansible.mysql/issues/268
-  - name: Assert that create table IF NOT EXISTS is not changed with pymysql
-    assert:
-      that:
-        # PyMySQL driver throws a warning for version before 0.10.0
-        - result is not changed
-    when:
-      - connector_name == 'pymysql'
-      - connector_version is version('0.10.0', '<')
-
-  # Issue https://github.com/ansible-collections/ansible.mysql/issues/268
   - name: Assert that create table IF NOT EXISTS is changed
     assert:
       that:
-        # pymysql 0.10.0+ drivers throw no warning,
-        # so it's impossible to figure out if the state was changed or not.
-        # We assume that it was for DDL queries by default in the code
         - result is changed
     when:
-      - connector_name == 'pymysql' and connector_version is version('0.10.0', '>')
+      - connector_name == 'pymysql'
 
   - name: Drop db {{ test_db }}
     mysql_query:

--- a/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/mysql_replication_initial.yml
@@ -324,15 +324,6 @@
         fail_on_error: true
       register: result
 
-    # pymysql 0.10.0+ always returns "changed"
-    - name: Assert that startreplica is not changed
-      assert:
-        that:
-          - result is not changed
-      when:
-        - connector_name == 'pymysql'
-        - connector_version is version('0.10.0', '<')
-
     # Test stopreplica mode:
     - name: Stop replica
       mysql_replication:
@@ -350,24 +341,6 @@
     - name: Pause for 2 seconds to let the replication stop
       ansible.builtin.wait_for:
         timeout: 2
-
-    # Test stopreplica mode:
-    # pymysql 0.10.0+ always returns "changed"
-    - name: Stop replica that is no longer running
-      mysql_replication:
-        <<: *mysql_params
-        login_port: '{{ mysql_replica1_port }}'
-        mode: stopreplica
-        fail_on_error: true
-      register: result
-
-    - name: Assert that stopreplica is not changed
-      assert:
-        that:
-          - result is not changed
-      when:
-        - connector_name == 'pymysql'
-        - connector_version is version('0.10.0', '<')
 
     # master / slave related choices were removed in 3.0.0
     # https://github.com/ansible-collections/ansible.mysql/pull/252

--- a/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/test_user_plugin_auth.yml
@@ -400,18 +400,9 @@
         user_name: "{{ test_user_name }}"
 
     # ============================================================
-    # Test plugin auth switching from one type of plugin to another without an auth string or hash. The only other
-    # plugins that are loaded by default are sha2*, but these aren't compatible with pymysql < 0.9, so skip these tests
-    # for those versions.
+    # Test plugin auth switching from one type of plugin to another without an auth string or hash.
     #
-    - name: Plugin auth | Test plugin auth switching which doesn't work on pymysql < 0.9
-      when:
-        - >
-          connector_name != 'pymysql'
-          or (
-            connector_name == 'pymysql'
-            and connector_version is version('0.9', '>=')
-          )
+    - name: Plugin auth | Test plugin auth switching
       block:
 
         - name: Plugin auth | Create user with plugin auth (empty auth string)
@@ -549,14 +540,7 @@
     # Test auth plugin change
     #
 
-    - name: Plugin auth | Test plugin auth switching which doesn't work on pymysql < 0.9
-      when:
-        - >
-          connector_name != 'pymysql'
-          or (
-            connector_name == 'pymysql'
-            and connector_version is version('0.9', '>=')
-          )
+    - name: Plugin auth | Test plugin auth switching
       block:
 
         - name: Cleanup user


### PR DESCRIPTION

##### SUMMARY
  Drop PyMySQL 0.9.3 (unmaintained, unfixed CVE-2024-36039) and 1.0.2 (redundant with 1.1.1) from the
  CI matrix. Promote 0.10.1 to the main matrix.

  The remaining two versions cover both module code paths: < 1.0.0 (0.10.1) and >= 1.0.0 (1.1.1).

  Also removes dead test conditionals that checked for versions we no longer test against (< 0.10.0, >= 0.9.3, >= 0.9).