### PR TITLE
Add mysql_perf_schema module for runtime performance schema management

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Every voice is important and every idea is valuable. If you have something on yo
 - **Modules**:
   - [mysql_db](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_db_module.html)
   - [mysql_info](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_info_module.html)
+  - [mysql_perf_schema](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_perf_schema_module.html)
   - [mysql_query](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_query_module.html)
   - [mysql_replication](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_replication_module.html)
   - [mysql_role](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_role_module.html)

--- a/TESTING.md
+++ b/TESTING.md
@@ -90,6 +90,7 @@ The Makefile accept the following options
     - "test_mysql_binlog_info"
     - "test_mysql_db"
     - "test_mysql_info"
+    - "test_mysql_perf_schema"
     - "test_mysql_query"
     - "test_mysql_replication"
     - "test_mysql_role"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -5,6 +5,7 @@ action_groups:
     - mysql_db
     - mysql_binlog_info
     - mysql_info
+    - mysql_perf_schema
     - mysql_query
     - mysql_replication
     - mysql_role

--- a/plugins/module_utils/perf_schema.py
+++ b/plugins/module_utils/perf_schema.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible_collections.ansible.mysql.plugins.module_utils.mysql import get_server_version
+"""Shared table-driven helpers for Performance Schema setup sections."""
 
 
 SECTION_DEFINITIONS = {
@@ -42,22 +42,6 @@ SECTION_DEFINITIONS = {
         'allow_delete': True,
     },
 }
-
-
-def get_server_version_tuple(cursor):
-    version = get_server_version(cursor).split('-', 1)[0]
-    version_tuple = []
-
-    for part in version.split('.'):
-        digits = ''.join(char for char in part if char.isdigit())
-        if not digits:
-            break
-        version_tuple.append(int(digits))
-
-    while len(version_tuple) < 3:
-        version_tuple.append(0)
-
-    return tuple(version_tuple[:3])
 
 
 def normalize_perf_schema_bool(value):
@@ -286,4 +270,5 @@ def _format_perf_schema_bool(value):
 
 
 def _quote_sql_value(value):
+    # This is only for human-readable query output in result['queries'].
     return "'%s'" % str(value).replace("'", "''")

--- a/plugins/module_utils/perf_schema.py
+++ b/plugins/module_utils/perf_schema.py
@@ -1,0 +1,289 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import get_server_version
+
+
+SECTION_DEFINITIONS = {
+    'instruments': {
+        'table': 'setup_instruments',
+        'key_fields': ('name',),
+        'db_key_fields': ('NAME',),
+        'value_fields': ('enabled', 'timed'),
+        'db_value_fields': ('ENABLED', 'TIMED'),
+        'allow_insert': False,
+        'allow_delete': False,
+    },
+    'consumers': {
+        'table': 'setup_consumers',
+        'key_fields': ('name',),
+        'db_key_fields': ('NAME',),
+        'value_fields': ('enabled',),
+        'db_value_fields': ('ENABLED',),
+        'allow_insert': False,
+        'allow_delete': False,
+    },
+    'actors': {
+        'table': 'setup_actors',
+        'key_fields': ('host', 'user', 'role'),
+        'db_key_fields': ('HOST', 'USER', 'ROLE'),
+        'value_fields': ('enabled', 'history'),
+        'db_value_fields': ('ENABLED', 'HISTORY'),
+        'allow_insert': True,
+        'allow_delete': True,
+    },
+    'objects': {
+        'table': 'setup_objects',
+        'key_fields': ('object_type', 'object_schema', 'object_name'),
+        'db_key_fields': ('OBJECT_TYPE', 'OBJECT_SCHEMA', 'OBJECT_NAME'),
+        'value_fields': ('enabled', 'timed'),
+        'db_value_fields': ('ENABLED', 'TIMED'),
+        'allow_insert': True,
+        'allow_delete': True,
+    },
+}
+
+
+def get_server_version_tuple(cursor):
+    version = get_server_version(cursor).split('-', 1)[0]
+    version_tuple = []
+
+    for part in version.split('.'):
+        digits = ''.join(char for char in part if char.isdigit())
+        if not digits:
+            break
+        version_tuple.append(int(digits))
+
+    while len(version_tuple) < 3:
+        version_tuple.append(0)
+
+    return tuple(version_tuple[:3])
+
+
+def normalize_perf_schema_bool(value):
+    if isinstance(value, bool):
+        return value
+
+    return str(value).upper() in ('YES', 'ON', 'TRUE', '1')
+
+
+def normalize_perf_schema_item(section, item):
+    definition = SECTION_DEFINITIONS[section]
+    normalized = {}
+
+    for field in definition['key_fields']:
+        value = item.get(field)
+        if value is None:
+            raise ValueError("Missing required field '%s' for section '%s'" % (field, section))
+        normalized[field] = value
+
+    state = item.get('state', 'present')
+    if state not in ('present', 'absent'):
+        raise ValueError("state must be 'present' or 'absent'")
+
+    if state == 'absent' and not definition['allow_delete']:
+        raise ValueError("Section '%s' does not support state=absent" % section)
+
+    if state == 'present':
+        for field in definition['value_fields']:
+            value = item.get(field)
+            if value is None:
+                raise ValueError("Missing required field '%s' for section '%s'" % (field, section))
+            normalized[field] = normalize_perf_schema_bool(value)
+
+    if definition['allow_delete']:
+        normalized['state'] = state
+
+    return normalized
+
+
+def normalize_perf_schema_row(section, row):
+    definition = SECTION_DEFINITIONS[section]
+    normalized = {}
+
+    for field, db_field in zip(definition['key_fields'], definition['db_key_fields']):
+        normalized[field] = row[db_field]
+
+    for field, db_field in zip(definition['value_fields'], definition['db_value_fields']):
+        normalized[field] = normalize_perf_schema_bool(row[db_field])
+
+    return normalized
+
+
+def ensure_perf_schema_sections_supported(module, cursor, sections):
+    table_names = sorted({SECTION_DEFINITIONS[section]['table'] for section in sections})
+    placeholders = ', '.join(['%s'] * len(table_names))
+    query = (
+        "SELECT TABLE_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
+        "WHERE TABLE_SCHEMA = 'performance_schema' AND TABLE_NAME IN (%s)"
+    ) % placeholders
+    cursor.execute(query, tuple(table_names))
+    rows = cursor.fetchall()
+
+    columns_by_table = {}
+    for row in rows:
+        columns_by_table.setdefault(row['TABLE_NAME'], set()).add(row['COLUMN_NAME'])
+
+    for section in sections:
+        definition = SECTION_DEFINITIONS[section]
+        expected = set(definition['db_key_fields'] + definition['db_value_fields'])
+        actual = columns_by_table.get(definition['table'], set())
+        missing = sorted(expected - actual)
+        if missing:
+            module.fail_json(
+                msg=("Performance Schema section '%s' is not supported by the server. "
+                     "Missing columns: %s" % (section, ', '.join(missing)))
+            )
+
+
+def plan_section_changes(section, desired_items, current_rows):
+    definition = SECTION_DEFINITIONS[section]
+    current_by_key = {}
+
+    for row in current_rows:
+        normalized = normalize_perf_schema_row(section, row)
+        current_by_key[_build_key(definition, normalized)] = normalized
+
+    queries = []
+    planned_rows = []
+
+    for raw_item in desired_items:
+        item = normalize_perf_schema_item(section, raw_item)
+        key = _build_key(definition, item)
+        current = current_by_key.get(key)
+        state = item.get('state', 'present')
+
+        if state == 'absent':
+            if current is not None:
+                queries.append(_build_delete_query(definition, item))
+            continue
+
+        if current is None:
+            if not definition['allow_insert']:
+                raise ValueError(
+                    "Performance Schema section '%s' does not contain the requested row %s"
+                    % (section, dict((field, item[field]) for field in definition['key_fields']))
+                )
+
+            queries.append(_build_insert_query(definition, item))
+            planned_rows.append(dict((field, item[field]) for field in definition['key_fields'] + definition['value_fields']))
+            continue
+
+        updates = {}
+        for field in definition['value_fields']:
+            if current[field] != item[field]:
+                updates[field] = item[field]
+
+        if updates:
+            queries.append(_build_update_query(definition, item, updates))
+
+        planned_rows.append(_merge_row(definition, current, item))
+
+    planned_rows.sort(key=lambda row: _build_key(definition, row))
+
+    return {
+        'changed': bool(queries),
+        'queries': queries,
+        'rows': planned_rows,
+    }
+
+
+def _build_key(definition, row):
+    return tuple(row[field] for field in definition['key_fields'])
+
+
+def _merge_row(definition, current, desired):
+    merged = {}
+
+    for field in definition['key_fields'] + definition['value_fields']:
+        merged[field] = desired.get(field, current.get(field))
+
+    return merged
+
+
+def _build_update_query(definition, item, updates):
+    set_parts = []
+    params = []
+
+    for field, db_field in zip(definition['value_fields'], definition['db_value_fields']):
+        if field not in updates:
+            continue
+        set_parts.append('%s = %%s' % db_field)
+        params.append(_format_perf_schema_bool(updates[field]))
+
+    where_parts = []
+    for field, db_field in zip(definition['key_fields'], definition['db_key_fields']):
+        where_parts.append('%s = %%s' % db_field)
+        params.append(item[field])
+
+    sql = 'UPDATE performance_schema.%s SET %s WHERE %s' % (
+        definition['table'],
+        ', '.join(set_parts),
+        ' AND '.join(where_parts),
+    )
+
+    display = 'UPDATE performance_schema.%s SET %s WHERE %s' % (
+        definition['table'],
+        ', '.join("%s = %s" % (db_field, _quote_sql_value(_format_perf_schema_bool(updates[field])))
+                  for field, db_field in zip(definition['value_fields'], definition['db_value_fields'])
+                  if field in updates),
+        ' AND '.join("%s = %s" % (db_field, _quote_sql_value(item[field]))
+                     for field, db_field in zip(definition['key_fields'], definition['db_key_fields'])),
+    )
+
+    return {'sql': sql, 'params': tuple(params), 'display': display}
+
+
+def _build_insert_query(definition, item):
+    fields = definition['db_key_fields'] + definition['db_value_fields']
+    params = []
+
+    for field in definition['key_fields']:
+        params.append(item[field])
+
+    for field in definition['value_fields']:
+        params.append(_format_perf_schema_bool(item[field]))
+
+    sql = 'INSERT INTO performance_schema.%s (%s) VALUES (%s)' % (
+        definition['table'],
+        ', '.join(fields),
+        ', '.join(['%s'] * len(fields)),
+    )
+
+    display_values = []
+    for field in definition['key_fields']:
+        display_values.append(_quote_sql_value(item[field]))
+    for field in definition['value_fields']:
+        display_values.append(_quote_sql_value(_format_perf_schema_bool(item[field])))
+
+    display = 'INSERT INTO performance_schema.%s (%s) VALUES (%s)' % (
+        definition['table'],
+        ', '.join(fields),
+        ', '.join(display_values),
+    )
+
+    return {'sql': sql, 'params': tuple(params), 'display': display}
+
+
+def _build_delete_query(definition, item):
+    params = tuple(item[field] for field in definition['key_fields'])
+    where_parts = ['%s = %%s' % db_field for db_field in definition['db_key_fields']]
+    sql = 'DELETE FROM performance_schema.%s WHERE %s' % (
+        definition['table'],
+        ' AND '.join(where_parts),
+    )
+    display = 'DELETE FROM performance_schema.%s WHERE %s' % (
+        definition['table'],
+        ' AND '.join("%s = %s" % (db_field, _quote_sql_value(item[field]))
+                     for field, db_field in zip(definition['key_fields'], definition['db_key_fields'])),
+    )
+
+    return {'sql': sql, 'params': params, 'display': display}
+
+
+def _format_perf_schema_bool(value):
+    return 'YES' if value else 'NO'
+
+
+def _quote_sql_value(value):
+    return "'%s'" % str(value).replace("'", "''")

