### PR TITLE
Exclude local development files from collection builds

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -15,3 +15,14 @@ repository: https://github.com/ansible-collections/ansible.mysql
 documentation: https://github.com/ansible-collections/ansible.mysql
 homepage: https://github.com/ansible-collections/ansible.mysql
 issues: https://github.com/ansible-collections/ansible.mysql/issues
+build_ignore:
+  - .vscode
+  - tests/integration
+  - tests/unit
+  - changelogs/.plugin-cache.yaml
+  - .github
+  - .agents
+  - .cursor
+  - .claude
+  - .gitignore
+  - .venv


### PR DESCRIPTION
#### SUMMARY
- add `build_ignore` entries in `galaxy.yml` so collection builds exclude local development files and non-release workspace content
- keep generated artifacts cleaner by omitting editor settings, local virtualenvs, local agent metadata, and test directories from the published tarball

#### ISSUE TYPE
- Bug Fix Pull Request

#### COMPONENT NAME
- galaxy.yml

#### ADDITIONAL INFORMATION
- affects collection packaging metadata only
