### PR TITLE
feat: add config-only mysql_password_policy module

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Every voice is important and every idea is valuable. If you have something on yo
   - [mysql_clone](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_clone_module.html)
   - [mysql_db](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_db_module.html)
   - [mysql_info](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_info_module.html)
+  - [mysql_password_policy](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_password_policy_module.html)
   - [mysql_perf_schema](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_perf_schema_module.html)
   - [mysql_query](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_query_module.html)
   - [mysql_replication](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_replication_module.html)

--- a/plugins/modules/mysql_password_policy.py
+++ b/plugins/modules/mysql_password_policy.py
@@ -1,0 +1,421 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_password_policy
+
+short_description: Manage MySQL or MariaDB password policy settings
+
+description:
+  - Manage password policy settings on MySQL or MariaDB.
+  - This module is configuration-only and does not install or uninstall password validation components or plugins.
+  - On MySQL, the module manages C(validate_password) settings and related global password policy variables.
+  - On MariaDB, the module manages the C(simple_password_check) plugin settings only.
+
+author:
+  - Steve Fulmer (@stevefulme1)
+  - Ron Gershburg (@ronger4)
+
+version_added: '5.2.0'
+
+options:
+  policy:
+    description:
+      - Password validation policy level on MySQL.
+      - Supported only on MySQL.
+    type: str
+    choices: [low, medium, strong]
+  length:
+    description:
+      - Minimum number of characters in a password.
+      - Maps to the active password validation facility for the current engine.
+    type: int
+  mixed_case_count:
+    description:
+      - Minimum number of same-case letters required by the active password validation facility.
+      - Supported on MySQL and on MariaDB C(simple_password_check).
+    type: int
+  number_count:
+    description:
+      - Minimum number of numeric characters required.
+      - Supported on MySQL and on MariaDB C(simple_password_check).
+    type: int
+  special_char_count:
+    description:
+      - Minimum number of non-alphanumeric characters required.
+      - Supported on MySQL and on MariaDB C(simple_password_check).
+    type: int
+  check_user_name:
+    description:
+      - Whether passwords are checked against the user name.
+      - Supported only on MySQL.
+    type: bool
+  password_lifetime:
+    description:
+      - Default password expiration lifetime in days.
+      - Supported only on MySQL.
+    type: int
+  password_history:
+    description:
+      - Number of previous passwords that cannot be reused.
+      - Supported only on MySQL.
+    type: int
+  reuse_interval:
+    description:
+      - Number of days before a password can be reused.
+      - Supported only on MySQL.
+    type: int
+  mode:
+    description:
+      - How supported MySQL variables are set.
+      - C(global) uses C(SET GLOBAL) and does not survive restarts by itself.
+      - C(persist) uses C(SET PERSIST) on MySQL.
+      - Supported only on MySQL.
+    type: str
+    choices: [global, persist]
+    default: global
+
+notes:
+  - The required password validation component or plugin must already be enabled on the target server.
+  - The module does not install C(validate_password) or MariaDB password validation plugins.
+  - MariaDB support in the first iteration is limited to C(simple_password_check).
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+seealso:
+  - module: ansible.mysql.mysql_query
+  - module: ansible.mysql.mysql_variables
+  - name: MySQL password validation component
+    description: Oracle MySQL reference for validate_password.
+    link: https://dev.mysql.com/doc/refman/8.4/en/validate-password.html
+  - name: MariaDB simple password check plugin
+    description: MariaDB reference for simple_password_check.
+    link: https://mariadb.com/docs/server/reference/plugins/password-validation-plugins/simple-password-check-plugin
+
+extends_documentation_fragment:
+  - ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Configure shared password complexity settings on MySQL
+  ansible.mysql.mysql_password_policy:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    length: 12
+    mixed_case_count: 2
+    number_count: 2
+    special_char_count: 1
+
+- name: Configure MySQL-specific password policy settings persistently
+  ansible.mysql.mysql_password_policy:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    policy: medium
+    check_user_name: true
+    password_lifetime: 90
+    password_history: 5
+    reuse_interval: 365
+    mode: persist
+
+- name: Configure MariaDB simple_password_check settings
+  ansible.mysql.mysql_password_policy:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    length: 14
+    mixed_case_count: 2
+    number_count: 2
+    special_char_count: 2
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed or predicted SQL statements.
+  returned: always
+  type: list
+  sample:
+    - SET GLOBAL `validate_password.length` = 12
+settings:
+  description: Normalized requested settings after execution or prediction.
+  returned: always
+  type: dict
+  sample:
+    length: 12
+    number_count: 2
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.ansible.mysql.plugins.module_utils._version import LooseVersion
+from ansible_collections.ansible.mysql.plugins.module_utils.database import mysql_quote_identifier
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    get_server_implementation,
+    get_server_version,
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+
+
+SETTING_VARIABLES = {
+    'mysql': {
+        'policy': 'validate_password.policy',
+        'length': 'validate_password.length',
+        'mixed_case_count': 'validate_password.mixed_case_count',
+        'number_count': 'validate_password.number_count',
+        'special_char_count': 'validate_password.special_char_count',
+        'check_user_name': 'validate_password.check_user_name',
+        'password_lifetime': 'default_password_lifetime',
+        'password_history': 'password_history',
+        'reuse_interval': 'password_reuse_interval',
+    },
+    'mariadb': {
+        'length': 'simple_password_check_minimal_length',
+        'mixed_case_count': 'simple_password_check_letters_same_case',
+        'number_count': 'simple_password_check_digits',
+        'special_char_count': 'simple_password_check_other_characters',
+    },
+}
+
+MYSQL_ONLY_OPTIONS = (
+    'policy',
+    'check_user_name',
+    'password_lifetime',
+    'password_history',
+    'reuse_interval',
+)
+
+INTEGER_OPTIONS = (
+    'length',
+    'mixed_case_count',
+    'number_count',
+    'special_char_count',
+    'password_lifetime',
+    'password_history',
+    'reuse_interval',
+)
+
+
+def normalize_int_value(value):
+    if isinstance(value, int):
+        return value
+
+    return int(value)
+
+
+def get_variable(cursor, mysqlvar):
+    cursor.execute("SHOW GLOBAL VARIABLES WHERE Variable_name = %s", (mysqlvar,))
+    rows = cursor.fetchall()
+    return rows[0][1] if rows else None
+
+
+def set_variable(cursor, mysqlvar, value, mode):
+    query = "SET %s %s = " % (mode.upper(), mysql_quote_identifier(mysqlvar, 'vars'))
+    cursor.execute(query + "%s", (value,))
+
+
+def normalize_bool_setting_value(value):
+    if isinstance(value, str):
+        value = value.upper()
+
+    if value in ('ON', '1', 1, True):
+        return 'ON'
+    if value in ('OFF', '0', 0, False):
+        return 'OFF'
+    return value
+
+
+def normalize_policy_value(value):
+    value = str(value).strip().lower()
+    numeric_policy = {
+        '0': 'low',
+        '1': 'medium',
+        '2': 'strong',
+    }
+    return numeric_policy.get(value, value)
+
+
+class MySQLPasswordPolicy(object):
+    def __init__(self, module, cursor, server_implementation):
+        self.module = module
+        self.cursor = cursor
+        self.server_implementation = server_implementation
+
+    def configure(self, desired_settings, mode='global', check_mode=False):
+        self.validate_supported_settings(desired_settings, mode)
+
+        effective_settings = {}
+        planned_changes = []
+
+        for setting_name, desired_value in desired_settings.items():
+            if desired_value is None:
+                continue
+
+            variable_name, current_value = self.read_setting(setting_name)
+            normalized_current = self.normalize_value(setting_name, current_value)
+            normalized_desired = self.normalize_value(setting_name, desired_value)
+
+            effective_settings[setting_name] = normalized_desired
+
+            if normalized_current != normalized_desired:
+                planned_changes.append(
+                    (setting_name, variable_name, self.query_value(setting_name, normalized_desired))
+                )
+
+        queries = []
+        changed = bool(planned_changes)
+
+        if check_mode:
+            for _setting_name, variable_name, query_value in planned_changes:
+                queries.append(self.format_set_query(variable_name, query_value, mode))
+            return dict(changed=changed, queries=queries, settings=effective_settings)
+
+        for _setting_name, variable_name, query_value in planned_changes:
+            try:
+                set_variable(self.cursor, variable_name, query_value, mode)
+            except Exception as exc:
+                self.module.fail_json(
+                    msg='Failed to set %s: %s' % (variable_name, to_native(exc)),
+                    changed=False,
+                )
+            queries.append(self.format_set_query(variable_name, query_value, mode))
+
+        return dict(changed=changed, queries=queries, settings=effective_settings)
+
+    def validate_supported_settings(self, desired_settings, mode):
+        if self.server_implementation == 'mariadb':
+            if mode == 'persist':
+                self.module.fail_json(msg='mode=persist is supported only on MySQL.', changed=False)
+
+            for option_name in MYSQL_ONLY_OPTIONS:
+                if desired_settings.get(option_name) is not None:
+                    self.module.fail_json(
+                        msg='Parameter "%s" is supported only on MySQL.' % option_name,
+                        changed=False,
+                    )
+
+    def read_setting(self, setting_name):
+        variable_name = SETTING_VARIABLES[self.server_implementation][setting_name]
+        value = get_variable(self.cursor, variable_name)
+        if value is not None:
+            return variable_name, value
+
+        self.module.fail_json(
+            msg='Password policy setting "%s" is not available on this server.' % setting_name,
+            changed=False,
+        )
+
+    def normalize_value(self, setting_name, value):
+        if setting_name == 'policy':
+            return normalize_policy_value(value)
+        if setting_name == 'check_user_name':
+            return normalize_bool_setting_value(value)
+        if setting_name in INTEGER_OPTIONS:
+            return normalize_int_value(value)
+        return value
+
+    def query_value(self, setting_name, normalized_value):
+        if setting_name == 'policy':
+            return str(normalized_value).upper()
+        if setting_name == 'check_user_name':
+            return normalize_bool_setting_value(normalized_value)
+        return normalized_value
+
+    @staticmethod
+    def format_set_query(variable_name, value, mode):
+        return "SET %s `%s` = %s" % (mode.upper(), variable_name, value)
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        policy=dict(type='str', choices=['low', 'medium', 'strong']),
+        length=dict(type='int'),
+        mixed_case_count=dict(type='int'),
+        number_count=dict(type='int'),
+        special_char_count=dict(type='int'),
+        check_user_name=dict(type='bool'),
+        password_lifetime=dict(type='int', no_log=False),
+        password_history=dict(type='int', no_log=False),
+        reuse_interval=dict(type='int', no_log=False),
+        mode=dict(type='str', choices=['global', 'persist'], default='global'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=[(
+            'policy',
+            'length',
+            'mixed_case_count',
+            'number_count',
+            'special_char_count',
+            'check_user_name',
+            'password_lifetime',
+            'password_history',
+            'reuse_interval',
+        )],
+        supports_check_mode=True,
+    )
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    try:
+        cursor, _db_conn = mysql_connect(
+            module,
+            module.params['login_user'],
+            module.params['login_password'],
+            module.params['config_file'],
+            module.params['client_cert'],
+            module.params['client_key'],
+            module.params['ca_cert'],
+            'mysql',
+            connect_timeout=module.params['connect_timeout'],
+            check_hostname=module.params['check_hostname'],
+        )
+    except Exception as exc:
+        module.fail_json(
+            msg="unable to connect to database, check login_user and "
+                "login_password are correct or %s has the credentials. "
+                "Exception message: %s" % (module.params['config_file'], to_native(exc))
+        )
+
+    server_implementation = get_server_implementation(cursor)
+    if server_implementation == 'mysql':
+        server_version = get_server_version(cursor).split('-', 1)[0]
+        if module.params['mode'] == 'persist' and LooseVersion(server_version) < LooseVersion('8.0'):
+            module.fail_json(msg='mode=persist requires MySQL 8.0 or later.', changed=False)
+
+    desired_settings = {
+        'policy': module.params['policy'],
+        'length': module.params['length'],
+        'mixed_case_count': module.params['mixed_case_count'],
+        'number_count': module.params['number_count'],
+        'special_char_count': module.params['special_char_count'],
+        'check_user_name': module.params['check_user_name'],
+        'password_lifetime': module.params['password_lifetime'],
+        'password_history': module.params['password_history'],
+        'reuse_interval': module.params['reuse_interval'],
+    }
+
+    password_policy = MySQLPasswordPolicy(module, cursor, server_implementation)
+    module.exit_json(
+        **password_policy.configure(
+            desired_settings,
+            mode=module.params['mode'],
+            check_mode=module.check_mode,
+        )
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_password_policy.py
+++ b/plugins/modules/mysql_password_policy.py
@@ -75,8 +75,8 @@ options:
   mode:
     description:
       - How supported MySQL variables are set.
-      - C(global) uses C(SET GLOBAL) and does not survive restarts by itself.
-      - C(persist) uses C(SET PERSIST) on MySQL.
+      - V(global) uses C(SET GLOBAL) and does not survive restarts by itself.
+      - V(persist) uses C(SET PERSIST) on MySQL.
       - Supported only on MySQL.
     type: str
     choices: [global, persist]

--- a/plugins/modules/mysql_password_policy.py
+++ b/plugins/modules/mysql_password_policy.py
@@ -144,7 +144,7 @@ queries:
   sample:
     - SET GLOBAL `validate_password`.`length` = 12
 settings:
-  description: Normalized requested settings after execution or prediction.
+  description: Normalized requested settings after execution or prediction (in check mode).
   returned: always
   type: dict
   sample:

--- a/plugins/modules/mysql_password_policy.py
+++ b/plugins/modules/mysql_password_policy.py
@@ -39,7 +39,7 @@ options:
     type: int
   mixed_case_count:
     description:
-      - Minimum number of same-case letters required by the active password validation facility.
+      - Minimum number of lowercase and uppercase letters required each by the active password validation facility.
       - Supported on MySQL and on MariaDB C(simple_password_check).
     type: int
   number_count:
@@ -140,8 +140,9 @@ queries:
   description: List of executed or predicted SQL statements.
   returned: always
   type: list
+  elements: str
   sample:
-    - SET GLOBAL `validate_password.length` = 12
+    - SET GLOBAL `validate_password`.`length` = 12
 settings:
   description: Normalized requested settings after execution or prediction.
   returned: always
@@ -332,7 +333,7 @@ class MySQLPasswordPolicy(object):
 
     @staticmethod
     def format_set_query(variable_name, value, mode):
-        return "SET %s `%s` = %s" % (mode.upper(), variable_name, value)
+        return "SET %s %s = %s" % (mode.upper(), mysql_quote_identifier(variable_name, 'vars'), value)
 
 
 def main():

--- a/plugins/modules/mysql_password_policy.py
+++ b/plugins/modules/mysql_password_policy.py
@@ -137,7 +137,7 @@ EXAMPLES = r'''
 
 RETURN = r'''
 queries:
-  description: List of executed or predicted SQL statements.
+  description: List of executed or predicted (in check mode) SQL statements.
   returned: always
   type: list
   elements: str

--- a/tests/integration/targets/test_mysql_password_policy/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_password_policy/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_password_policy/meta/main.yml
+++ b/tests/integration/targets/test_mysql_password_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_password_policy/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_password_policy/tasks/main.yml
@@ -1,0 +1,7 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: MySQL password policy | Run integration checks
+  ansible.builtin.import_tasks: mysql_password_policy.yml

--- a/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
+++ b/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
@@ -1,0 +1,438 @@
+# test code for the mysql_password_policy module
+#
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: MySQL password policy | Run engine-specific checks
+  vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+    - name: MySQL password policy | Ensure MySQL validate_password component is available
+      when: db_engine == 'mysql'
+      block:
+        - name: MySQL password policy | Check validate_password component state
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query: "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
+          register: mysql_validate_password_state
+
+        - name: MySQL password policy | Install validate_password component for test setup
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query: "INSTALL COMPONENT 'file://component_validate_password'"
+          when: mysql_validate_password_state.query_result[0] | length == 0
+
+        - name: MySQL password policy | Re-check validate_password component state
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query: "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
+          register: mysql_validate_password_ready
+
+        - name: MySQL password policy | Assert validate_password component is available
+          ansible.builtin.assert:
+            that:
+              - mysql_validate_password_ready.query_result[0] | length == 1
+
+        - name: MySQL password policy | Remove validate_password component outside module
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query: "UNINSTALL COMPONENT 'file://component_validate_password'"
+
+        - name: MySQL password policy | Fail clearly when validation component is missing
+          ansible.mysql.mysql_password_policy:
+            <<: *mysql_params
+            length: 12
+          register: mysql_missing_facility
+          ignore_errors: true
+
+        - name: MySQL password policy | Assert missing-component failure
+          ansible.builtin.assert:
+            that:
+              - mysql_missing_facility is failed
+              - "'Password policy setting \"length\" is not available on this server.' in mysql_missing_facility.msg"
+
+        - name: MySQL password policy | Reinstall validate_password component for module tests
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query: "INSTALL COMPONENT 'file://component_validate_password'"
+
+        - name: MySQL password policy | Set MySQL baseline values
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query:
+              - "SET GLOBAL `validate_password.policy` = LOW"
+              - "SET GLOBAL `validate_password.length` = 8"
+              - "SET GLOBAL `validate_password.mixed_case_count` = 1"
+              - "SET GLOBAL `validate_password.number_count` = 1"
+              - "SET GLOBAL `validate_password.special_char_count` = 0"
+              - "SET GLOBAL `validate_password.check_user_name` = OFF"
+              - "SET GLOBAL `default_password_lifetime` = 0"
+              - "SET GLOBAL `password_history` = 0"
+              - "SET GLOBAL `password_reuse_interval` = 0"
+
+        - name: MySQL password policy | Configure settings in check mode
+          check_mode: true
+          ansible.mysql.mysql_password_policy:
+            <<: *mysql_params
+            policy: medium
+            length: 12
+            mixed_case_count: 2
+            number_count: 2
+            special_char_count: 1
+            check_user_name: true
+            password_lifetime: 90
+            password_history: 5
+            reuse_interval: 365
+          register: mysql_check_mode_result
+
+        - name: MySQL password policy | Assert MySQL check mode result
+          ansible.builtin.assert:
+            that:
+              - mysql_check_mode_result is changed
+              - mysql_check_mode_result.queries == expected_queries
+          vars:
+            expected_queries:
+              - "SET GLOBAL `validate_password.policy` = MEDIUM"
+              - "SET GLOBAL `validate_password.length` = 12"
+              - "SET GLOBAL `validate_password.mixed_case_count` = 2"
+              - "SET GLOBAL `validate_password.number_count` = 2"
+              - "SET GLOBAL `validate_password.special_char_count` = 1"
+              - "SET GLOBAL `validate_password.check_user_name` = ON"
+              - "SET GLOBAL `default_password_lifetime` = 90"
+              - "SET GLOBAL `password_history` = 5"
+              - "SET GLOBAL `password_reuse_interval` = 365"
+
+        - name: MySQL password policy | Verify check mode left baseline unchanged
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query:
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.policy'"
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.mixed_case_count'"
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.number_count'"
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.special_char_count'"
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.check_user_name'"
+              - "SHOW GLOBAL VARIABLES LIKE 'default_password_lifetime'"
+              - "SHOW GLOBAL VARIABLES LIKE 'password_history'"
+              - "SHOW GLOBAL VARIABLES LIKE 'password_reuse_interval'"
+          register: mysql_check_mode_state
+
+        - name: MySQL password policy | Assert MySQL baseline remained unchanged
+          ansible.builtin.assert:
+            that:
+              - mysql_check_mode_state.query_result[0][0].Value in ['LOW', '0']
+              - mysql_check_mode_state.query_result[1][0].Value | int == 8
+              - mysql_check_mode_state.query_result[2][0].Value | int == 1
+              - mysql_check_mode_state.query_result[3][0].Value | int == 1
+              - mysql_check_mode_state.query_result[4][0].Value | int == 0
+              - mysql_check_mode_state.query_result[5][0].Value in ['OFF', '0']
+              - mysql_check_mode_state.query_result[6][0].Value | int == 0
+              - mysql_check_mode_state.query_result[7][0].Value | int == 0
+              - mysql_check_mode_state.query_result[8][0].Value | int == 0
+
+        - name: MySQL password policy | Apply MySQL settings
+          ansible.mysql.mysql_password_policy:
+            <<: *mysql_params
+            policy: medium
+            length: 12
+            mixed_case_count: 2
+            number_count: 2
+            special_char_count: 1
+            check_user_name: true
+            password_lifetime: 90
+            password_history: 5
+            reuse_interval: 365
+          register: mysql_apply_result
+
+        - name: MySQL password policy | Assert MySQL apply result
+          ansible.builtin.assert:
+            that:
+              - mysql_apply_result is changed
+              - mysql_apply_result.queries == expected_queries
+          vars:
+            expected_queries:
+              - "SET GLOBAL `validate_password.policy` = MEDIUM"
+              - "SET GLOBAL `validate_password.length` = 12"
+              - "SET GLOBAL `validate_password.mixed_case_count` = 2"
+              - "SET GLOBAL `validate_password.number_count` = 2"
+              - "SET GLOBAL `validate_password.special_char_count` = 1"
+              - "SET GLOBAL `validate_password.check_user_name` = ON"
+              - "SET GLOBAL `default_password_lifetime` = 90"
+              - "SET GLOBAL `password_history` = 5"
+              - "SET GLOBAL `password_reuse_interval` = 365"
+
+        - name: MySQL password policy | Verify applied MySQL settings
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query:
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.policy'"
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.mixed_case_count'"
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.number_count'"
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.special_char_count'"
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.check_user_name'"
+              - "SHOW GLOBAL VARIABLES LIKE 'default_password_lifetime'"
+              - "SHOW GLOBAL VARIABLES LIKE 'password_history'"
+              - "SHOW GLOBAL VARIABLES LIKE 'password_reuse_interval'"
+          register: mysql_apply_state
+
+        - name: MySQL password policy | Assert MySQL applied settings
+          ansible.builtin.assert:
+            that:
+              - mysql_apply_state.query_result[0][0].Value in ['MEDIUM', '1']
+              - mysql_apply_state.query_result[1][0].Value | int == 12
+              - mysql_apply_state.query_result[2][0].Value | int == 2
+              - mysql_apply_state.query_result[3][0].Value | int == 2
+              - mysql_apply_state.query_result[4][0].Value | int == 1
+              - mysql_apply_state.query_result[5][0].Value in ['ON', '1']
+              - mysql_apply_state.query_result[6][0].Value | int == 90
+              - mysql_apply_state.query_result[7][0].Value | int == 5
+              - mysql_apply_state.query_result[8][0].Value | int == 365
+
+        - name: MySQL password policy | Re-run MySQL settings for idempotency
+          ansible.mysql.mysql_password_policy:
+            <<: *mysql_params
+            policy: medium
+            length: 12
+            mixed_case_count: 2
+            number_count: 2
+            special_char_count: 1
+            check_user_name: true
+            password_lifetime: 90
+            password_history: 5
+            reuse_interval: 365
+          register: mysql_idempotency_result
+
+        - name: MySQL password policy | Assert MySQL idempotency
+          ansible.builtin.assert:
+            that:
+              - mysql_idempotency_result is not changed
+              - mysql_idempotency_result.queries == []
+
+        - name: MySQL password policy | Switch to strong policy and disable username check
+          ansible.mysql.mysql_password_policy:
+            <<: *mysql_params
+            policy: strong
+            check_user_name: false
+          register: mysql_toggle_result
+
+        - name: MySQL password policy | Assert strong-policy toggle result
+          ansible.builtin.assert:
+            that:
+              - mysql_toggle_result is changed
+              - mysql_toggle_result.queries == expected_queries
+          vars:
+            expected_queries:
+              - "SET GLOBAL `validate_password.policy` = STRONG"
+              - "SET GLOBAL `validate_password.check_user_name` = OFF"
+
+        - name: MySQL password policy | Verify strong policy and disabled username check
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query:
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.policy'"
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.check_user_name'"
+          register: mysql_toggle_state
+
+        - name: MySQL password policy | Assert strong policy and disabled username check
+          ansible.builtin.assert:
+            that:
+              - mysql_toggle_state.query_result[0][0].Value in ['STRONG', '2']
+              - mysql_toggle_state.query_result[1][0].Value in ['OFF', '0']
+
+        - name: MySQL password policy | Persist selected MySQL settings
+          ansible.mysql.mysql_password_policy:
+            <<: *mysql_params
+            length: 14
+            password_history: 7
+            mode: persist
+          register: mysql_persist_result
+
+        - name: MySQL password policy | Assert persist-mode result
+          ansible.builtin.assert:
+            that:
+              - mysql_persist_result is changed
+              - mysql_persist_result.queries == expected_queries
+          vars:
+            expected_queries:
+              - "SET PERSIST `validate_password.length` = 14"
+              - "SET PERSIST `password_history` = 7"
+
+        - name: MySQL password policy | Verify persisted MySQL settings
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query:
+              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
+              - "SHOW GLOBAL VARIABLES LIKE 'password_history'"
+              - "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'validate_password.length'"
+              - "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'password_history'"
+          register: mysql_persist_state
+
+        - name: MySQL password policy | Assert persisted MySQL settings
+          ansible.builtin.assert:
+            that:
+              - mysql_persist_state.query_result[0][0].Value | int == 14
+              - mysql_persist_state.query_result[1][0].Value | int == 7
+              - mysql_persist_state.query_result[2][0].persisted_value | int == 14
+              - mysql_persist_state.query_result[3][0].persisted_value | int == 7
+
+    - name: MySQL password policy | Ensure MariaDB simple_password_check plugin is available
+      when: db_engine == 'mariadb'
+      block:
+        - name: MySQL password policy | Check simple_password_check plugin state
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query: "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_minimal_length'"
+          register: mariadb_simple_password_check_state
+
+        - name: MySQL password policy | Install simple_password_check plugin for test setup
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query: "INSTALL SONAME 'simple_password_check'"
+          when: mariadb_simple_password_check_state.query_result[0] | length == 0
+
+        - name: MySQL password policy | Re-check simple_password_check plugin state
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query: "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_minimal_length'"
+          register: mariadb_simple_password_check_ready
+
+        - name: MySQL password policy | Assert simple_password_check plugin is available
+          ansible.builtin.assert:
+            that:
+              - mariadb_simple_password_check_ready.query_result[0] | length == 1
+
+        - name: MySQL password policy | Set MariaDB baseline values
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query:
+              - "SET GLOBAL `simple_password_check_minimal_length` = 8"
+              - "SET GLOBAL `simple_password_check_letters_same_case` = 1"
+              - "SET GLOBAL `simple_password_check_digits` = 1"
+              - "SET GLOBAL `simple_password_check_other_characters` = 0"
+
+        - name: MySQL password policy | Configure MariaDB settings in check mode
+          check_mode: true
+          ansible.mysql.mysql_password_policy:
+            <<: *mysql_params
+            length: 12
+            mixed_case_count: 2
+            number_count: 2
+            special_char_count: 1
+          register: mariadb_check_mode_result
+
+        - name: MySQL password policy | Assert MariaDB check mode result
+          ansible.builtin.assert:
+            that:
+              - mariadb_check_mode_result is changed
+              - mariadb_check_mode_result.queries == expected_queries
+          vars:
+            expected_queries:
+              - "SET GLOBAL `simple_password_check_minimal_length` = 12"
+              - "SET GLOBAL `simple_password_check_letters_same_case` = 2"
+              - "SET GLOBAL `simple_password_check_digits` = 2"
+              - "SET GLOBAL `simple_password_check_other_characters` = 1"
+
+        - name: MySQL password policy | Verify MariaDB check mode left baseline unchanged
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query:
+              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_minimal_length'"
+              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_letters_same_case'"
+              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_digits'"
+              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_other_characters'"
+          register: mariadb_check_mode_state
+
+        - name: MySQL password policy | Assert MariaDB baseline remained unchanged
+          ansible.builtin.assert:
+            that:
+              - mariadb_check_mode_state.query_result[0][0].Value | int == 8
+              - mariadb_check_mode_state.query_result[1][0].Value | int == 1
+              - mariadb_check_mode_state.query_result[2][0].Value | int == 1
+              - mariadb_check_mode_state.query_result[3][0].Value | int == 0
+
+        - name: MySQL password policy | Apply MariaDB shared settings
+          ansible.mysql.mysql_password_policy:
+            <<: *mysql_params
+            length: 12
+            mixed_case_count: 2
+            number_count: 2
+            special_char_count: 1
+          register: mariadb_apply_result
+
+        - name: MySQL password policy | Assert MariaDB apply result
+          ansible.builtin.assert:
+            that:
+              - mariadb_apply_result is changed
+              - mariadb_apply_result.queries == expected_queries
+          vars:
+            expected_queries:
+              - "SET GLOBAL `simple_password_check_minimal_length` = 12"
+              - "SET GLOBAL `simple_password_check_letters_same_case` = 2"
+              - "SET GLOBAL `simple_password_check_digits` = 2"
+              - "SET GLOBAL `simple_password_check_other_characters` = 1"
+
+        - name: MySQL password policy | Verify applied MariaDB settings
+          ansible.mysql.mysql_query:
+            <<: *mysql_params
+            query:
+              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_minimal_length'"
+              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_letters_same_case'"
+              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_digits'"
+              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_other_characters'"
+          register: mariadb_apply_state
+
+        - name: MySQL password policy | Assert applied MariaDB settings
+          ansible.builtin.assert:
+            that:
+              - mariadb_apply_state.query_result[0][0].Value | int == 12
+              - mariadb_apply_state.query_result[1][0].Value | int == 2
+              - mariadb_apply_state.query_result[2][0].Value | int == 2
+              - mariadb_apply_state.query_result[3][0].Value | int == 1
+
+        - name: MySQL password policy | Re-run MariaDB shared settings for idempotency
+          ansible.mysql.mysql_password_policy:
+            <<: *mysql_params
+            length: 12
+            mixed_case_count: 2
+            number_count: 2
+            special_char_count: 1
+          register: mariadb_idempotency_result
+
+        - name: MySQL password policy | Assert MariaDB idempotency
+          ansible.builtin.assert:
+            that:
+              - mariadb_idempotency_result is not changed
+              - mariadb_idempotency_result.queries == []
+
+        - name: MySQL password policy | Reject MySQL-only parameters on MariaDB
+          ansible.mysql.mysql_password_policy:
+            <<: *mysql_params
+            policy: medium
+          register: mariadb_unsupported_result
+          ignore_errors: true
+
+        - name: MySQL password policy | Assert MariaDB unsupported-parameter failure
+          ansible.builtin.assert:
+            that:
+              - mariadb_unsupported_result is failed
+              - "'Parameter \"policy\" is supported only on MySQL.' in mariadb_unsupported_result.msg"
+
+        - name: MySQL password policy | Reject persist mode on MariaDB
+          ansible.mysql.mysql_password_policy:
+            <<: *mysql_params
+            length: 12
+            mode: persist
+          register: mariadb_persist_result
+          ignore_errors: true
+
+        - name: MySQL password policy | Assert MariaDB persist-mode failure
+          ansible.builtin.assert:
+            that:
+              - mariadb_persist_result is failed
+              - "'mode=persist is supported only on MySQL.' in mariadb_persist_result.msg"

--- a/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
+++ b/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
@@ -21,93 +21,27 @@
             query: "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
           register: mysql_validate_password_state
 
-        - name: MySQL password policy | Install validate_password component for test setup
-          ansible.mysql.mysql_query:
-            <<: *mysql_params
-            query: "INSTALL COMPONENT 'file://component_validate_password'"
-          when: mysql_validate_password_state.query_result[0] | length == 0
+        - name: MySQL password policy | Record initial MySQL component state
+          ansible.builtin.set_fact:
+            mysql_validate_password_initially_present: "{{ mysql_validate_password_state.query_result[0] | length == 1 }}"
 
-        - name: MySQL password policy | Re-check validate_password component state
-          ansible.mysql.mysql_query:
-            <<: *mysql_params
-            query: "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
-          register: mysql_validate_password_ready
-
-        - name: MySQL password policy | Assert validate_password component is available
-          ansible.builtin.assert:
-            that:
-              - mysql_validate_password_ready.query_result[0] | length == 1
-
-        - name: MySQL password policy | Remove validate_password component outside module
-          ansible.mysql.mysql_query:
-            <<: *mysql_params
-            query: "UNINSTALL COMPONENT 'file://component_validate_password'"
-
-        - name: MySQL password policy | Fail clearly when validation component is missing
-          ansible.mysql.mysql_password_policy:
-            <<: *mysql_params
-            length: 12
-          register: mysql_missing_facility
-          ignore_errors: true
-
-        - name: MySQL password policy | Assert missing-component failure
-          ansible.builtin.assert:
-            that:
-              - mysql_missing_facility is failed
-              - "'Password policy setting \"length\" is not available on this server.' in mysql_missing_facility.msg"
-
-        - name: MySQL password policy | Reinstall validate_password component for module tests
-          ansible.mysql.mysql_query:
-            <<: *mysql_params
-            query: "INSTALL COMPONENT 'file://component_validate_password'"
-
-        - name: MySQL password policy | Set MySQL baseline values
+        - name: MySQL password policy | Query initial MySQL global password settings
           ansible.mysql.mysql_query:
             <<: *mysql_params
             query:
-              - "SET GLOBAL `validate_password.policy` = LOW"
-              - "SET GLOBAL `validate_password.length` = 8"
-              - "SET GLOBAL `validate_password.mixed_case_count` = 1"
-              - "SET GLOBAL `validate_password.number_count` = 1"
-              - "SET GLOBAL `validate_password.special_char_count` = 0"
-              - "SET GLOBAL `validate_password.check_user_name` = OFF"
-              - "SET GLOBAL `default_password_lifetime` = 0"
-              - "SET GLOBAL `password_history` = 0"
-              - "SET GLOBAL `password_reuse_interval` = 0"
+              - "SHOW GLOBAL VARIABLES LIKE 'default_password_lifetime'"
+              - "SHOW GLOBAL VARIABLES LIKE 'password_history'"
+              - "SHOW GLOBAL VARIABLES LIKE 'password_reuse_interval'"
+          register: mysql_initial_global_state
 
-        - name: MySQL password policy | Configure settings in check mode
-          check_mode: true
-          ansible.mysql.mysql_password_policy:
-            <<: *mysql_params
-            policy: medium
-            length: 12
-            mixed_case_count: 2
-            number_count: 2
-            special_char_count: 1
-            check_user_name: true
-            password_lifetime: 90
-            password_history: 5
-            reuse_interval: 365
-          register: mysql_check_mode_result
+        - name: MySQL password policy | Record initial MySQL global password settings
+          ansible.builtin.set_fact:
+            mysql_initial_password_lifetime: "{{ mysql_initial_global_state.query_result[0][0].Value | int }}"
+            mysql_initial_password_history: "{{ mysql_initial_global_state.query_result[1][0].Value | int }}"
+            mysql_initial_reuse_interval: "{{ mysql_initial_global_state.query_result[2][0].Value | int }}"
 
-        - name: MySQL password policy | Assert MySQL check mode result
-          ansible.builtin.assert:
-            that:
-              - mysql_check_mode_result is changed
-              - mysql_check_mode_result.queries == expected_queries
-          vars:
-            expected_queries:
-              - "SET GLOBAL `validate_password.policy` = MEDIUM"
-              - "SET GLOBAL `validate_password.length` = 12"
-              - "SET GLOBAL `validate_password.mixed_case_count` = 2"
-              - "SET GLOBAL `validate_password.number_count` = 2"
-              - "SET GLOBAL `validate_password.special_char_count` = 1"
-              - "SET GLOBAL `validate_password.check_user_name` = ON"
-              - "SET GLOBAL `default_password_lifetime` = 90"
-              - "SET GLOBAL `password_history` = 5"
-              - "SET GLOBAL `password_reuse_interval` = 365"
-
-        - name: MySQL password policy | Verify check mode left baseline unchanged
+        - name: MySQL password policy | Query initial validate_password settings
+          when: mysql_validate_password_initially_present
           ansible.mysql.mysql_query:
             <<: *mysql_params
             query:
@@ -117,169 +51,313 @@
               - "SHOW GLOBAL VARIABLES LIKE 'validate_password.number_count'"
               - "SHOW GLOBAL VARIABLES LIKE 'validate_password.special_char_count'"
               - "SHOW GLOBAL VARIABLES LIKE 'validate_password.check_user_name'"
-              - "SHOW GLOBAL VARIABLES LIKE 'default_password_lifetime'"
-              - "SHOW GLOBAL VARIABLES LIKE 'password_history'"
-              - "SHOW GLOBAL VARIABLES LIKE 'password_reuse_interval'"
-          register: mysql_check_mode_state
+          register: mysql_initial_validate_password_state
 
-        - name: MySQL password policy | Assert MySQL baseline remained unchanged
-          ansible.builtin.assert:
-            that:
-              - mysql_check_mode_state.query_result[0][0].Value in ['LOW', '0']
-              - mysql_check_mode_state.query_result[1][0].Value | int == 8
-              - mysql_check_mode_state.query_result[2][0].Value | int == 1
-              - mysql_check_mode_state.query_result[3][0].Value | int == 1
-              - mysql_check_mode_state.query_result[4][0].Value | int == 0
-              - mysql_check_mode_state.query_result[5][0].Value in ['OFF', '0']
-              - mysql_check_mode_state.query_result[6][0].Value | int == 0
-              - mysql_check_mode_state.query_result[7][0].Value | int == 0
-              - mysql_check_mode_state.query_result[8][0].Value | int == 0
+        - name: MySQL password policy | Record initial validate_password settings
+          when: mysql_validate_password_initially_present
+          ansible.builtin.set_fact:
+            mysql_initial_validate_password_policy: "{{ mysql_initial_validate_password_state.query_result[0][0].Value }}"
+            mysql_initial_validate_password_length: "{{ mysql_initial_validate_password_state.query_result[1][0].Value | int }}"
+            mysql_initial_validate_password_mixed_case_count: "{{ mysql_initial_validate_password_state.query_result[2][0].Value | int }}"
+            mysql_initial_validate_password_number_count: "{{ mysql_initial_validate_password_state.query_result[3][0].Value | int }}"
+            mysql_initial_validate_password_special_char_count: "{{ mysql_initial_validate_password_state.query_result[4][0].Value | int }}"
+            mysql_initial_validate_password_check_user_name: "{{ mysql_initial_validate_password_state.query_result[5][0].Value }}"
 
-        - name: MySQL password policy | Apply MySQL settings
-          ansible.mysql.mysql_password_policy:
-            <<: *mysql_params
-            policy: medium
-            length: 12
-            mixed_case_count: 2
-            number_count: 2
-            special_char_count: 1
-            check_user_name: true
-            password_lifetime: 90
-            password_history: 5
-            reuse_interval: 365
-          register: mysql_apply_result
+        - name: MySQL password policy | Run MySQL module tests
+          block:
+            - name: MySQL password policy | Install validate_password component for test setup
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "INSTALL COMPONENT 'file://component_validate_password'"
+              when: mysql_validate_password_state.query_result[0] | length == 0
 
-        - name: MySQL password policy | Assert MySQL apply result
-          ansible.builtin.assert:
-            that:
-              - mysql_apply_result is changed
-              - mysql_apply_result.queries == expected_queries
-          vars:
-            expected_queries:
-              - "SET GLOBAL `validate_password.policy` = MEDIUM"
-              - "SET GLOBAL `validate_password.length` = 12"
-              - "SET GLOBAL `validate_password.mixed_case_count` = 2"
-              - "SET GLOBAL `validate_password.number_count` = 2"
-              - "SET GLOBAL `validate_password.special_char_count` = 1"
-              - "SET GLOBAL `validate_password.check_user_name` = ON"
-              - "SET GLOBAL `default_password_lifetime` = 90"
-              - "SET GLOBAL `password_history` = 5"
-              - "SET GLOBAL `password_reuse_interval` = 365"
+            - name: MySQL password policy | Re-check validate_password component state
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
+              register: mysql_validate_password_ready
 
-        - name: MySQL password policy | Verify applied MySQL settings
-          ansible.mysql.mysql_query:
-            <<: *mysql_params
-            query:
-              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.policy'"
-              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
-              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.mixed_case_count'"
-              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.number_count'"
-              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.special_char_count'"
-              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.check_user_name'"
-              - "SHOW GLOBAL VARIABLES LIKE 'default_password_lifetime'"
-              - "SHOW GLOBAL VARIABLES LIKE 'password_history'"
-              - "SHOW GLOBAL VARIABLES LIKE 'password_reuse_interval'"
-          register: mysql_apply_state
+            - name: MySQL password policy | Assert validate_password component is available
+              ansible.builtin.assert:
+                that:
+                  - mysql_validate_password_ready.query_result[0] | length == 1
 
-        - name: MySQL password policy | Assert MySQL applied settings
-          ansible.builtin.assert:
-            that:
-              - mysql_apply_state.query_result[0][0].Value in ['MEDIUM', '1']
-              - mysql_apply_state.query_result[1][0].Value | int == 12
-              - mysql_apply_state.query_result[2][0].Value | int == 2
-              - mysql_apply_state.query_result[3][0].Value | int == 2
-              - mysql_apply_state.query_result[4][0].Value | int == 1
-              - mysql_apply_state.query_result[5][0].Value in ['ON', '1']
-              - mysql_apply_state.query_result[6][0].Value | int == 90
-              - mysql_apply_state.query_result[7][0].Value | int == 5
-              - mysql_apply_state.query_result[8][0].Value | int == 365
+            - name: MySQL password policy | Remove validate_password component outside module
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "UNINSTALL COMPONENT 'file://component_validate_password'"
 
-        - name: MySQL password policy | Re-run MySQL settings for idempotency
-          ansible.mysql.mysql_password_policy:
-            <<: *mysql_params
-            policy: medium
-            length: 12
-            mixed_case_count: 2
-            number_count: 2
-            special_char_count: 1
-            check_user_name: true
-            password_lifetime: 90
-            password_history: 5
-            reuse_interval: 365
-          register: mysql_idempotency_result
+            - name: MySQL password policy | Fail clearly when validation component is missing
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                length: 12
+              register: mysql_missing_facility
+              ignore_errors: true
 
-        - name: MySQL password policy | Assert MySQL idempotency
-          ansible.builtin.assert:
-            that:
-              - mysql_idempotency_result is not changed
-              - mysql_idempotency_result.queries == []
+            - name: MySQL password policy | Assert missing-component failure
+              ansible.builtin.assert:
+                that:
+                  - mysql_missing_facility is failed
+                  - "'Password policy setting \"length\" is not available on this server.' in mysql_missing_facility.msg"
 
-        - name: MySQL password policy | Switch to strong policy and disable username check
-          ansible.mysql.mysql_password_policy:
-            <<: *mysql_params
-            policy: strong
-            check_user_name: false
-          register: mysql_toggle_result
+            - name: MySQL password policy | Reinstall validate_password component for module tests
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "INSTALL COMPONENT 'file://component_validate_password'"
 
-        - name: MySQL password policy | Assert strong-policy toggle result
-          ansible.builtin.assert:
-            that:
-              - mysql_toggle_result is changed
-              - mysql_toggle_result.queries == expected_queries
-          vars:
-            expected_queries:
-              - "SET GLOBAL `validate_password.policy` = STRONG"
-              - "SET GLOBAL `validate_password.check_user_name` = OFF"
+            - name: MySQL password policy | Set MySQL baseline values
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query:
+                  - "SET GLOBAL `validate_password.policy` = LOW"
+                  - "SET GLOBAL `validate_password.length` = 8"
+                  - "SET GLOBAL `validate_password.mixed_case_count` = 1"
+                  - "SET GLOBAL `validate_password.number_count` = 1"
+                  - "SET GLOBAL `validate_password.special_char_count` = 0"
+                  - "SET GLOBAL `validate_password.check_user_name` = OFF"
+                  - "SET GLOBAL `default_password_lifetime` = 0"
+                  - "SET GLOBAL `password_history` = 0"
+                  - "SET GLOBAL `password_reuse_interval` = 0"
 
-        - name: MySQL password policy | Verify strong policy and disabled username check
-          ansible.mysql.mysql_query:
-            <<: *mysql_params
-            query:
-              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.policy'"
-              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.check_user_name'"
-          register: mysql_toggle_state
+            - name: MySQL password policy | Configure settings in check mode
+              check_mode: true
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                policy: medium
+                length: 12
+                mixed_case_count: 2
+                number_count: 2
+                special_char_count: 1
+                check_user_name: true
+                password_lifetime: 90
+                password_history: 5
+                reuse_interval: 365
+              register: mysql_check_mode_result
 
-        - name: MySQL password policy | Assert strong policy and disabled username check
-          ansible.builtin.assert:
-            that:
-              - mysql_toggle_state.query_result[0][0].Value in ['STRONG', '2']
-              - mysql_toggle_state.query_result[1][0].Value in ['OFF', '0']
+            - name: MySQL password policy | Assert MySQL check mode result
+              ansible.builtin.assert:
+                that:
+                  - mysql_check_mode_result is changed
+                  - mysql_check_mode_result.queries == expected_queries
+              vars:
+                expected_queries:
+                  - "SET GLOBAL `validate_password.policy` = MEDIUM"
+                  - "SET GLOBAL `validate_password.length` = 12"
+                  - "SET GLOBAL `validate_password.mixed_case_count` = 2"
+                  - "SET GLOBAL `validate_password.number_count` = 2"
+                  - "SET GLOBAL `validate_password.special_char_count` = 1"
+                  - "SET GLOBAL `validate_password.check_user_name` = ON"
+                  - "SET GLOBAL `default_password_lifetime` = 90"
+                  - "SET GLOBAL `password_history` = 5"
+                  - "SET GLOBAL `password_reuse_interval` = 365"
 
-        - name: MySQL password policy | Persist selected MySQL settings
-          ansible.mysql.mysql_password_policy:
-            <<: *mysql_params
-            length: 14
-            password_history: 7
-            mode: persist
-          register: mysql_persist_result
+            - name: MySQL password policy | Verify check mode left baseline unchanged
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query:
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.policy'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.mixed_case_count'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.number_count'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.special_char_count'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.check_user_name'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'default_password_lifetime'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'password_history'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'password_reuse_interval'"
+              register: mysql_check_mode_state
 
-        - name: MySQL password policy | Assert persist-mode result
-          ansible.builtin.assert:
-            that:
-              - mysql_persist_result is changed
-              - mysql_persist_result.queries == expected_queries
-          vars:
-            expected_queries:
-              - "SET PERSIST `validate_password.length` = 14"
-              - "SET PERSIST `password_history` = 7"
+            - name: MySQL password policy | Assert MySQL baseline remained unchanged
+              ansible.builtin.assert:
+                that:
+                  - mysql_check_mode_state.query_result[0][0].Value in ['LOW', '0']
+                  - mysql_check_mode_state.query_result[1][0].Value | int == 8
+                  - mysql_check_mode_state.query_result[2][0].Value | int == 1
+                  - mysql_check_mode_state.query_result[3][0].Value | int == 1
+                  - mysql_check_mode_state.query_result[4][0].Value | int == 0
+                  - mysql_check_mode_state.query_result[5][0].Value in ['OFF', '0']
+                  - mysql_check_mode_state.query_result[6][0].Value | int == 0
+                  - mysql_check_mode_state.query_result[7][0].Value | int == 0
+                  - mysql_check_mode_state.query_result[8][0].Value | int == 0
 
-        - name: MySQL password policy | Verify persisted MySQL settings
-          ansible.mysql.mysql_query:
-            <<: *mysql_params
-            query:
-              - "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
-              - "SHOW GLOBAL VARIABLES LIKE 'password_history'"
-              - "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'validate_password.length'"
-              - "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'password_history'"
-          register: mysql_persist_state
+            - name: MySQL password policy | Apply MySQL settings
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                policy: medium
+                length: 12
+                mixed_case_count: 2
+                number_count: 2
+                special_char_count: 1
+                check_user_name: true
+                password_lifetime: 90
+                password_history: 5
+                reuse_interval: 365
+              register: mysql_apply_result
 
-        - name: MySQL password policy | Assert persisted MySQL settings
-          ansible.builtin.assert:
-            that:
-              - mysql_persist_state.query_result[0][0].Value | int == 14
-              - mysql_persist_state.query_result[1][0].Value | int == 7
-              - mysql_persist_state.query_result[2][0].persisted_value | int == 14
-              - mysql_persist_state.query_result[3][0].persisted_value | int == 7
+            - name: MySQL password policy | Assert MySQL apply result
+              ansible.builtin.assert:
+                that:
+                  - mysql_apply_result is changed
+                  - mysql_apply_result.queries == expected_queries
+              vars:
+                expected_queries:
+                  - "SET GLOBAL `validate_password.policy` = MEDIUM"
+                  - "SET GLOBAL `validate_password.length` = 12"
+                  - "SET GLOBAL `validate_password.mixed_case_count` = 2"
+                  - "SET GLOBAL `validate_password.number_count` = 2"
+                  - "SET GLOBAL `validate_password.special_char_count` = 1"
+                  - "SET GLOBAL `validate_password.check_user_name` = ON"
+                  - "SET GLOBAL `default_password_lifetime` = 90"
+                  - "SET GLOBAL `password_history` = 5"
+                  - "SET GLOBAL `password_reuse_interval` = 365"
+
+            - name: MySQL password policy | Verify applied MySQL settings
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query:
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.policy'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.mixed_case_count'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.number_count'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.special_char_count'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.check_user_name'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'default_password_lifetime'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'password_history'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'password_reuse_interval'"
+              register: mysql_apply_state
+
+            - name: MySQL password policy | Assert MySQL applied settings
+              ansible.builtin.assert:
+                that:
+                  - mysql_apply_state.query_result[0][0].Value in ['MEDIUM', '1']
+                  - mysql_apply_state.query_result[1][0].Value | int == 12
+                  - mysql_apply_state.query_result[2][0].Value | int == 2
+                  - mysql_apply_state.query_result[3][0].Value | int == 2
+                  - mysql_apply_state.query_result[4][0].Value | int == 1
+                  - mysql_apply_state.query_result[5][0].Value in ['ON', '1']
+                  - mysql_apply_state.query_result[6][0].Value | int == 90
+                  - mysql_apply_state.query_result[7][0].Value | int == 5
+                  - mysql_apply_state.query_result[8][0].Value | int == 365
+
+            - name: MySQL password policy | Re-run MySQL settings for idempotency
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                policy: medium
+                length: 12
+                mixed_case_count: 2
+                number_count: 2
+                special_char_count: 1
+                check_user_name: true
+                password_lifetime: 90
+                password_history: 5
+                reuse_interval: 365
+              register: mysql_idempotency_result
+
+            - name: MySQL password policy | Assert MySQL idempotency
+              ansible.builtin.assert:
+                that:
+                  - mysql_idempotency_result is not changed
+                  - mysql_idempotency_result.queries == []
+
+            - name: MySQL password policy | Switch to strong policy and disable username check
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                policy: strong
+                check_user_name: false
+              register: mysql_toggle_result
+
+            - name: MySQL password policy | Assert strong-policy toggle result
+              ansible.builtin.assert:
+                that:
+                  - mysql_toggle_result is changed
+                  - mysql_toggle_result.queries == expected_queries
+              vars:
+                expected_queries:
+                  - "SET GLOBAL `validate_password.policy` = STRONG"
+                  - "SET GLOBAL `validate_password.check_user_name` = OFF"
+
+            - name: MySQL password policy | Verify strong policy and disabled username check
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query:
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.policy'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.check_user_name'"
+              register: mysql_toggle_state
+
+            - name: MySQL password policy | Assert strong policy and disabled username check
+              ansible.builtin.assert:
+                that:
+                  - mysql_toggle_state.query_result[0][0].Value in ['STRONG', '2']
+                  - mysql_toggle_state.query_result[1][0].Value in ['OFF', '0']
+
+            - name: MySQL password policy | Persist selected MySQL settings
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                length: 14
+                password_history: 7
+                mode: persist
+              register: mysql_persist_result
+
+            - name: MySQL password policy | Assert persist-mode result
+              ansible.builtin.assert:
+                that:
+                  - mysql_persist_result is changed
+                  - mysql_persist_result.queries == expected_queries
+              vars:
+                expected_queries:
+                  - "SET PERSIST `validate_password.length` = 14"
+                  - "SET PERSIST `password_history` = 7"
+
+            - name: MySQL password policy | Verify persisted MySQL settings
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query:
+                  - "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'password_history'"
+                  - "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'validate_password.length'"
+                  - "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'password_history'"
+              register: mysql_persist_state
+
+            - name: MySQL password policy | Assert persisted MySQL settings
+              ansible.builtin.assert:
+                that:
+                  - mysql_persist_state.query_result[0][0].Value | int == 14
+                  - mysql_persist_state.query_result[1][0].Value | int == 7
+                  - mysql_persist_state.query_result[2][0].persisted_value | int == 14
+                  - mysql_persist_state.query_result[3][0].persisted_value | int == 7
+          always:
+            - name: MySQL password policy | Restore initial MySQL global password settings
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query:
+                  - "SET GLOBAL `default_password_lifetime` = {{ mysql_initial_password_lifetime }}"
+                  - "SET GLOBAL `password_history` = {{ mysql_initial_password_history }}"
+                  - "SET GLOBAL `password_reuse_interval` = {{ mysql_initial_reuse_interval }}"
+
+            - name: MySQL password policy | Restore initial validate_password settings
+              when: mysql_validate_password_initially_present
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query:
+                  - "SET GLOBAL `validate_password.policy` = {{ mysql_initial_validate_password_policy }}"
+                  - "SET GLOBAL `validate_password.length` = {{ mysql_initial_validate_password_length }}"
+                  - "SET GLOBAL `validate_password.mixed_case_count` = {{ mysql_initial_validate_password_mixed_case_count }}"
+                  - "SET GLOBAL `validate_password.number_count` = {{ mysql_initial_validate_password_number_count }}"
+                  - "SET GLOBAL `validate_password.special_char_count` = {{ mysql_initial_validate_password_special_char_count }}"
+                  - "SET GLOBAL `validate_password.check_user_name` = {{ mysql_initial_validate_password_check_user_name }}"
+
+            - name: MySQL password policy | Check current validate_password component state for cleanup
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "SHOW GLOBAL VARIABLES LIKE 'validate_password.length'"
+              register: mysql_validate_password_cleanup_state
+
+            - name: MySQL password policy | Remove validate_password component if test enabled it
+              when:
+                - not mysql_validate_password_initially_present
+                - mysql_validate_password_cleanup_state.query_result[0] | length == 1
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "UNINSTALL COMPONENT 'file://component_validate_password'"
 
     - name: MySQL password policy | Ensure MariaDB simple_password_check plugin is available
       when: db_engine == 'mariadb'
@@ -290,55 +368,12 @@
             query: "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_minimal_length'"
           register: mariadb_simple_password_check_state
 
-        - name: MySQL password policy | Install simple_password_check plugin for test setup
-          ansible.mysql.mysql_query:
-            <<: *mysql_params
-            query: "INSTALL SONAME 'simple_password_check'"
-          when: mariadb_simple_password_check_state.query_result[0] | length == 0
+        - name: MySQL password policy | Record initial MariaDB plugin state
+          ansible.builtin.set_fact:
+            mariadb_simple_password_check_initially_present: "{{ mariadb_simple_password_check_state.query_result[0] | length == 1 }}"
 
-        - name: MySQL password policy | Re-check simple_password_check plugin state
-          ansible.mysql.mysql_query:
-            <<: *mysql_params
-            query: "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_minimal_length'"
-          register: mariadb_simple_password_check_ready
-
-        - name: MySQL password policy | Assert simple_password_check plugin is available
-          ansible.builtin.assert:
-            that:
-              - mariadb_simple_password_check_ready.query_result[0] | length == 1
-
-        - name: MySQL password policy | Set MariaDB baseline values
-          ansible.mysql.mysql_query:
-            <<: *mysql_params
-            query:
-              - "SET GLOBAL `simple_password_check_minimal_length` = 8"
-              - "SET GLOBAL `simple_password_check_letters_same_case` = 1"
-              - "SET GLOBAL `simple_password_check_digits` = 1"
-              - "SET GLOBAL `simple_password_check_other_characters` = 0"
-
-        - name: MySQL password policy | Configure MariaDB settings in check mode
-          check_mode: true
-          ansible.mysql.mysql_password_policy:
-            <<: *mysql_params
-            length: 12
-            mixed_case_count: 2
-            number_count: 2
-            special_char_count: 1
-          register: mariadb_check_mode_result
-
-        - name: MySQL password policy | Assert MariaDB check mode result
-          ansible.builtin.assert:
-            that:
-              - mariadb_check_mode_result is changed
-              - mariadb_check_mode_result.queries == expected_queries
-          vars:
-            expected_queries:
-              - "SET GLOBAL `simple_password_check_minimal_length` = 12"
-              - "SET GLOBAL `simple_password_check_letters_same_case` = 2"
-              - "SET GLOBAL `simple_password_check_digits` = 2"
-              - "SET GLOBAL `simple_password_check_other_characters` = 1"
-
-        - name: MySQL password policy | Verify MariaDB check mode left baseline unchanged
+        - name: MySQL password policy | Query initial MariaDB simple_password_check settings
+          when: mariadb_simple_password_check_initially_present
           ansible.mysql.mysql_query:
             <<: *mysql_params
             query:
@@ -346,93 +381,185 @@
               - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_letters_same_case'"
               - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_digits'"
               - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_other_characters'"
-          register: mariadb_check_mode_state
+          register: mariadb_initial_simple_password_check_state
 
-        - name: MySQL password policy | Assert MariaDB baseline remained unchanged
-          ansible.builtin.assert:
-            that:
-              - mariadb_check_mode_state.query_result[0][0].Value | int == 8
-              - mariadb_check_mode_state.query_result[1][0].Value | int == 1
-              - mariadb_check_mode_state.query_result[2][0].Value | int == 1
-              - mariadb_check_mode_state.query_result[3][0].Value | int == 0
+        - name: MySQL password policy | Record initial MariaDB simple_password_check settings
+          when: mariadb_simple_password_check_initially_present
+          ansible.builtin.set_fact:
+            mariadb_initial_minimal_length: "{{ mariadb_initial_simple_password_check_state.query_result[0][0].Value | int }}"
+            mariadb_initial_letters_same_case: "{{ mariadb_initial_simple_password_check_state.query_result[1][0].Value | int }}"
+            mariadb_initial_digits: "{{ mariadb_initial_simple_password_check_state.query_result[2][0].Value | int }}"
+            mariadb_initial_other_characters: "{{ mariadb_initial_simple_password_check_state.query_result[3][0].Value | int }}"
 
-        - name: MySQL password policy | Apply MariaDB shared settings
-          ansible.mysql.mysql_password_policy:
-            <<: *mysql_params
-            length: 12
-            mixed_case_count: 2
-            number_count: 2
-            special_char_count: 1
-          register: mariadb_apply_result
+        - name: MySQL password policy | Run MariaDB module tests
+          block:
+            - name: MySQL password policy | Install simple_password_check plugin for test setup
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "INSTALL SONAME 'simple_password_check'"
+              when: mariadb_simple_password_check_state.query_result[0] | length == 0
 
-        - name: MySQL password policy | Assert MariaDB apply result
-          ansible.builtin.assert:
-            that:
-              - mariadb_apply_result is changed
-              - mariadb_apply_result.queries == expected_queries
-          vars:
-            expected_queries:
-              - "SET GLOBAL `simple_password_check_minimal_length` = 12"
-              - "SET GLOBAL `simple_password_check_letters_same_case` = 2"
-              - "SET GLOBAL `simple_password_check_digits` = 2"
-              - "SET GLOBAL `simple_password_check_other_characters` = 1"
+            - name: MySQL password policy | Re-check simple_password_check plugin state
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_minimal_length'"
+              register: mariadb_simple_password_check_ready
 
-        - name: MySQL password policy | Verify applied MariaDB settings
-          ansible.mysql.mysql_query:
-            <<: *mysql_params
-            query:
-              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_minimal_length'"
-              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_letters_same_case'"
-              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_digits'"
-              - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_other_characters'"
-          register: mariadb_apply_state
+            - name: MySQL password policy | Assert simple_password_check plugin is available
+              ansible.builtin.assert:
+                that:
+                  - mariadb_simple_password_check_ready.query_result[0] | length == 1
 
-        - name: MySQL password policy | Assert applied MariaDB settings
-          ansible.builtin.assert:
-            that:
-              - mariadb_apply_state.query_result[0][0].Value | int == 12
-              - mariadb_apply_state.query_result[1][0].Value | int == 2
-              - mariadb_apply_state.query_result[2][0].Value | int == 2
-              - mariadb_apply_state.query_result[3][0].Value | int == 1
+            - name: MySQL password policy | Set MariaDB baseline values
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query:
+                  - "SET GLOBAL `simple_password_check_minimal_length` = 8"
+                  - "SET GLOBAL `simple_password_check_letters_same_case` = 1"
+                  - "SET GLOBAL `simple_password_check_digits` = 1"
+                  - "SET GLOBAL `simple_password_check_other_characters` = 0"
 
-        - name: MySQL password policy | Re-run MariaDB shared settings for idempotency
-          ansible.mysql.mysql_password_policy:
-            <<: *mysql_params
-            length: 12
-            mixed_case_count: 2
-            number_count: 2
-            special_char_count: 1
-          register: mariadb_idempotency_result
+            - name: MySQL password policy | Configure MariaDB settings in check mode
+              check_mode: true
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                length: 12
+                mixed_case_count: 2
+                number_count: 2
+                special_char_count: 1
+              register: mariadb_check_mode_result
 
-        - name: MySQL password policy | Assert MariaDB idempotency
-          ansible.builtin.assert:
-            that:
-              - mariadb_idempotency_result is not changed
-              - mariadb_idempotency_result.queries == []
+            - name: MySQL password policy | Assert MariaDB check mode result
+              ansible.builtin.assert:
+                that:
+                  - mariadb_check_mode_result is changed
+                  - mariadb_check_mode_result.queries == expected_queries
+              vars:
+                expected_queries:
+                  - "SET GLOBAL `simple_password_check_minimal_length` = 12"
+                  - "SET GLOBAL `simple_password_check_letters_same_case` = 2"
+                  - "SET GLOBAL `simple_password_check_digits` = 2"
+                  - "SET GLOBAL `simple_password_check_other_characters` = 1"
 
-        - name: MySQL password policy | Reject MySQL-only parameters on MariaDB
-          ansible.mysql.mysql_password_policy:
-            <<: *mysql_params
-            policy: medium
-          register: mariadb_unsupported_result
-          ignore_errors: true
+            - name: MySQL password policy | Verify MariaDB check mode left baseline unchanged
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query:
+                  - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_minimal_length'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_letters_same_case'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_digits'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_other_characters'"
+              register: mariadb_check_mode_state
 
-        - name: MySQL password policy | Assert MariaDB unsupported-parameter failure
-          ansible.builtin.assert:
-            that:
-              - mariadb_unsupported_result is failed
-              - "'Parameter \"policy\" is supported only on MySQL.' in mariadb_unsupported_result.msg"
+            - name: MySQL password policy | Assert MariaDB baseline remained unchanged
+              ansible.builtin.assert:
+                that:
+                  - mariadb_check_mode_state.query_result[0][0].Value | int == 8
+                  - mariadb_check_mode_state.query_result[1][0].Value | int == 1
+                  - mariadb_check_mode_state.query_result[2][0].Value | int == 1
+                  - mariadb_check_mode_state.query_result[3][0].Value | int == 0
 
-        - name: MySQL password policy | Reject persist mode on MariaDB
-          ansible.mysql.mysql_password_policy:
-            <<: *mysql_params
-            length: 12
-            mode: persist
-          register: mariadb_persist_result
-          ignore_errors: true
+            - name: MySQL password policy | Apply MariaDB shared settings
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                length: 12
+                mixed_case_count: 2
+                number_count: 2
+                special_char_count: 1
+              register: mariadb_apply_result
 
-        - name: MySQL password policy | Assert MariaDB persist-mode failure
-          ansible.builtin.assert:
-            that:
-              - mariadb_persist_result is failed
-              - "'mode=persist is supported only on MySQL.' in mariadb_persist_result.msg"
+            - name: MySQL password policy | Assert MariaDB apply result
+              ansible.builtin.assert:
+                that:
+                  - mariadb_apply_result is changed
+                  - mariadb_apply_result.queries == expected_queries
+              vars:
+                expected_queries:
+                  - "SET GLOBAL `simple_password_check_minimal_length` = 12"
+                  - "SET GLOBAL `simple_password_check_letters_same_case` = 2"
+                  - "SET GLOBAL `simple_password_check_digits` = 2"
+                  - "SET GLOBAL `simple_password_check_other_characters` = 1"
+
+            - name: MySQL password policy | Verify applied MariaDB settings
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query:
+                  - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_minimal_length'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_letters_same_case'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_digits'"
+                  - "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_other_characters'"
+              register: mariadb_apply_state
+
+            - name: MySQL password policy | Assert applied MariaDB settings
+              ansible.builtin.assert:
+                that:
+                  - mariadb_apply_state.query_result[0][0].Value | int == 12
+                  - mariadb_apply_state.query_result[1][0].Value | int == 2
+                  - mariadb_apply_state.query_result[2][0].Value | int == 2
+                  - mariadb_apply_state.query_result[3][0].Value | int == 1
+
+            - name: MySQL password policy | Re-run MariaDB shared settings for idempotency
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                length: 12
+                mixed_case_count: 2
+                number_count: 2
+                special_char_count: 1
+              register: mariadb_idempotency_result
+
+            - name: MySQL password policy | Assert MariaDB idempotency
+              ansible.builtin.assert:
+                that:
+                  - mariadb_idempotency_result is not changed
+                  - mariadb_idempotency_result.queries == []
+
+            - name: MySQL password policy | Reject MySQL-only parameters on MariaDB
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                policy: medium
+              register: mariadb_unsupported_result
+              ignore_errors: true
+
+            - name: MySQL password policy | Assert MariaDB unsupported-parameter failure
+              ansible.builtin.assert:
+                that:
+                  - mariadb_unsupported_result is failed
+                  - "'Parameter \"policy\" is supported only on MySQL.' in mariadb_unsupported_result.msg"
+
+            - name: MySQL password policy | Reject persist mode on MariaDB
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                length: 12
+                mode: persist
+              register: mariadb_persist_result
+              ignore_errors: true
+
+            - name: MySQL password policy | Assert MariaDB persist-mode failure
+              ansible.builtin.assert:
+                that:
+                  - mariadb_persist_result is failed
+                  - "'mode=persist is supported only on MySQL.' in mariadb_persist_result.msg"
+          always:
+            - name: MySQL password policy | Restore initial MariaDB simple_password_check settings
+              when: mariadb_simple_password_check_initially_present
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query:
+                  - "SET GLOBAL `simple_password_check_minimal_length` = {{ mariadb_initial_minimal_length }}"
+                  - "SET GLOBAL `simple_password_check_letters_same_case` = {{ mariadb_initial_letters_same_case }}"
+                  - "SET GLOBAL `simple_password_check_digits` = {{ mariadb_initial_digits }}"
+                  - "SET GLOBAL `simple_password_check_other_characters` = {{ mariadb_initial_other_characters }}"
+
+            - name: MySQL password policy | Check current MariaDB plugin state for cleanup
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "SHOW GLOBAL VARIABLES LIKE 'simple_password_check_minimal_length'"
+              register: mariadb_simple_password_check_cleanup_state
+
+            - name: MySQL password policy | Remove simple_password_check plugin if test enabled it
+              when:
+                - not mariadb_simple_password_check_initially_present
+                - mariadb_simple_password_check_cleanup_state.query_result[0] | length == 1
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "UNINSTALL SONAME IF EXISTS 'simple_password_check'"

--- a/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
+++ b/tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml
@@ -141,12 +141,12 @@
                   - mysql_check_mode_result.queries == expected_queries
               vars:
                 expected_queries:
-                  - "SET GLOBAL `validate_password.policy` = MEDIUM"
-                  - "SET GLOBAL `validate_password.length` = 12"
-                  - "SET GLOBAL `validate_password.mixed_case_count` = 2"
-                  - "SET GLOBAL `validate_password.number_count` = 2"
-                  - "SET GLOBAL `validate_password.special_char_count` = 1"
-                  - "SET GLOBAL `validate_password.check_user_name` = ON"
+                  - "SET GLOBAL `validate_password`.`policy` = MEDIUM"
+                  - "SET GLOBAL `validate_password`.`length` = 12"
+                  - "SET GLOBAL `validate_password`.`mixed_case_count` = 2"
+                  - "SET GLOBAL `validate_password`.`number_count` = 2"
+                  - "SET GLOBAL `validate_password`.`special_char_count` = 1"
+                  - "SET GLOBAL `validate_password`.`check_user_name` = ON"
                   - "SET GLOBAL `default_password_lifetime` = 90"
                   - "SET GLOBAL `password_history` = 5"
                   - "SET GLOBAL `password_reuse_interval` = 365"
@@ -198,17 +198,28 @@
                 that:
                   - mysql_apply_result is changed
                   - mysql_apply_result.queries == expected_queries
+                  - mysql_apply_result.settings == expected_settings
               vars:
                 expected_queries:
-                  - "SET GLOBAL `validate_password.policy` = MEDIUM"
-                  - "SET GLOBAL `validate_password.length` = 12"
-                  - "SET GLOBAL `validate_password.mixed_case_count` = 2"
-                  - "SET GLOBAL `validate_password.number_count` = 2"
-                  - "SET GLOBAL `validate_password.special_char_count` = 1"
-                  - "SET GLOBAL `validate_password.check_user_name` = ON"
+                  - "SET GLOBAL `validate_password`.`policy` = MEDIUM"
+                  - "SET GLOBAL `validate_password`.`length` = 12"
+                  - "SET GLOBAL `validate_password`.`mixed_case_count` = 2"
+                  - "SET GLOBAL `validate_password`.`number_count` = 2"
+                  - "SET GLOBAL `validate_password`.`special_char_count` = 1"
+                  - "SET GLOBAL `validate_password`.`check_user_name` = ON"
                   - "SET GLOBAL `default_password_lifetime` = 90"
                   - "SET GLOBAL `password_history` = 5"
                   - "SET GLOBAL `password_reuse_interval` = 365"
+                expected_settings:
+                  policy: medium
+                  length: 12
+                  mixed_case_count: 2
+                  number_count: 2
+                  special_char_count: 1
+                  check_user_name: 'ON'
+                  password_lifetime: 90
+                  password_history: 5
+                  reuse_interval: 365
 
             - name: MySQL password policy | Verify applied MySQL settings
               ansible.mysql.mysql_query:
@@ -258,6 +269,27 @@
                   - mysql_idempotency_result is not changed
                   - mysql_idempotency_result.queries == []
 
+            - name: MySQL password policy | Re-run MySQL settings in check mode for idempotency
+              check_mode: true
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                policy: medium
+                length: 12
+                mixed_case_count: 2
+                number_count: 2
+                special_char_count: 1
+                check_user_name: true
+                password_lifetime: 90
+                password_history: 5
+                reuse_interval: 365
+              register: mysql_check_idempotency_result
+
+            - name: MySQL password policy | Assert MySQL check mode idempotency
+              ansible.builtin.assert:
+                that:
+                  - mysql_check_idempotency_result is not changed
+                  - mysql_check_idempotency_result.queries == []
+
             - name: MySQL password policy | Switch to strong policy and disable username check
               ansible.mysql.mysql_password_policy:
                 <<: *mysql_params
@@ -272,8 +304,8 @@
                   - mysql_toggle_result.queries == expected_queries
               vars:
                 expected_queries:
-                  - "SET GLOBAL `validate_password.policy` = STRONG"
-                  - "SET GLOBAL `validate_password.check_user_name` = OFF"
+                  - "SET GLOBAL `validate_password`.`policy` = STRONG"
+                  - "SET GLOBAL `validate_password`.`check_user_name` = OFF"
 
             - name: MySQL password policy | Verify strong policy and disabled username check
               ansible.mysql.mysql_query:
@@ -288,6 +320,32 @@
                 that:
                   - mysql_toggle_state.query_result[0][0].Value in ['STRONG', '2']
                   - mysql_toggle_state.query_result[1][0].Value in ['OFF', '0']
+
+            - name: MySQL password policy | Switch back to low policy
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                policy: low
+              register: mysql_low_policy_result
+
+            - name: MySQL password policy | Assert low-policy toggle result
+              ansible.builtin.assert:
+                that:
+                  - mysql_low_policy_result is changed
+                  - mysql_low_policy_result.queries == expected_queries
+              vars:
+                expected_queries:
+                  - "SET GLOBAL `validate_password`.`policy` = LOW"
+
+            - name: MySQL password policy | Verify low policy
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "SHOW GLOBAL VARIABLES LIKE 'validate_password.policy'"
+              register: mysql_low_policy_state
+
+            - name: MySQL password policy | Assert low policy
+              ansible.builtin.assert:
+                that:
+                  - mysql_low_policy_state.query_result[0][0].Value in ['LOW', '0']
 
             - name: MySQL password policy | Persist selected MySQL settings
               ansible.mysql.mysql_password_policy:
@@ -304,7 +362,7 @@
                   - mysql_persist_result.queries == expected_queries
               vars:
                 expected_queries:
-                  - "SET PERSIST `validate_password.length` = 14"
+                  - "SET PERSIST `validate_password`.`length` = 14"
                   - "SET PERSIST `password_history` = 7"
 
             - name: MySQL password policy | Verify persisted MySQL settings
@@ -410,6 +468,29 @@
                 that:
                   - mariadb_simple_password_check_ready.query_result[0] | length == 1
 
+            - name: MySQL password policy | Remove simple_password_check plugin outside module
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "UNINSTALL SONAME 'simple_password_check'"
+
+            - name: MySQL password policy | Fail clearly when simple_password_check is missing
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                length: 12
+              register: mariadb_missing_facility
+              ignore_errors: true
+
+            - name: MySQL password policy | Assert missing-plugin failure
+              ansible.builtin.assert:
+                that:
+                  - mariadb_missing_facility is failed
+                  - "'Password policy setting \"length\" is not available on this server.' in mariadb_missing_facility.msg"
+
+            - name: MySQL password policy | Reinstall simple_password_check plugin for module tests
+              ansible.mysql.mysql_query:
+                <<: *mysql_params
+                query: "INSTALL SONAME 'simple_password_check'"
+
             - name: MySQL password policy | Set MariaDB baseline values
               ansible.mysql.mysql_query:
                 <<: *mysql_params
@@ -473,12 +554,18 @@
                 that:
                   - mariadb_apply_result is changed
                   - mariadb_apply_result.queries == expected_queries
+                  - mariadb_apply_result.settings == expected_settings
               vars:
                 expected_queries:
                   - "SET GLOBAL `simple_password_check_minimal_length` = 12"
                   - "SET GLOBAL `simple_password_check_letters_same_case` = 2"
                   - "SET GLOBAL `simple_password_check_digits` = 2"
                   - "SET GLOBAL `simple_password_check_other_characters` = 1"
+                expected_settings:
+                  length: 12
+                  mixed_case_count: 2
+                  number_count: 2
+                  special_char_count: 1
 
             - name: MySQL password policy | Verify applied MariaDB settings
               ansible.mysql.mysql_query:
@@ -512,6 +599,22 @@
                 that:
                   - mariadb_idempotency_result is not changed
                   - mariadb_idempotency_result.queries == []
+
+            - name: MySQL password policy | Re-run MariaDB shared settings in check mode for idempotency
+              check_mode: true
+              ansible.mysql.mysql_password_policy:
+                <<: *mysql_params
+                length: 12
+                mixed_case_count: 2
+                number_count: 2
+                special_char_count: 1
+              register: mariadb_check_idempotency_result
+
+            - name: MySQL password policy | Assert MariaDB check mode idempotency
+              ansible.builtin.assert:
+                that:
+                  - mariadb_check_idempotency_result is not changed
+                  - mariadb_check_idempotency_result.queries == []
 
             - name: MySQL password policy | Reject MySQL-only parameters on MariaDB
               ansible.mysql.mysql_password_policy:

--- a/tests/unit/plugins/modules/test_mysql_password_policy.py
+++ b/tests/unit/plugins/modules/test_mysql_password_policy.py
@@ -1,0 +1,422 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from contextlib import contextmanager
+import json
+import sys
+
+import pytest
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock  # pyright: ignore[reportMissingImports]
+
+from ansible.module_utils import basic
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_bytes
+try:
+    from ansible.module_utils.testing import patch_module_args  # pyright: ignore[reportMissingImports]
+except ImportError:
+    patch_module_args = None
+
+from ansible_collections.ansible.mysql.plugins.modules import mysql_password_policy
+from ansible_collections.ansible.mysql.plugins.modules.mysql_password_policy import (
+    MySQLPasswordPolicy,
+    get_variable,
+    normalize_bool_setting_value,
+    normalize_int_value,
+    normalize_policy_value,
+    set_variable,
+)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+@contextmanager
+def set_module_args(args):
+    module_args = dict(args)
+
+    original_argv = sys.argv[:]
+    sys.argv = ['ansible_unittest']
+
+    try:
+        if patch_module_args is not None:
+            with patch_module_args(module_args):
+                yield
+            return
+
+        original_args = getattr(basic, '_ANSIBLE_ARGS', None)
+        original_profile = getattr(basic, '_ANSIBLE_PROFILE', None)
+        had_profile = hasattr(basic, '_ANSIBLE_PROFILE')
+
+        basic._ANSIBLE_ARGS = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': module_args}))
+        basic._ANSIBLE_PROFILE = 'legacy'
+
+        try:
+            yield
+        finally:
+            basic._ANSIBLE_ARGS = original_args
+            if had_profile:
+                basic._ANSIBLE_PROFILE = original_profile
+            else:
+                delattr(basic, '_ANSIBLE_PROFILE')
+    finally:
+        sys.argv = original_argv
+
+
+class FakeCursor(object):
+    def __init__(self, variables):
+        self.variables = variables.copy()
+        self.executed = []
+        self._rows = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+        if query == "SHOW GLOBAL VARIABLES WHERE Variable_name = %s":
+            variable_name = params[0]
+            if variable_name in self.variables:
+                self._rows = [(variable_name, self.variables[variable_name])]
+            else:
+                self._rows = []
+            return
+
+        if query.startswith("SET GLOBAL ") or query.startswith("SET PERSIST "):
+            variable_name = query.split('`')[1]
+            self.variables[variable_name] = params[0]
+            self._rows = []
+            return
+
+        raise AssertionError('Unexpected query: %s' % query)
+
+    def fetchall(self):
+        return list(self._rows)
+
+
+class ModuleStub(object):
+    def fail_json(self, **kwargs):
+        raise RuntimeError(kwargs['msg'])
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    [
+        ('12', 12),
+        (12, 12),
+    ],
+)
+def test_normalize_int_value_returns_expected_int(value, expected):
+    assert normalize_int_value(value) == expected
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    [
+        ('ON', 'ON'),
+        ('off', 'OFF'),
+        (1, 'ON'),
+        (False, 'OFF'),
+    ],
+)
+def test_normalize_bool_setting_value_normalizes_supported_inputs(value, expected):
+    assert normalize_bool_setting_value(value) == expected
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    [
+        ('medium', 'medium'),
+        ('MEDIUM', 'medium'),
+        ('1', 'medium'),
+        ('2', 'strong'),
+    ],
+)
+def test_normalize_policy_value_normalizes_numeric_and_string_inputs(value, expected):
+    assert normalize_policy_value(value) == expected
+
+
+def test_get_variable_returns_matching_value():
+    cursor = FakeCursor({
+        'password_history': '3',
+    })
+
+    assert get_variable(cursor, 'password_history') == '3'
+
+
+def test_get_variable_returns_none_when_variable_is_missing():
+    assert get_variable(FakeCursor({}), 'password_history') is None
+
+
+def test_set_variable_executes_global_query():
+    cursor = FakeCursor({})
+
+    set_variable(cursor, 'password_history', 4, 'global')
+
+    assert cursor.executed[-1] == ("SET GLOBAL `password_history` = %s", (4,))
+    assert cursor.variables['password_history'] == 4
+
+
+def test_set_variable_executes_persist_query():
+    cursor = FakeCursor({})
+
+    set_variable(cursor, 'password_history', 4, 'persist')
+
+    assert cursor.executed[-1] == ("SET PERSIST `password_history` = %s", (4,))
+    assert cursor.variables['password_history'] == 4
+
+
+def test_configure_returns_unchanged_when_mysql_settings_already_match():
+    cursor = FakeCursor({
+        'validate_password.length': '12',
+        'validate_password.mixed_case_count': '2',
+        'validate_password.number_count': '2',
+        'validate_password.special_char_count': '1',
+        'default_password_lifetime': '90',
+    })
+
+    policy = MySQLPasswordPolicy(ModuleStub(), cursor, 'mysql')
+
+    result = policy.configure({
+        'length': 12,
+        'mixed_case_count': 2,
+        'number_count': 2,
+        'special_char_count': 1,
+        'password_lifetime': 90,
+    })
+
+    assert result['changed'] is False
+    assert result['queries'] == []
+    assert result['settings'] == {
+        'length': 12,
+        'mixed_case_count': 2,
+        'number_count': 2,
+        'special_char_count': 1,
+        'password_lifetime': 90,
+    }
+
+
+def test_configure_in_check_mode_predicts_mysql_persist_queries_without_writes():
+    cursor = FakeCursor({
+        'validate_password.length': '8',
+        'password_history': '3',
+    })
+
+    policy = MySQLPasswordPolicy(ModuleStub(), cursor, 'mysql')
+
+    result = policy.configure({
+        'length': 12,
+        'password_history': 5,
+    }, mode='persist', check_mode=True)
+
+    assert result['changed'] is True
+    assert result['queries'] == [
+        "SET PERSIST `validate_password.length` = 12",
+        "SET PERSIST `password_history` = 5",
+    ]
+    assert cursor.variables['validate_password.length'] == '8'
+    assert cursor.variables['password_history'] == '3'
+    assert not any(query.startswith('SET PERSIST ') for query, _params in cursor.executed)
+
+
+def test_configure_uses_mariadb_simple_password_check_mapping():
+    cursor = FakeCursor({
+        'simple_password_check_minimal_length': '12',
+        'simple_password_check_letters_same_case': '2',
+        'simple_password_check_digits': '2',
+        'simple_password_check_other_characters': '1',
+    })
+
+    policy = MySQLPasswordPolicy(ModuleStub(), cursor, 'mariadb')
+
+    result = policy.configure({
+        'length': 12,
+        'mixed_case_count': 2,
+        'number_count': 2,
+        'special_char_count': 1,
+    })
+
+    assert result['changed'] is False
+    assert result['settings'] == {
+        'length': 12,
+        'mixed_case_count': 2,
+        'number_count': 2,
+        'special_char_count': 1,
+    }
+
+
+def test_configure_fails_when_mariadb_receives_mysql_only_option():
+    policy = MySQLPasswordPolicy(ModuleStub(), FakeCursor({}), 'mariadb')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        policy.configure({'policy': 'medium'})
+
+    assert str(exc_info.value) == 'Parameter "policy" is supported only on MySQL.'
+
+
+def test_validate_supported_settings_allows_mysql_specific_options():
+    policy = MySQLPasswordPolicy(ModuleStub(), FakeCursor({}), 'mysql')
+
+    policy.validate_supported_settings({'policy': 'medium'}, mode='persist')
+
+
+def test_configure_fails_when_requested_validation_facility_is_missing():
+    policy = MySQLPasswordPolicy(ModuleStub(), FakeCursor({}), 'mysql')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        policy.configure({'length': 12})
+
+    assert str(exc_info.value) == 'Password policy setting "length" is not available on this server.'
+
+
+def test_configure_allows_mysql_global_settings_without_validate_password_component():
+    cursor = FakeCursor({
+        'password_history': '3',
+    })
+
+    policy = MySQLPasswordPolicy(ModuleStub(), cursor, 'mysql')
+
+    result = policy.configure({
+        'password_history': 5,
+    })
+
+    assert result['changed'] is True
+    assert result['queries'] == [
+        "SET GLOBAL `password_history` = 5",
+    ]
+    assert cursor.variables['password_history'] == 5
+
+
+def test_configure_fails_when_mariadb_requests_persist_mode():
+    cursor = FakeCursor({
+        'simple_password_check_minimal_length': '8',
+    })
+
+    policy = MySQLPasswordPolicy(ModuleStub(), cursor, 'mariadb')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        policy.configure({'length': 12}, mode='persist')
+
+    assert str(exc_info.value) == 'mode=persist is supported only on MySQL.'
+
+
+def test_read_setting_returns_mapped_mysql_variable_name_and_value():
+    policy = MySQLPasswordPolicy(
+        ModuleStub(),
+        FakeCursor({'validate_password.policy': 'MEDIUM'}),
+        'mysql',
+    )
+
+    variable_name, value = policy.read_setting('policy')
+
+    assert variable_name == 'validate_password.policy'
+    assert value == 'MEDIUM'
+
+
+def test_normalize_value_handles_supported_setting_types():
+    policy = MySQLPasswordPolicy(ModuleStub(), FakeCursor({}), 'mysql')
+
+    assert policy.normalize_value('policy', '1') == 'medium'
+    assert policy.normalize_value('check_user_name', 'off') == 'OFF'
+    assert policy.normalize_value('length', '12') == 12
+
+
+def test_query_value_formats_policy_and_bool_for_sql():
+    policy = MySQLPasswordPolicy(ModuleStub(), FakeCursor({}), 'mysql')
+
+    assert policy.query_value('policy', 'medium') == 'MEDIUM'
+    assert policy.query_value('check_user_name', False) == 'OFF'
+
+
+def test_format_set_query_formats_expected_statement():
+    assert MySQLPasswordPolicy.format_set_query('password_history', 5, 'persist') == (
+        "SET PERSIST `password_history` = 5"
+    )
+
+
+def test_configure_treats_policy_values_case_insensitively():
+    cursor = FakeCursor({
+        'validate_password.policy': 'MEDIUM',
+    })
+
+    policy = MySQLPasswordPolicy(ModuleStub(), cursor, 'mysql')
+
+    result = policy.configure({
+        'policy': 'medium',
+    })
+
+    assert result['changed'] is False
+    assert result['queries'] == []
+
+
+def test_main_rejects_persist_mode_for_old_mysql(monkeypatch):
+    with set_module_args(
+        {
+            'login_unix_socket': '/run/mysqld/mysqld.sock',
+            'length': 12,
+            'mode': 'persist',
+        }
+    ):
+        monkeypatch.setattr(AnsibleModule, 'exit_json', exit_json)
+        monkeypatch.setattr(AnsibleModule, 'fail_json', fail_json)
+        monkeypatch.setattr(mysql_password_policy, 'mysql_driver', object())
+        monkeypatch.setattr(mysql_password_policy, 'mysql_connect', lambda *args, **kwargs: (MagicMock(), MagicMock()))
+        monkeypatch.setattr(mysql_password_policy, 'get_server_implementation', lambda cursor: 'mysql')
+        monkeypatch.setattr(mysql_password_policy, 'get_server_version', lambda cursor: '5.7.44')
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            mysql_password_policy.main()
+
+    assert exc.value.args[0]['msg'] == 'mode=persist requires MySQL 8.0 or later.'
+
+
+def test_main_returns_configure_result(monkeypatch):
+    with set_module_args(
+        {
+            'login_unix_socket': '/run/mysqld/mysqld.sock',
+            'length': 12,
+        }
+    ):
+        monkeypatch.setattr(AnsibleModule, 'exit_json', exit_json)
+        monkeypatch.setattr(AnsibleModule, 'fail_json', fail_json)
+        monkeypatch.setattr(mysql_password_policy, 'mysql_driver', object())
+        monkeypatch.setattr(mysql_password_policy, 'mysql_connect', lambda *args, **kwargs: (MagicMock(), MagicMock()))
+        monkeypatch.setattr(mysql_password_policy, 'get_server_implementation', lambda cursor: 'mariadb')
+
+        def fake_configure(self, desired_settings, mode='global', check_mode=False):
+            assert desired_settings['length'] == 12
+            assert mode == 'global'
+            assert check_mode is False
+            return {
+                'changed': False,
+                'queries': [],
+                'settings': {'length': 12},
+            }
+
+        monkeypatch.setattr(mysql_password_policy.MySQLPasswordPolicy, 'configure', fake_configure)
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            mysql_password_policy.main()
+
+    assert exc.value.args[0] == {
+        'changed': False,
+        'queries': [],
+        'settings': {'length': 12},
+    }