--- a/plugins/modules/mysql_perf_schema.py
+++ b/plugins/modules/mysql_perf_schema.py
@@ -1,0 +1,387 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_perf_schema
+
+short_description: Manage MySQL or MariaDB Performance Schema setup tables
+
+description:
+  - Manage runtime Performance Schema configuration through setup tables.
+  - Supports instruments, consumers, actors, and objects.
+  - Reconciles only the rows requested in the task and leaves unrelated rows untouched.
+  - This module manages runtime state only. Restart-persistent Performance Schema configuration remains outside its scope.
+
+author:
+  - Ron Gershburg (@rgershbu)
+
+version_added: '5.1.0'
+
+options:
+  instruments:
+    description:
+      - Instrument rows to reconcile in C(performance_schema.setup_instruments).
+      - Existing instrument rows are updated in place.
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - Instrument name.
+        type: str
+        required: true
+      enabled:
+        description:
+          - Whether the instrument should be enabled.
+        type: bool
+        required: true
+      timed:
+        description:
+          - Whether the instrument should be timed.
+        type: bool
+        required: true
+  consumers:
+    description:
+      - Consumer rows to reconcile in C(performance_schema.setup_consumers).
+      - Existing consumer rows are updated in place.
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - Consumer name.
+        type: str
+        required: true
+      enabled:
+        description:
+          - Whether the consumer should be enabled.
+        type: bool
+        required: true
+  actors:
+    description:
+      - Actor rows to reconcile in C(performance_schema.setup_actors).
+    type: list
+    elements: dict
+    suboptions:
+      user:
+        description:
+          - Account user pattern.
+        type: str
+        required: true
+      host:
+        description:
+          - Account host pattern.
+        type: str
+        required: true
+      role:
+        description:
+          - Role pattern.
+        type: str
+        required: true
+      enabled:
+        description:
+          - Whether matching threads should be instrumented.
+          - Required when C(state=present).
+        type: bool
+      history:
+        description:
+          - Whether history consumers should retain data for matching threads.
+          - Required when C(state=present).
+        type: bool
+      state:
+        description:
+          - Whether the actor row should exist.
+        type: str
+        choices: [absent, present]
+        default: present
+  objects:
+    description:
+      - Object rows to reconcile in C(performance_schema.setup_objects).
+    type: list
+    elements: dict
+    suboptions:
+      object_type:
+        description:
+          - Object type stored in Performance Schema.
+        type: str
+        required: true
+      object_schema:
+        description:
+          - Schema name pattern.
+        type: str
+        required: true
+      object_name:
+        description:
+          - Object name pattern.
+        type: str
+        required: true
+      enabled:
+        description:
+          - Whether the object should be instrumented.
+          - Required when C(state=present).
+        type: bool
+      timed:
+        description:
+          - Whether the object should be timed.
+          - Required when C(state=present).
+        type: bool
+      state:
+        description:
+          - Whether the object row should exist.
+        type: str
+        choices: [absent, present]
+        default: present
+
+notes:
+  - Compatible with MariaDB or MySQL when the requested Performance Schema sections are available on the server.
+  - The module requires Performance Schema to be enabled and the requested setup table columns to exist.
+  - Changes are runtime only and are not persisted across restart by this module.
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+seealso:
+  - module: ansible.mysql.mysql_query
+  - name: MySQL Performance Schema reference
+    description: Oracle MySQL Performance Schema documentation.
+    link: https://dev.mysql.com/doc/en/performance-schema.html
+  - name: MariaDB Performance Schema overview
+    description: MariaDB Performance Schema documentation.
+    link: https://mariadb.com/docs/server/reference/system-tables/performance-schema/performance-schema-overview
+
+extends_documentation_fragment:
+  - ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Apply a standard monitoring baseline profile
+  ansible.mysql.mysql_perf_schema:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    instruments:
+      - name: statement/sql/select
+        enabled: true
+        timed: true
+      - name: stage/sql/Opening_tables
+        enabled: true
+        timed: true
+      - name: wait/io/table/sql/handler
+        enabled: true
+        timed: true
+    consumers:
+      - name: events_statements_history
+        enabled: true
+      - name: events_waits_current
+        enabled: true
+
+- name: Enable statement instrumentation for one instrument
+  ansible.mysql.mysql_perf_schema:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    instruments:
+      - name: statement/sql/insert
+        enabled: true
+        timed: true
+
+- name: Enable one consumer and add one actor row
+  ansible.mysql.mysql_perf_schema:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    consumers:
+      - name: events_waits_current
+        enabled: true
+    actors:
+      - user: app
+        host: '%'
+        role: '%'
+        enabled: true
+        history: false
+
+- name: Remove one object rule
+  ansible.mysql.mysql_perf_schema:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    objects:
+      - object_type: TABLE
+        object_schema: reporting
+        object_name: slow_queries
+        state: absent
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed SQL statements or predicted SQL statements in check mode.
+  returned: when changed
+  type: list
+  sample:
+    - "UPDATE performance_schema.setup_consumers SET ENABLED = 'YES' WHERE NAME = 'events_waits_current'"
+instruments:
+  description: Normalized requested instrument rows after module execution or prediction.
+  returned: when O(instruments) is provided
+  type: list
+  elements: dict
+consumers:
+  description: Normalized requested consumer rows after module execution or prediction.
+  returned: when O(consumers) is provided
+  type: list
+  elements: dict
+actors:
+  description: Normalized requested actor rows after module execution or prediction.
+  returned: when O(actors) is provided
+  type: list
+  elements: dict
+objects:
+  description: Normalized requested object rows after module execution or prediction.
+  returned: when O(objects) is provided
+  type: list
+  elements: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils.perf_schema import (
+    SECTION_DEFINITIONS,
+    ensure_perf_schema_sections_supported,
+    plan_section_changes,
+)
+
+
+class MySQL_Perf_Schema(object):
+    def __init__(self, module, cursor):
+        self.module = module
+        self.cursor = cursor
+
+    def apply(self, params):
+        sections = [section for section in SECTION_DEFINITIONS if params.get(section)]
+        ensure_perf_schema_sections_supported(self.module, self.cursor, sections)
+
+        result = {
+            'changed': False,
+            'queries': [],
+        }
+
+        for section in sections:
+            current_rows = self.get_section_rows(section)
+            planned = plan_section_changes(section, params[section], current_rows)
+            result['changed'] = result['changed'] or planned['changed']
+            result['queries'].extend(query['display'] for query in planned['queries'])
+            result[section] = planned['rows']
+
+            if not self.module.check_mode:
+                self.execute_queries(planned['queries'])
+
+        if not result['queries']:
+            del result['queries']
+
+        return result
+
+    def get_section_rows(self, section):
+        query = 'SELECT * FROM performance_schema.%s' % SECTION_DEFINITIONS[section]['table']
+        self.cursor.execute(query)
+        return self.cursor.fetchall()
+
+    def execute_queries(self, queries):
+        for query in queries:
+            self.cursor.execute(query['sql'], query['params'])
+            self.cursor.fetchall()
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        instruments=dict(
+            type='list',
+            elements='dict',
+            options=dict(
+                name=dict(type='str', required=True),
+                enabled=dict(type='bool', required=True),
+                timed=dict(type='bool', required=True),
+            ),
+        ),
+        consumers=dict(
+            type='list',
+            elements='dict',
+            options=dict(
+                name=dict(type='str', required=True),
+                enabled=dict(type='bool', required=True),
+            ),
+        ),
+        actors=dict(
+            type='list',
+            elements='dict',
+            options=dict(
+                user=dict(type='str', required=True),
+                host=dict(type='str', required=True),
+                role=dict(type='str', required=True),
+                enabled=dict(type='bool'),
+                history=dict(type='bool'),
+                state=dict(type='str', choices=['absent', 'present'], default='present'),
+            ),
+        ),
+        objects=dict(
+            type='list',
+            elements='dict',
+            options=dict(
+                object_type=dict(type='str', required=True),
+                object_schema=dict(type='str', required=True),
+                object_name=dict(type='str', required=True),
+                enabled=dict(type='bool'),
+                timed=dict(type='bool'),
+                state=dict(type='str', choices=['absent', 'present'], default='present'),
+            ),
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=[('instruments', 'consumers', 'actors', 'objects')],
+        supports_check_mode=True,
+    )
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    try:
+        cursor, db_conn = mysql_connect(
+            module,
+            module.params['login_user'],
+            module.params['login_password'],
+            module.params['config_file'],
+            module.params['client_cert'],
+            module.params['client_key'],
+            module.params['ca_cert'],
+            connect_timeout=module.params['connect_timeout'],
+            check_hostname=module.params['check_hostname'],
+            cursor_class='DictCursor',
+            autocommit=True,
+        )
+    except Exception as e:
+        module.fail_json(msg='unable to connect to database: %s' % to_native(e))
+
+    executor = MySQL_Perf_Schema(module, cursor)
+
+    try:
+        result = executor.apply(module.params)
+    except ValueError as e:
+        module.fail_json(msg=to_native(e))
+    except Exception as e:
+        module.fail_json(msg=to_native(e))
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_perf_schema.py
+++ b/plugins/modules/mysql_perf_schema.py
@@ -20,7 +20,7 @@ description:
   - This module manages runtime state only. Restart-persistent Performance Schema configuration remains outside its scope.
 
 author:
-  - Ron Gershburg (@rgershbu)
+  - Ron Gershburg (@ronger4)
 
 version_added: '5.1.0'
 
@@ -34,7 +34,7 @@ options:
     suboptions:
       name:
         description:
-          - Instrument name.
+          - Instrument name or pattern from C(performance_schema.setup_instruments), for example C(statement/%).
         type: str
         required: true
       enabled:
@@ -226,21 +226,40 @@ instruments:
   returned: when O(instruments) is provided
   type: list
   elements: dict
+  sample:
+    - name: statement/sql/select
+      enabled: true
+      timed: true
 consumers:
   description: Normalized requested consumer rows after module execution or prediction.
   returned: when O(consumers) is provided
   type: list
   elements: dict
+  sample:
+    - name: events_waits_current
+      enabled: true
 actors:
   description: Normalized requested actor rows after module execution or prediction.
   returned: when O(actors) is provided
   type: list
   elements: dict
+  sample:
+    - user: app
+      host: '%'
+      role: '%'
+      enabled: true
+      history: false
 objects:
   description: Normalized requested object rows after module execution or prediction.
   returned: when O(objects) is provided
   type: list
   elements: dict
+  sample:
+    - object_type: TABLE
+      object_schema: reporting
+      object_name: slow_queries
+      enabled: true
+      timed: false
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -259,7 +278,7 @@ from ansible_collections.ansible.mysql.plugins.module_utils.perf_schema import (
 )
 
 
-class MySQL_Perf_Schema(object):
+class MySQLPerfSchema(object):
     def __init__(self, module, cursor):
         self.module = module
         self.cursor = cursor
@@ -289,7 +308,9 @@ class MySQL_Perf_Schema(object):
         return result
 
     def get_section_rows(self, section):
-        query = 'SELECT * FROM performance_schema.%s' % SECTION_DEFINITIONS[section]['table']
+        definition = SECTION_DEFINITIONS[section]
+        fields = ', '.join(definition['db_key_fields'] + definition['db_value_fields'])
+        query = 'SELECT %s FROM performance_schema.%s' % (fields, definition['table'])
         self.cursor.execute(query)
         return self.cursor.fetchall()
 
@@ -322,6 +343,7 @@ def main():
         actors=dict(
             type='list',
             elements='dict',
+            required_if=[('state', 'present', ('enabled', 'history'))],
             options=dict(
                 user=dict(type='str', required=True),
                 host=dict(type='str', required=True),
@@ -334,6 +356,7 @@ def main():
         objects=dict(
             type='list',
             elements='dict',
+            required_if=[('state', 'present', ('enabled', 'timed'))],
             options=dict(
                 object_type=dict(type='str', required=True),
                 object_schema=dict(type='str', required=True),
@@ -371,12 +394,12 @@ def main():
     except Exception as e:
         module.fail_json(msg='unable to connect to database: %s' % to_native(e))
 
-    executor = MySQL_Perf_Schema(module, cursor)
+    executor = MySQLPerfSchema(module, cursor)
 
     try:
         result = executor.apply(module.params)
     except ValueError as e:
-        module.fail_json(msg=to_native(e))
+        module.fail_json(msg='invalid performance schema request: %s' % to_native(e))
     except Exception as e:
         module.fail_json(msg=to_native(e))
 

--- a/tests/integration/targets/test_mysql_perf_schema/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_perf_schema/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_perf_schema/meta/main.yml
+++ b/tests/integration/targets/test_mysql_perf_schema/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_perf_schema/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_perf_schema/tasks/main.yml
@@ -1,0 +1,414 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: Perf schema | Run tests
+  vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+    actor_user: ansible_perf_schema
+    actor_host: '%'
+    actor_role: '%'
+    object_type: TABLE
+    object_schema: ansible_perf_schema
+    object_name: sample_%
+
+  block:
+    - name: Perf schema | Check whether performance schema is enabled
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: "SHOW GLOBAL VARIABLES LIKE 'performance_schema'"
+      register: perf_schema_variable
+
+    - name: Perf schema | Skip tests when performance schema is disabled
+      ansible.builtin.meta: end_play
+      when: perf_schema_variable.query_result[0][0]['Value'] | upper != 'ON'
+
+    - name: Perf schema | Select one instrument row
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT NAME, ENABLED, TIMED
+          FROM performance_schema.setup_instruments
+          WHERE TIMED IS NOT NULL
+          ORDER BY NAME
+          LIMIT 1
+      register: instrument_row
+
+    - name: Perf schema | Select one consumer row
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT NAME, ENABLED
+          FROM performance_schema.setup_consumers
+          ORDER BY NAME
+          LIMIT 1
+      register: consumer_row
+
+    - name: Perf schema | Set desired instrument and consumer facts
+      ansible.builtin.set_fact:
+        instrument_name: "{{ instrument_row.query_result[0][0]['NAME'] }}"
+        instrument_enabled_initial: "{{ instrument_row.query_result[0][0]['ENABLED'] | upper == 'YES' }}"
+        instrument_timed_initial: "{{ instrument_row.query_result[0][0]['TIMED'] | upper == 'YES' }}"
+        instrument_enabled_desired: "{{ not (instrument_row.query_result[0][0]['ENABLED'] | upper == 'YES') }}"
+        instrument_timed_desired: "{{ not (instrument_row.query_result[0][0]['TIMED'] | upper == 'YES') }}"
+        consumer_name: "{{ consumer_row.query_result[0][0]['NAME'] }}"
+        consumer_enabled_initial: "{{ consumer_row.query_result[0][0]['ENABLED'] | upper == 'YES' }}"
+        consumer_enabled_desired: "{{ not (consumer_row.query_result[0][0]['ENABLED'] | upper == 'YES') }}"
+
+    - name: Perf schema | Update instrument and consumer in check mode
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        instruments:
+          - name: '{{ instrument_name }}'
+            enabled: '{{ instrument_enabled_desired }}'
+            timed: '{{ instrument_timed_desired }}'
+        consumers:
+          - name: '{{ consumer_name }}'
+            enabled: '{{ consumer_enabled_desired }}'
+      check_mode: true
+      register: result
+
+    - name: Perf schema | Assert instrument and consumer check mode result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 2
+          - result.instruments[0].name == instrument_name
+          - result.instruments[0].enabled == instrument_enabled_desired
+          - result.instruments[0].timed == instrument_timed_desired
+          - result.consumers[0].name == consumer_name
+          - result.consumers[0].enabled == consumer_enabled_desired
+
+    - name: Perf schema | Verify instrument and consumer stayed unchanged after check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - >
+            SELECT ENABLED, TIMED
+            FROM performance_schema.setup_instruments
+            WHERE NAME = '{{ instrument_name }}'
+          - >
+            SELECT ENABLED
+            FROM performance_schema.setup_consumers
+            WHERE NAME = '{{ consumer_name }}'
+      register: result
+
+    - name: Perf schema | Assert instrument and consumer stayed unchanged after check mode
+      ansible.builtin.assert:
+        that:
+          - (result.query_result[0][0]['ENABLED'] | upper == 'YES') == instrument_enabled_initial
+          - (result.query_result[0][0]['TIMED'] | upper == 'YES') == instrument_timed_initial
+          - (result.query_result[1][0]['ENABLED'] | upper == 'YES') == consumer_enabled_initial
+
+    - name: Perf schema | Update instrument and consumer
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        instruments:
+          - name: '{{ instrument_name }}'
+            enabled: '{{ instrument_enabled_desired }}'
+            timed: '{{ instrument_timed_desired }}'
+        consumers:
+          - name: '{{ consumer_name }}'
+            enabled: '{{ consumer_enabled_desired }}'
+      register: result
+
+    - name: Perf schema | Assert instrument and consumer update result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.instruments[0].enabled == instrument_enabled_desired
+          - result.instruments[0].timed == instrument_timed_desired
+          - result.consumers[0].enabled == consumer_enabled_desired
+
+    - name: Perf schema | Verify instrument and consumer changed in database
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - >
+            SELECT ENABLED, TIMED
+            FROM performance_schema.setup_instruments
+            WHERE NAME = '{{ instrument_name }}'
+          - >
+            SELECT ENABLED
+            FROM performance_schema.setup_consumers
+            WHERE NAME = '{{ consumer_name }}'
+      register: result
+
+    - name: Perf schema | Assert instrument and consumer changed in database
+      ansible.builtin.assert:
+        that:
+          - (result.query_result[0][0]['ENABLED'] | upper == 'YES') == instrument_enabled_desired
+          - (result.query_result[0][0]['TIMED'] | upper == 'YES') == instrument_timed_desired
+          - (result.query_result[1][0]['ENABLED'] | upper == 'YES') == consumer_enabled_desired
+
+    - name: Perf schema | Re-apply instrument and consumer
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        instruments:
+          - name: '{{ instrument_name }}'
+            enabled: '{{ instrument_enabled_desired }}'
+            timed: '{{ instrument_timed_desired }}'
+        consumers:
+          - name: '{{ consumer_name }}'
+            enabled: '{{ consumer_enabled_desired }}'
+      register: result
+
+    - name: Perf schema | Assert idempotent apply for instrument and consumer
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+
+    - name: Perf schema | Ensure actor and object rows are absent
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        actors:
+          - user: '{{ actor_user }}'
+            host: '{{ actor_host }}'
+            role: '{{ actor_role }}'
+            state: absent
+        objects:
+          - object_type: '{{ object_type }}'
+            object_schema: '{{ object_schema }}'
+            object_name: '{{ object_name }}'
+            state: absent
+
+    - name: Perf schema | Create actor and object in check mode
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        actors:
+          - user: '{{ actor_user }}'
+            host: '{{ actor_host }}'
+            role: '{{ actor_role }}'
+            enabled: true
+            history: false
+        objects:
+          - object_type: '{{ object_type }}'
+            object_schema: '{{ object_schema }}'
+            object_name: '{{ object_name }}'
+            enabled: true
+            timed: false
+      check_mode: true
+      register: result
+
+    - name: Perf schema | Assert actor and object check mode create result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 2
+          - result.actors[0].user == actor_user
+          - result.actors[0].host == actor_host
+          - result.actors[0].role == actor_role
+          - result.actors[0].enabled
+          - not result.actors[0].history
+          - result.objects[0].object_type == object_type
+          - result.objects[0].object_schema == object_schema
+          - result.objects[0].object_name == object_name
+          - result.objects[0].enabled
+          - not result.objects[0].timed
+
+    - name: Perf schema | Verify actor and object do not exist after check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - >
+            SELECT COUNT(*) AS actor_count
+            FROM performance_schema.setup_actors
+            WHERE HOST = '{{ actor_host }}'
+              AND USER = '{{ actor_user }}'
+              AND ROLE = '{{ actor_role }}'
+          - >
+            SELECT COUNT(*) AS object_count
+            FROM performance_schema.setup_objects
+            WHERE OBJECT_TYPE = '{{ object_type }}'
+              AND OBJECT_SCHEMA = '{{ object_schema }}'
+              AND OBJECT_NAME = '{{ object_name }}'
+      register: result
+
+    - name: Perf schema | Assert actor and object absent after check mode
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['actor_count'] == 0
+          - result.query_result[1][0]['object_count'] == 0
+
+    - name: Perf schema | Create actor and object
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        actors:
+          - user: '{{ actor_user }}'
+            host: '{{ actor_host }}'
+            role: '{{ actor_role }}'
+            enabled: true
+            history: false
+        objects:
+          - object_type: '{{ object_type }}'
+            object_schema: '{{ object_schema }}'
+            object_name: '{{ object_name }}'
+            enabled: true
+            timed: false
+      register: result
+
+    - name: Perf schema | Assert actor and object create result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.actors[0].enabled
+          - not result.actors[0].history
+          - result.objects[0].enabled
+          - not result.objects[0].timed
+
+    - name: Perf schema | Verify actor and object exist in database
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - >
+            SELECT ENABLED, HISTORY
+            FROM performance_schema.setup_actors
+            WHERE HOST = '{{ actor_host }}'
+              AND USER = '{{ actor_user }}'
+              AND ROLE = '{{ actor_role }}'
+          - >
+            SELECT ENABLED, TIMED
+            FROM performance_schema.setup_objects
+            WHERE OBJECT_TYPE = '{{ object_type }}'
+              AND OBJECT_SCHEMA = '{{ object_schema }}'
+              AND OBJECT_NAME = '{{ object_name }}'
+      register: result
+
+    - name: Perf schema | Assert actor and object exist in database
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['ENABLED'] | upper == 'YES'
+          - result.query_result[0][0]['HISTORY'] | upper == 'NO'
+          - result.query_result[1][0]['ENABLED'] | upper == 'YES'
+          - result.query_result[1][0]['TIMED'] | upper == 'NO'
+
+    - name: Perf schema | Re-apply actor and object
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        actors:
+          - user: '{{ actor_user }}'
+            host: '{{ actor_host }}'
+            role: '{{ actor_role }}'
+            enabled: true
+            history: false
+        objects:
+          - object_type: '{{ object_type }}'
+            object_schema: '{{ object_schema }}'
+            object_name: '{{ object_name }}'
+            enabled: true
+            timed: false
+      register: result
+
+    - name: Perf schema | Assert idempotent apply for actor and object
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+
+    - name: Perf schema | Remove actor and object in check mode
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        actors:
+          - user: '{{ actor_user }}'
+            host: '{{ actor_host }}'
+            role: '{{ actor_role }}'
+            state: absent
+        objects:
+          - object_type: '{{ object_type }}'
+            object_schema: '{{ object_schema }}'
+            object_name: '{{ object_name }}'
+            state: absent
+      check_mode: true
+      register: result
+
+    - name: Perf schema | Assert actor and object absent check mode result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 2
+          - result.actors | length == 0
+          - result.objects | length == 0
+
+    - name: Perf schema | Verify actor and object still exist after absent check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - >
+            SELECT COUNT(*) AS actor_count
+            FROM performance_schema.setup_actors
+            WHERE HOST = '{{ actor_host }}'
+              AND USER = '{{ actor_user }}'
+              AND ROLE = '{{ actor_role }}'
+          - >
+            SELECT COUNT(*) AS object_count
+            FROM performance_schema.setup_objects
+            WHERE OBJECT_TYPE = '{{ object_type }}'
+              AND OBJECT_SCHEMA = '{{ object_schema }}'
+              AND OBJECT_NAME = '{{ object_name }}'
+      register: result
+
+    - name: Perf schema | Assert actor and object still exist after absent check mode
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['actor_count'] == 1
+          - result.query_result[1][0]['object_count'] == 1
+
+    - name: Perf schema | Remove actor and object
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        actors:
+          - user: '{{ actor_user }}'
+            host: '{{ actor_host }}'
+            role: '{{ actor_role }}'
+            state: absent
+        objects:
+          - object_type: '{{ object_type }}'
+            object_schema: '{{ object_schema }}'
+            object_name: '{{ object_name }}'
+            state: absent
+      register: result
+
+    - name: Perf schema | Assert actor and object absent result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+
+    - name: Perf schema | Verify actor and object are absent in database
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - >
+            SELECT COUNT(*) AS actor_count
+            FROM performance_schema.setup_actors
+            WHERE HOST = '{{ actor_host }}'
+              AND USER = '{{ actor_user }}'
+              AND ROLE = '{{ actor_role }}'
+          - >
+            SELECT COUNT(*) AS object_count
+            FROM performance_schema.setup_objects
+            WHERE OBJECT_TYPE = '{{ object_type }}'
+              AND OBJECT_SCHEMA = '{{ object_schema }}'
+              AND OBJECT_NAME = '{{ object_name }}'
+      register: result
+
+    - name: Perf schema | Assert actor and object are absent in database
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['actor_count'] == 0
+          - result.query_result[1][0]['object_count'] == 0
+
+    - name: Perf schema | Restore original instrument and consumer values
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        instruments:
+          - name: '{{ instrument_name }}'
+            enabled: '{{ instrument_enabled_initial }}'
+            timed: '{{ instrument_timed_initial }}'
+        consumers:
+          - name: '{{ consumer_name }}'
+            enabled: '{{ consumer_enabled_initial }}'

--- a/tests/integration/targets/test_mysql_perf_schema/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_perf_schema/tasks/main.yml
@@ -61,6 +61,26 @@
         consumer_enabled_initial: "{{ consumer_row.query_result[0][0]['ENABLED'] | upper == 'YES' }}"
         consumer_enabled_desired: "{{ not (consumer_row.query_result[0][0]['ENABLED'] | upper == 'YES') }}"
 
+    - name: Perf schema | Select one wildcard instrument row
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT NAME, ENABLED, TIMED
+          FROM performance_schema.setup_instruments
+          WHERE NAME LIKE '%/%'
+            AND TIMED IS NOT NULL
+          ORDER BY NAME
+          LIMIT 1
+      register: wildcard_instrument_row
+
+    - name: Perf schema | Set wildcard instrument facts
+      ansible.builtin.set_fact:
+        wildcard_instrument_name: "{{ wildcard_instrument_row.query_result[0][0]['NAME'] }}"
+        wildcard_instrument_enabled_initial: "{{ wildcard_instrument_row.query_result[0][0]['ENABLED'] | upper == 'YES' }}"
+        wildcard_instrument_timed_initial: "{{ wildcard_instrument_row.query_result[0][0]['TIMED'] | upper == 'YES' }}"
+        wildcard_instrument_enabled_desired: "{{ not (wildcard_instrument_row.query_result[0][0]['ENABLED'] | upper == 'YES') }}"
+        wildcard_instrument_timed_desired: "{{ not (wildcard_instrument_row.query_result[0][0]['TIMED'] | upper == 'YES') }}"
+
     - name: Perf schema | Update instrument and consumer in check mode
       ansible.mysql.mysql_perf_schema:
         <<: *mysql_params
@@ -163,6 +183,55 @@
       ansible.builtin.assert:
         that:
           - result is not changed
+
+    - name: Perf schema | Update wildcard instrument row
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        instruments:
+          - name: '{{ wildcard_instrument_name }}'
+            enabled: '{{ wildcard_instrument_enabled_desired }}'
+            timed: '{{ wildcard_instrument_timed_desired }}'
+      register: result
+
+    - name: Perf schema | Assert wildcard instrument update result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.instruments[0].name == wildcard_instrument_name
+          - result.instruments[0].enabled == wildcard_instrument_enabled_desired
+          - result.instruments[0].timed == wildcard_instrument_timed_desired
+
+    - name: Perf schema | Verify wildcard instrument changed in database
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >
+          SELECT ENABLED, TIMED
+          FROM performance_schema.setup_instruments
+          WHERE NAME = '{{ wildcard_instrument_name }}'
+      register: result
+
+    - name: Perf schema | Assert wildcard instrument changed in database
+      ansible.builtin.assert:
+        that:
+          - (result.query_result[0][0]['ENABLED'] | upper == 'YES') == wildcard_instrument_enabled_desired
+          - (result.query_result[0][0]['TIMED'] | upper == 'YES') == wildcard_instrument_timed_desired
+
+    - name: Perf schema | Fail when instrument row does not exist
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        instruments:
+          - name: ansible/nonexistent/instrument
+            enabled: true
+            timed: true
+      register: result
+      ignore_errors: true
+
+    - name: Perf schema | Assert missing instrument failure
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'invalid performance schema request:' in result.msg"
+          - "'ansible/nonexistent/instrument' in result.msg"
 
     - name: Perf schema | Ensure actor and object rows are absent
       ansible.mysql.mysql_perf_schema:
@@ -288,6 +357,58 @@
           - result.query_result[1][0]['ENABLED'] | upper == 'YES'
           - result.query_result[1][0]['TIMED'] | upper == 'NO'
 
+    - name: Perf schema | Update actor and object rows
+      ansible.mysql.mysql_perf_schema:
+        <<: *mysql_params
+        actors:
+          - user: '{{ actor_user }}'
+            host: '{{ actor_host }}'
+            role: '{{ actor_role }}'
+            enabled: false
+            history: true
+        objects:
+          - object_type: '{{ object_type }}'
+            object_schema: '{{ object_schema }}'
+            object_name: '{{ object_name }}'
+            enabled: false
+            timed: true
+      register: result
+
+    - name: Perf schema | Assert actor and object update result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - not result.actors[0].enabled
+          - result.actors[0].history
+          - not result.objects[0].enabled
+          - result.objects[0].timed
+
+    - name: Perf schema | Verify actor and object updates in database
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - >
+            SELECT ENABLED, HISTORY
+            FROM performance_schema.setup_actors
+            WHERE HOST = '{{ actor_host }}'
+              AND USER = '{{ actor_user }}'
+              AND ROLE = '{{ actor_role }}'
+          - >
+            SELECT ENABLED, TIMED
+            FROM performance_schema.setup_objects
+            WHERE OBJECT_TYPE = '{{ object_type }}'
+              AND OBJECT_SCHEMA = '{{ object_schema }}'
+              AND OBJECT_NAME = '{{ object_name }}'
+      register: result
+
+    - name: Perf schema | Assert actor and object updates in database
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['ENABLED'] | upper == 'NO'
+          - result.query_result[0][0]['HISTORY'] | upper == 'YES'
+          - result.query_result[1][0]['ENABLED'] | upper == 'NO'
+          - result.query_result[1][0]['TIMED'] | upper == 'YES'
+
     - name: Perf schema | Re-apply actor and object
       ansible.mysql.mysql_perf_schema:
         <<: *mysql_params
@@ -295,14 +416,14 @@
           - user: '{{ actor_user }}'
             host: '{{ actor_host }}'
             role: '{{ actor_role }}'
-            enabled: true
-            history: false
+            enabled: false
+            history: true
         objects:
           - object_type: '{{ object_type }}'
             object_schema: '{{ object_schema }}'
             object_name: '{{ object_name }}'
-            enabled: true
-            timed: false
+            enabled: false
+            timed: true
       register: result
 
     - name: Perf schema | Assert idempotent apply for actor and object
@@ -409,6 +530,9 @@
           - name: '{{ instrument_name }}'
             enabled: '{{ instrument_enabled_initial }}'
             timed: '{{ instrument_timed_initial }}'
+          - name: '{{ wildcard_instrument_name }}'
+            enabled: '{{ wildcard_instrument_enabled_initial }}'
+            timed: '{{ wildcard_instrument_timed_initial }}'
         consumers:
           - name: '{{ consumer_name }}'
             enabled: '{{ consumer_enabled_initial }}'

--- a/tests/unit/plugins/module_utils/test_perf_schema.py
+++ b/tests/unit/plugins/module_utils/test_perf_schema.py
@@ -10,28 +10,10 @@ except ImportError:
 
 from ansible_collections.ansible.mysql.plugins.module_utils.perf_schema import (
     ensure_perf_schema_sections_supported,
-    get_server_version_tuple,
     normalize_perf_schema_item,
     normalize_perf_schema_row,
     plan_section_changes,
 )
-
-
-class dummy_cursor_class():
-    def __init__(self, output):
-        self.output = output
-
-    def execute(self, query):
-        pass
-
-    def fetchone(self):
-        return {'version': self.output}
-
-
-def test_get_server_version_tuple_strips_engine_suffix():
-    cursor = dummy_cursor_class('10.11.8-MariaDB-1:10.11.8+maria~ubu2204')
-
-    assert get_server_version_tuple(cursor) == (10, 11, 8)
 
 
 def test_normalize_perf_schema_item_for_instrument_converts_bool_values():
@@ -139,6 +121,20 @@ def test_plan_section_changes_inserts_and_deletes_actors():
             'history': False,
         }
     ]
+
+
+def test_plan_section_changes_fails_for_missing_non_insertable_row():
+    with pytest.raises(ValueError) as exc:
+        plan_section_changes(
+            'instruments',
+            [{'name': 'statement/%', 'enabled': True, 'timed': True}],
+            [],
+        )
+
+    assert str(exc.value) == (
+        "Performance Schema section 'instruments' does not contain the requested row "
+        "{'name': 'statement/%'}"
+    )
 
 
 def test_ensure_perf_schema_sections_supported_fails_when_columns_are_missing():

--- a/tests/unit/plugins/module_utils/test_perf_schema.py
+++ b/tests/unit/plugins/module_utils/test_perf_schema.py
@@ -1,0 +1,159 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+from ansible_collections.ansible.mysql.plugins.module_utils.perf_schema import (
+    ensure_perf_schema_sections_supported,
+    get_server_version_tuple,
+    normalize_perf_schema_item,
+    normalize_perf_schema_row,
+    plan_section_changes,
+)
+
+
+class dummy_cursor_class():
+    def __init__(self, output):
+        self.output = output
+
+    def execute(self, query):
+        pass
+
+    def fetchone(self):
+        return {'version': self.output}
+
+
+def test_get_server_version_tuple_strips_engine_suffix():
+    cursor = dummy_cursor_class('10.11.8-MariaDB-1:10.11.8+maria~ubu2204')
+
+    assert get_server_version_tuple(cursor) == (10, 11, 8)
+
+
+def test_normalize_perf_schema_item_for_instrument_converts_bool_values():
+    normalized = normalize_perf_schema_item(
+        'instruments',
+        {'name': 'memory/sql/THD::transactions::mem_root', 'enabled': 'yes', 'timed': 0},
+    )
+
+    assert normalized == {
+        'name': 'memory/sql/THD::transactions::mem_root',
+        'enabled': True,
+        'timed': False,
+    }
+
+
+def test_normalize_perf_schema_row_for_object_uses_canonical_keys():
+    normalized = normalize_perf_schema_row(
+        'objects',
+        {
+            'OBJECT_TYPE': 'TABLE',
+            'OBJECT_SCHEMA': 'db1',
+            'OBJECT_NAME': 'orders',
+            'ENABLED': 'YES',
+            'TIMED': 'NO',
+        },
+    )
+
+    assert normalized == {
+        'object_type': 'TABLE',
+        'object_schema': 'db1',
+        'object_name': 'orders',
+        'enabled': True,
+        'timed': False,
+    }
+
+
+def test_plan_section_changes_updates_requested_instrument_only():
+    current_rows = [
+        {
+            'NAME': 'wait/io/table/sql/handler',
+            'ENABLED': 'NO',
+            'TIMED': 'NO',
+        },
+        {
+            'NAME': 'statement/sql/select',
+            'ENABLED': 'YES',
+            'TIMED': 'YES',
+        },
+    ]
+
+    planned = plan_section_changes(
+        'instruments',
+        [{'name': 'wait/io/table/sql/handler', 'enabled': True, 'timed': True}],
+        current_rows,
+    )
+
+    assert planned['changed'] is True
+    assert [query['display'] for query in planned['queries']] == [
+        "UPDATE performance_schema.setup_instruments "
+        "SET ENABLED = 'YES', TIMED = 'YES' "
+        "WHERE NAME = 'wait/io/table/sql/handler'"
+    ]
+    assert planned['rows'] == [
+        {
+            'name': 'wait/io/table/sql/handler',
+            'enabled': True,
+            'timed': True,
+        }
+    ]
+
+
+def test_plan_section_changes_inserts_and_deletes_actors():
+    current_rows = [
+        {
+            'HOST': '%',
+            'USER': 'old_app',
+            'ROLE': '%',
+            'ENABLED': 'YES',
+            'HISTORY': 'YES',
+        }
+    ]
+
+    planned = plan_section_changes(
+        'actors',
+        [
+            {'user': 'old_app', 'host': '%', 'role': '%', 'state': 'absent'},
+            {'user': 'new_app', 'host': '%', 'role': '%', 'enabled': True, 'history': False},
+        ],
+        current_rows,
+    )
+
+    assert planned['changed'] is True
+    assert [query['display'] for query in planned['queries']] == [
+        "DELETE FROM performance_schema.setup_actors "
+        "WHERE HOST = '%' AND USER = 'old_app' AND ROLE = '%'",
+        "INSERT INTO performance_schema.setup_actors (HOST, USER, ROLE, ENABLED, HISTORY) "
+        "VALUES ('%', 'new_app', '%', 'YES', 'NO')",
+    ]
+    assert planned['rows'] == [
+        {
+            'user': 'new_app',
+            'host': '%',
+            'role': '%',
+            'enabled': True,
+            'history': False,
+        }
+    ]
+
+
+def test_ensure_perf_schema_sections_supported_fails_when_columns_are_missing():
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [
+        {'TABLE_NAME': 'setup_instruments', 'COLUMN_NAME': 'NAME'},
+        {'TABLE_NAME': 'setup_instruments', 'COLUMN_NAME': 'ENABLED'},
+    ]
+
+    module = MagicMock()
+    module.fail_json.side_effect = RuntimeError
+
+    with pytest.raises(RuntimeError):
+        ensure_perf_schema_sections_supported(module, cursor, ['instruments'])
+
+    module.fail_json.assert_called_once_with(
+        msg="Performance Schema section 'instruments' is not supported by the server. Missing columns: TIMED"
+    )

--- a/tests/unit/plugins/modules/test_mysql_perf_schema.py
+++ b/tests/unit/plugins/modules/test_mysql_perf_schema.py
@@ -1,12 +1,42 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import json
+
+import pytest
+
 try:
     from unittest.mock import MagicMock
 except ImportError:
     from mock import MagicMock
 
-from ansible_collections.ansible.mysql.plugins.modules.mysql_perf_schema import MySQL_Perf_Schema
+from ansible.module_utils import basic
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.ansible.mysql.plugins.modules import mysql_perf_schema
+from ansible_collections.ansible.mysql.plugins.modules.mysql_perf_schema import MySQLPerfSchema
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    basic._ANSIBLE_ARGS = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': args}))
 
 
 def test_apply_in_check_mode_returns_predicted_queries_without_executing_updates():
@@ -24,7 +54,7 @@ def test_apply_in_check_mode_returns_predicted_queries_without_executing_updates
     def execute_side_effect(query, params=None):
         if query.startswith('SELECT TABLE_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS'):
             cursor.fetchall.return_value = support_rows
-        elif query == 'SELECT * FROM performance_schema.setup_instruments':
+        elif query == 'SELECT NAME, ENABLED, TIMED FROM performance_schema.setup_instruments':
             cursor.fetchall.return_value = current_rows
         else:
             raise AssertionError('Unexpected query: %s' % query)
@@ -33,7 +63,7 @@ def test_apply_in_check_mode_returns_predicted_queries_without_executing_updates
 
     module = MagicMock()
     module.check_mode = True
-    executor = MySQL_Perf_Schema(module, cursor)
+    executor = MySQLPerfSchema(module, cursor)
 
     result = executor.apply({
         'instruments': [
@@ -79,9 +109,9 @@ def test_apply_executes_mutations_and_returns_rows_for_multiple_sections():
     def execute_side_effect(query, params=None):
         if query.startswith('SELECT TABLE_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS'):
             cursor.fetchall.return_value = support_rows
-        elif query == 'SELECT * FROM performance_schema.setup_consumers':
+        elif query == 'SELECT NAME, ENABLED FROM performance_schema.setup_consumers':
             cursor.fetchall.return_value = consumer_rows
-        elif query == 'SELECT * FROM performance_schema.setup_actors':
+        elif query == 'SELECT HOST, USER, ROLE, ENABLED, HISTORY FROM performance_schema.setup_actors':
             cursor.fetchall.return_value = actor_rows
         else:
             cursor.fetchall.return_value = []
@@ -90,7 +120,7 @@ def test_apply_executes_mutations_and_returns_rows_for_multiple_sections():
 
     module = MagicMock()
     module.check_mode = False
-    executor = MySQL_Perf_Schema(module, cursor)
+    executor = MySQLPerfSchema(module, cursor)
 
     result = executor.apply({
         'consumers': [
@@ -119,3 +149,77 @@ def test_apply_executes_mutations_and_returns_rows_for_multiple_sections():
     }
     assert cursor.execute.call_args_list[2][0][0].startswith('UPDATE performance_schema.setup_consumers')
     assert cursor.execute.call_args_list[4][0][0].startswith('INSERT INTO performance_schema.setup_actors')
+
+
+def test_get_section_rows_selects_only_key_and_value_columns():
+    cursor = MagicMock()
+    cursor.fetchall.return_value = []
+
+    executor = MySQLPerfSchema(MagicMock(), cursor)
+
+    executor.get_section_rows('objects')
+
+    cursor.execute.assert_called_once_with(
+        'SELECT OBJECT_TYPE, OBJECT_SCHEMA, OBJECT_NAME, ENABLED, TIMED FROM performance_schema.setup_objects'
+    )
+
+
+@pytest.mark.parametrize(
+    'module_args,missing_fields',
+    [
+        (
+            {
+                'login_unix_socket': '/run/mysqld/mysqld.sock',
+                'actors': [{'user': 'app', 'host': '%', 'role': '%'}],
+            },
+            ('enabled', 'history'),
+        ),
+        (
+            {
+                'login_unix_socket': '/run/mysqld/mysqld.sock',
+                'objects': [{'object_type': 'TABLE', 'object_schema': 'app', 'object_name': 'orders'}],
+            },
+            ('enabled', 'timed'),
+        ),
+    ],
+)
+def test_main_validates_nested_required_fields_before_connect(monkeypatch, module_args, missing_fields):
+    set_module_args(module_args)
+    monkeypatch.setattr(AnsibleModule, 'exit_json', exit_json)
+    monkeypatch.setattr(AnsibleModule, 'fail_json', fail_json)
+    monkeypatch.setattr(mysql_perf_schema, 'mysql_driver', object())
+
+    def unexpected_connect(*args, **kwargs):
+        raise AssertionError('mysql_connect should not be called')
+
+    monkeypatch.setattr(mysql_perf_schema, 'mysql_connect', unexpected_connect)
+
+    with pytest.raises(AnsibleFailJson) as exc:
+        mysql_perf_schema.main()
+
+    message = exc.value.args[0]['msg']
+    for field in missing_fields:
+        assert field in message
+
+
+def test_main_returns_prefixed_validation_error_for_invalid_perf_schema_request(monkeypatch):
+    set_module_args(
+        {
+            'login_unix_socket': '/run/mysqld/mysqld.sock',
+            'instruments': [{'name': 'statement/sql/select', 'enabled': True, 'timed': True}],
+        }
+    )
+    monkeypatch.setattr(AnsibleModule, 'exit_json', exit_json)
+    monkeypatch.setattr(AnsibleModule, 'fail_json', fail_json)
+    monkeypatch.setattr(mysql_perf_schema, 'mysql_driver', object())
+    monkeypatch.setattr(mysql_perf_schema, 'mysql_connect', lambda *args, **kwargs: (MagicMock(), MagicMock()))
+
+    def invalid_request(self, params):
+        raise ValueError('bad request')
+
+    monkeypatch.setattr(mysql_perf_schema.MySQLPerfSchema, 'apply', invalid_request)
+
+    with pytest.raises(AnsibleFailJson) as exc:
+        mysql_perf_schema.main()
+
+    assert exc.value.args[0]['msg'] == 'invalid performance schema request: bad request'

--- a/tests/unit/plugins/modules/test_mysql_perf_schema.py
+++ b/tests/unit/plugins/modules/test_mysql_perf_schema.py
@@ -1,0 +1,121 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+from ansible_collections.ansible.mysql.plugins.modules.mysql_perf_schema import MySQL_Perf_Schema
+
+
+def test_apply_in_check_mode_returns_predicted_queries_without_executing_updates():
+    support_rows = [
+        {'TABLE_NAME': 'setup_instruments', 'COLUMN_NAME': 'NAME'},
+        {'TABLE_NAME': 'setup_instruments', 'COLUMN_NAME': 'ENABLED'},
+        {'TABLE_NAME': 'setup_instruments', 'COLUMN_NAME': 'TIMED'},
+    ]
+    current_rows = [
+        {'NAME': 'wait/io/table/sql/handler', 'ENABLED': 'NO', 'TIMED': 'NO'},
+    ]
+
+    cursor = MagicMock()
+
+    def execute_side_effect(query, params=None):
+        if query.startswith('SELECT TABLE_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS'):
+            cursor.fetchall.return_value = support_rows
+        elif query == 'SELECT * FROM performance_schema.setup_instruments':
+            cursor.fetchall.return_value = current_rows
+        else:
+            raise AssertionError('Unexpected query: %s' % query)
+
+    cursor.execute.side_effect = execute_side_effect
+
+    module = MagicMock()
+    module.check_mode = True
+    executor = MySQL_Perf_Schema(module, cursor)
+
+    result = executor.apply({
+        'instruments': [
+            {'name': 'wait/io/table/sql/handler', 'enabled': True, 'timed': True},
+        ]
+    })
+
+    assert result == {
+        'changed': True,
+        'queries': [
+            "UPDATE performance_schema.setup_instruments "
+            "SET ENABLED = 'YES', TIMED = 'YES' "
+            "WHERE NAME = 'wait/io/table/sql/handler'"
+        ],
+        'instruments': [
+            {
+                'name': 'wait/io/table/sql/handler',
+                'enabled': True,
+                'timed': True,
+            }
+        ],
+    }
+    assert cursor.execute.call_count == 2
+
+
+def test_apply_executes_mutations_and_returns_rows_for_multiple_sections():
+    support_rows = [
+        {'TABLE_NAME': 'setup_consumers', 'COLUMN_NAME': 'NAME'},
+        {'TABLE_NAME': 'setup_consumers', 'COLUMN_NAME': 'ENABLED'},
+        {'TABLE_NAME': 'setup_actors', 'COLUMN_NAME': 'HOST'},
+        {'TABLE_NAME': 'setup_actors', 'COLUMN_NAME': 'USER'},
+        {'TABLE_NAME': 'setup_actors', 'COLUMN_NAME': 'ROLE'},
+        {'TABLE_NAME': 'setup_actors', 'COLUMN_NAME': 'ENABLED'},
+        {'TABLE_NAME': 'setup_actors', 'COLUMN_NAME': 'HISTORY'},
+    ]
+    consumer_rows = [
+        {'NAME': 'events_waits_current', 'ENABLED': 'NO'},
+    ]
+    actor_rows = []
+
+    cursor = MagicMock()
+
+    def execute_side_effect(query, params=None):
+        if query.startswith('SELECT TABLE_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS'):
+            cursor.fetchall.return_value = support_rows
+        elif query == 'SELECT * FROM performance_schema.setup_consumers':
+            cursor.fetchall.return_value = consumer_rows
+        elif query == 'SELECT * FROM performance_schema.setup_actors':
+            cursor.fetchall.return_value = actor_rows
+        else:
+            cursor.fetchall.return_value = []
+
+    cursor.execute.side_effect = execute_side_effect
+
+    module = MagicMock()
+    module.check_mode = False
+    executor = MySQL_Perf_Schema(module, cursor)
+
+    result = executor.apply({
+        'consumers': [
+            {'name': 'events_waits_current', 'enabled': True},
+        ],
+        'actors': [
+            {'user': 'app', 'host': '%', 'role': '%', 'enabled': True, 'history': False},
+        ],
+    })
+
+    assert result == {
+        'changed': True,
+        'queries': [
+            "UPDATE performance_schema.setup_consumers "
+            "SET ENABLED = 'YES' "
+            "WHERE NAME = 'events_waits_current'",
+            "INSERT INTO performance_schema.setup_actors (HOST, USER, ROLE, ENABLED, HISTORY) "
+            "VALUES ('%', 'app', '%', 'YES', 'NO')",
+        ],
+        'consumers': [
+            {'name': 'events_waits_current', 'enabled': True},
+        ],
+        'actors': [
+            {'user': 'app', 'host': '%', 'role': '%', 'enabled': True, 'history': False},
+        ],
+    }
+    assert cursor.execute.call_args_list[2][0][0].startswith('UPDATE performance_schema.setup_consumers')
+    assert cursor.execute.call_args_list[4][0][0].startswith('INSERT INTO performance_schema.setup_actors')

--- a/tests/unit/plugins/modules/test_mysql_perf_schema.py
+++ b/tests/unit/plugins/modules/test_mysql_perf_schema.py
@@ -1,18 +1,24 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from contextlib import contextmanager
 import json
+import sys
 
 import pytest
 
 try:
     from unittest.mock import MagicMock
 except ImportError:
-    from mock import MagicMock
+    from mock import MagicMock  # pyright: ignore[reportMissingImports]
 
 from ansible.module_utils import basic
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_bytes
+try:
+    from ansible.module_utils.testing import patch_module_args  # pyright: ignore[reportMissingImports]
+except ImportError:
+    patch_module_args = None
 
 from ansible_collections.ansible.mysql.plugins.modules import mysql_perf_schema
 from ansible_collections.ansible.mysql.plugins.modules.mysql_perf_schema import MySQLPerfSchema
@@ -35,8 +41,36 @@ def fail_json(*args, **kwargs):
     raise AnsibleFailJson(kwargs)
 
 
+@contextmanager
 def set_module_args(args):
-    basic._ANSIBLE_ARGS = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': args}))
+    module_args = dict(args)
+
+    original_argv = sys.argv[:]
+    sys.argv = ['ansible_unittest']
+
+    try:
+        if patch_module_args is not None:
+            with patch_module_args(module_args):
+                yield
+            return
+
+        original_args = getattr(basic, '_ANSIBLE_ARGS', None)
+        original_profile = getattr(basic, '_ANSIBLE_PROFILE', None)
+        had_profile = hasattr(basic, '_ANSIBLE_PROFILE')
+
+        basic._ANSIBLE_ARGS = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': module_args}))
+        basic._ANSIBLE_PROFILE = 'legacy'
+
+        try:
+            yield
+        finally:
+            basic._ANSIBLE_ARGS = original_args
+            if had_profile:
+                basic._ANSIBLE_PROFILE = original_profile
+            else:
+                delattr(basic, '_ANSIBLE_PROFILE')
+    finally:
+        sys.argv = original_argv
 
 
 def test_apply_in_check_mode_returns_predicted_queries_without_executing_updates():
@@ -184,18 +218,18 @@ def test_get_section_rows_selects_only_key_and_value_columns():
     ],
 )
 def test_main_validates_nested_required_fields_before_connect(monkeypatch, module_args, missing_fields):
-    set_module_args(module_args)
-    monkeypatch.setattr(AnsibleModule, 'exit_json', exit_json)
-    monkeypatch.setattr(AnsibleModule, 'fail_json', fail_json)
-    monkeypatch.setattr(mysql_perf_schema, 'mysql_driver', object())
+    with set_module_args(module_args):
+        monkeypatch.setattr(AnsibleModule, 'exit_json', exit_json)
+        monkeypatch.setattr(AnsibleModule, 'fail_json', fail_json)
+        monkeypatch.setattr(mysql_perf_schema, 'mysql_driver', object())
 
-    def unexpected_connect(*args, **kwargs):
-        raise AssertionError('mysql_connect should not be called')
+        def unexpected_connect(*args, **kwargs):
+            raise AssertionError('mysql_connect should not be called')
 
-    monkeypatch.setattr(mysql_perf_schema, 'mysql_connect', unexpected_connect)
+        monkeypatch.setattr(mysql_perf_schema, 'mysql_connect', unexpected_connect)
 
-    with pytest.raises(AnsibleFailJson) as exc:
-        mysql_perf_schema.main()
+        with pytest.raises(AnsibleFailJson) as exc:
+            mysql_perf_schema.main()
 
     message = exc.value.args[0]['msg']
     for field in missing_fields:
@@ -203,23 +237,23 @@ def test_main_validates_nested_required_fields_before_connect(monkeypatch, modul
 
 
 def test_main_returns_prefixed_validation_error_for_invalid_perf_schema_request(monkeypatch):
-    set_module_args(
+    with set_module_args(
         {
             'login_unix_socket': '/run/mysqld/mysqld.sock',
             'instruments': [{'name': 'statement/sql/select', 'enabled': True, 'timed': True}],
         }
-    )
-    monkeypatch.setattr(AnsibleModule, 'exit_json', exit_json)
-    monkeypatch.setattr(AnsibleModule, 'fail_json', fail_json)
-    monkeypatch.setattr(mysql_perf_schema, 'mysql_driver', object())
-    monkeypatch.setattr(mysql_perf_schema, 'mysql_connect', lambda *args, **kwargs: (MagicMock(), MagicMock()))
+    ):
+        monkeypatch.setattr(AnsibleModule, 'exit_json', exit_json)
+        monkeypatch.setattr(AnsibleModule, 'fail_json', fail_json)
+        monkeypatch.setattr(mysql_perf_schema, 'mysql_driver', object())
+        monkeypatch.setattr(mysql_perf_schema, 'mysql_connect', lambda *args, **kwargs: (MagicMock(), MagicMock()))
 
-    def invalid_request(self, params):
-        raise ValueError('bad request')
+        def invalid_request(self, params):
+            raise ValueError('bad request')
 
-    monkeypatch.setattr(mysql_perf_schema.MySQLPerfSchema, 'apply', invalid_request)
+        monkeypatch.setattr(mysql_perf_schema.MySQLPerfSchema, 'apply', invalid_request)
 
-    with pytest.raises(AnsibleFailJson) as exc:
-        mysql_perf_schema.main()
+        with pytest.raises(AnsibleFailJson) as exc:
+            mysql_perf_schema.main()
 
     assert exc.value.args[0]['msg'] == 'invalid performance schema request: bad request'


### PR DESCRIPTION
#### SUMMARY
- add the new `mysql_perf_schema` module to manage runtime Performance Schema instruments, consumers, actors, and objects

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- `plugins/modules/mysql_perf_schema.py`
- `plugins/module_utils/perf_schema.py`
- `tests/unit/plugins/modules/test_mysql_perf_schema.py`
- `tests/unit/plugins/module_utils/test_perf_schema.py`
- `tests/integration/targets/test_mysql_perf_schema/tasks/main.yml`
- `tests/integration/targets/test_mysql_perf_schema/meta/main.yml`
- `tests/integration/targets/test_mysql_perf_schema/defaults/main.yml`
- `meta/runtime.yml`
- `TESTING.md`

#### ADDITIONAL INFORMATION
- adds a new runtime-only Performance Schema management module; persistence across restart remains out of scope
- includes unit coverage for normalization and SQL planning and integration coverage for MySQL runtime updates and normal-mode idempotency
- MariaDB integration exits early when `performance_schema=OFF`, which matches the current test-container behavior
- Was created with the help of GPT5.4 with human in the loop and manual testing