--- a/tests/unit/plugins/modules/test_mysql_password_policy.py
+++ b/tests/unit/plugins/modules/test_mysql_password_policy.py
@@ -228,7 +228,7 @@ def test_configure_in_check_mode_predicts_mysql_persist_queries_without_writes()
 
     assert result['changed'] is True
     assert result['queries'] == [
-        "SET PERSIST `validate_password.length` = 12",
+        "SET PERSIST `validate_password`.`length` = 12",
         "SET PERSIST `password_history` = 5",
     ]
     assert cursor.variables['validate_password.length'] == '8'
@@ -348,6 +348,12 @@ def test_query_value_formats_policy_and_bool_for_sql():
 def test_format_set_query_formats_expected_statement():
     assert MySQLPasswordPolicy.format_set_query('password_history', 5, 'persist') == (
         "SET PERSIST `password_history` = 5"
+    )
+
+
+def test_format_set_query_quotes_dotted_variable_fragments():
+    assert MySQLPasswordPolicy.format_set_query('validate_password.length', 12, 'global') == (
+        "SET GLOBAL `validate_password`.`length` = 12"
     )
 
 


### PR DESCRIPTION
#### SUMMARY
- add `mysql_password_policy` as a configuration-only module for password policy settings
- support a shared MySQL/MariaDB complexity core while failing fast on MySQL-only options used against MariaDB

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- `plugins/modules/mysql_password_policy.py`
- `tests/unit/plugins/modules/test_mysql_password_policy.py`
- `tests/integration/targets/test_mysql_password_policy/defaults/main.yml`
- `tests/integration/targets/test_mysql_password_policy/meta/main.yml`
- `tests/integration/targets/test_mysql_password_policy/tasks/main.yml`
- `tests/integration/targets/test_mysql_password_policy/tasks/mysql_password_policy.yml`
- `README.md`
- `galaxy.yml`

#### ADDITIONAL INFORMATION
- keeps plugin/component installation out of module scope; the required validation facility must already be enabled
- limits first-pass MariaDB support to `simple_password_check`
- Used Cursor for implementing with human in the loop with manual testing