### PR TITLE
feat: add mysql_tls module

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -163,6 +163,7 @@ jobs:
           docker exec -e cnf=$prima_conf ${{ job.services.db_primary.id }} bash -c 'echo -e ${cnf//\\n/\n} > /etc/mysql/conf.d/replication.cnf'
           docker exec -e cnf=$repl1_conf ${{ job.services.db_replica1.id }} bash -c 'echo -e ${cnf//\\n/\n} > /etc/mysql/conf.d/replication.cnf'
           docker exec -e cnf=$repl2_conf ${{ job.services.db_replica2.id }} bash -c 'echo -e ${cnf//\\n/\n} > /etc/mysql/conf.d/replication.cnf'
+          bash tests/integration/setup_tls_harness.sh docker ${{ job.services.db_primary.id }} ${{ job.services.db_replica1.id }} ${{ job.services.db_replica2.id }}
           docker restart -t 30 ${{ job.services.db_primary.id }}
           docker restart -t 30 ${{ job.services.db_replica1.id }}
           docker restart -t 30 ${{ job.services.db_replica2.id }}

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -147,6 +147,9 @@ jobs:
 
       # No need to check for service health. GitHub Action took care of it.
 
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Restart MySQL server with settings for replication
         run: |
           db_ver="${{ matrix.db_engine_version }}"

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ test-integration:
 	podman exec -e cnf="$$prima_conf" primary bash -c 'echo -e "$${cnf//\\n/\n}" > /etc/mysql/conf.d/replication.cnf'; \
 	podman exec -e cnf="$$repl1_conf" replica1 bash -c 'echo -e "$${cnf//\\n/\n}" > /etc/mysql/conf.d/replication.cnf'; \
 	podman exec -e cnf="$$repl2_conf" replica2 bash -c 'echo -e "$${cnf//\\n/\n}" > /etc/mysql/conf.d/replication.cnf'
+	bash tests/integration/setup_tls_harness.sh podman primary replica1 replica2
 	# Don't restart a container unless it is healthy
 	while ! podman healthcheck run primary && [[ "$$SECONDS" -lt 120 ]]; do sleep 1; done
 	podman restart -t 30 primary

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Every voice is important and every idea is valuable. If you have something on yo
   - [mysql_resource_group_info](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_resource_group_info_module.html)
   - [mysql_role](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_role_module.html)
   - [mysql_slow_log](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_slow_log_module.html)
+  - [mysql_tls](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_tls_module.html)
   - [mysql_user](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_user_module.html)
   - [mysql_variables](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_variables_module.html)
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -14,5 +14,6 @@ action_groups:
     - mysql_resource_group_info
     - mysql_role
     - mysql_slow_log
+    - mysql_tls
     - mysql_user
     - mysql_variables

--- a/plugins/modules/mysql_tls.py
+++ b/plugins/modules/mysql_tls.py
@@ -1,0 +1,371 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_tls
+
+short_description: Manage MySQL or MariaDB TLS runtime settings
+
+description:
+  - Manage selected TLS runtime settings for MySQL or MariaDB.
+  - MySQL supports certificate paths, TLS versions, secure transport, and explicit reloads.
+  - MariaDB support in this module is limited to the runtime C(require_secure_transport) setting.
+  - In this module, MariaDB does not support certificate path management, C(tls_version),
+    explicit reloads, or C(mode=persist).
+
+author:
+  - Ron Gershburg (@ronger4)
+  - Steve Fulmer (@stevefulme1)
+
+version_added: '5.2.0'
+
+options:
+  server_cert:
+    description:
+      - Path to the TLS server certificate on the database host.
+    type: path
+    version_added: '5.2.0'
+  server_key:
+    description:
+      - Path to the TLS server private key on the database host.
+    type: path
+    version_added: '5.2.0'
+  server_ca:
+    description:
+      - Path to the TLS CA certificate on the database host.
+    type: path
+    version_added: '5.2.0'
+  require_secure_transport:
+    description:
+      - Require encrypted client connections.
+    type: bool
+    version_added: '5.2.0'
+  tls_version:
+    description:
+      - Allowed TLS protocol versions.
+    type: str
+    version_added: '5.2.0'
+  reload:
+    description:
+      - Execute C(ALTER INSTANCE RELOAD TLS) after applying changes.
+      - Reload is explicit and is only attempted when settings actually change.
+      - MariaDB does not support O(reload) in this module.
+    type: bool
+    default: false
+    version_added: '5.2.0'
+  mode:
+    description:
+      - How runtime values are written.
+      - C(global) uses C(SET GLOBAL).
+      - C(persist) uses C(SET PERSIST) and depends on MySQL 8.0 or later support for that statement.
+      - In this module, C(persist) is supported only for MySQL and is rejected for MariaDB.
+    type: str
+    choices:
+      - global
+      - persist
+    default: global
+    version_added: '5.2.0'
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+notes:
+  - MariaDB support in this module is limited to runtime C(require_secure_transport).
+  - On MariaDB, O(server_cert), O(server_key), O(server_ca), O(tls_version), O(reload),
+    and O(mode=persist) are not supported by this module.
+
+extends_documentation_fragment:
+  - ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Require secure transport
+  ansible.mysql.mysql_tls:
+    login_user: root
+    login_password: rootpass
+    require_secure_transport: true
+
+- name: Configure MySQL TLS files and reload explicitly
+  ansible.mysql.mysql_tls:
+    login_user: root
+    login_password: rootpass
+    server_cert: /etc/mysql/ssl/server-cert.pem
+    server_key: /etc/mysql/ssl/server-key.pem
+    server_ca: /etc/mysql/ssl/ca-cert.pem
+    reload: true
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed queries which modified DB state.
+  returned: always
+  type: list
+  elements: str
+  sample:
+    - SET GLOBAL `ssl_cert` = '/etc/mysql/ssl/server-cert.pem'
+settings:
+  description: Effective TLS settings after applying requested changes.
+  returned: always
+  type: dict
+  sample:
+    server_cert: /etc/mysql/ssl/server-cert.pem
+    server_key: /etc/mysql/ssl/server-key.pem
+    server_ca: /etc/mysql/ssl/ca-cert.pem
+    require_secure_transport: 'ON'
+    tls_version: TLSv1.3
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.ansible.mysql.plugins.module_utils.database import mysql_quote_identifier
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    get_server_implementation,
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+
+
+PARAM_TO_VAR = {
+    'server_cert': 'ssl_cert',
+    'server_key': 'ssl_key',
+    'server_ca': 'ssl_ca',
+    'require_secure_transport': 'require_secure_transport',
+    'tls_version': 'tls_version',
+}
+
+SUPPORTED_SETTINGS = {
+    'mysql': tuple(PARAM_TO_VAR.keys()),
+    'mariadb': ('require_secure_transport',),
+}
+
+MODE_CHOICES = ('global', 'persist')
+RELOAD_QUERY = 'ALTER INSTANCE RELOAD TLS'
+
+
+def get_variable(cursor, mysqlvar):
+    cursor.execute("SHOW GLOBAL VARIABLES WHERE Variable_name = %s", (mysqlvar,))
+    mysqlvar_val = cursor.fetchone()
+    if mysqlvar_val:
+        return mysqlvar_val[1]
+    return None
+
+
+def normalize_bool_setting(value):
+    if isinstance(value, str):
+        value = value.upper()
+
+    if value in ('ON', '1', 1, True):
+        return 'ON'
+    if value in ('OFF', '0', 0, False):
+        return 'OFF'
+    return value
+
+
+def format_query_value(value):
+    if isinstance(value, str):
+        if value in ('ON', 'OFF'):
+            return value
+        return "'%s'" % value.replace("'", "\\'")
+    return str(value)
+
+
+def set_variable(cursor, mysqlvar, value, mode, executed_queries):
+    prefix = 'SET PERSIST' if mode == 'persist' else 'SET GLOBAL'
+    query = "%s %s = " % (prefix, mysql_quote_identifier(mysqlvar, 'vars'))
+
+    try:
+        cursor.execute(query + "%s", (value,))
+        cursor.fetchall()
+    except Exception as e:
+        return to_native(e)
+
+    executed_queries.append(query + format_query_value(value))
+    return True
+
+
+class MySQLTLS(object):
+    def __init__(self, module, cursor, server_implementation):
+        self.module = module
+        self.cursor = cursor
+        self.server_implementation = server_implementation
+
+    def configure(self, desired_settings, reload=False, mode='global', check_mode=False):
+        self.validate_server_support(desired_settings, reload, mode)
+
+        current_settings = self.get_current_settings()
+        effective_settings = current_settings.copy()
+        planned_changes = []
+
+        for setting_name, value in desired_settings.items():
+            if value is None:
+                continue
+
+            normalized_value = self.normalize_value(setting_name, value)
+            variable_name = PARAM_TO_VAR[setting_name]
+            effective_settings[setting_name] = normalized_value
+
+            if current_settings.get(setting_name) != normalized_value:
+                planned_changes.append((setting_name, variable_name, normalized_value))
+
+        changed = bool(planned_changes)
+        queries = []
+
+        if check_mode:
+            for _setting_name, variable_name, value in planned_changes:
+                queries.append(self.format_set_query(variable_name, value, mode))
+
+            if reload and changed:
+                queries.append(RELOAD_QUERY)
+
+            return dict(changed=changed, queries=queries, settings=effective_settings)
+
+        for _setting_name, variable_name, value in planned_changes:
+            result = set_variable(self.cursor, variable_name, value, mode, queries)
+            if result is not True:
+                self.module.fail_json(msg=result, changed=False)
+
+        if reload and changed:
+            try:
+                self.cursor.execute(RELOAD_QUERY)
+                self.cursor.fetchall()
+            except Exception as e:
+                self.module.fail_json(msg="Cannot execute SQL '%s': %s" % (RELOAD_QUERY, to_native(e)))
+
+            queries.append(RELOAD_QUERY)
+
+        return dict(changed=changed, queries=queries, settings=effective_settings)
+
+    def validate_server_support(self, desired_settings, reload, mode):
+        if self.server_implementation != 'mariadb':
+            return
+
+        if mode == 'persist':
+            self.module.fail_json(
+                msg='MariaDB does not support mysql_tls mode "persist"',
+                changed=False,
+            )
+
+        unsupported_settings = [
+            setting_name for setting_name, value in desired_settings.items()
+            if value is not None and setting_name not in SUPPORTED_SETTINGS['mariadb']
+        ]
+        if unsupported_settings:
+            self.module.fail_json(
+                msg='MariaDB does not support mysql_tls setting "%s"' % unsupported_settings[0],
+                changed=False,
+            )
+
+        if reload:
+            self.module.fail_json(msg='MariaDB does not support mysql_tls reload', changed=False)
+
+    def get_current_settings(self):
+        settings = {}
+
+        for setting_name in SUPPORTED_SETTINGS[self.server_implementation]:
+            variable_name = PARAM_TO_VAR[setting_name]
+            value = get_variable(self.cursor, variable_name)
+            if value is None:
+                self.module.fail_json(
+                    msg='TLS setting "%s" is not available on this server.' % setting_name,
+                    changed=False,
+                )
+
+            settings[setting_name] = self.normalize_value(setting_name, value)
+
+        return settings
+
+    def normalize_value(self, setting_name, value):
+        if setting_name == 'require_secure_transport':
+            return normalize_bool_setting(value)
+        return value
+
+    @staticmethod
+    def format_set_query(variable_name, value, mode):
+        prefix = 'SET PERSIST' if mode == 'persist' else 'SET GLOBAL'
+        return "%s `%s` = %s" % (prefix, variable_name, format_query_value(value))
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        server_cert=dict(type='path'),
+        server_key=dict(type='path'),
+        server_ca=dict(type='path'),
+        require_secure_transport=dict(type='bool'),
+        tls_version=dict(type='str'),
+        reload=dict(type='bool', default=False),
+        mode=dict(type='str', choices=list(MODE_CHOICES), default='global'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    connect_timeout = module.params['connect_timeout']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    ssl_cert = module.params['client_cert']
+    ssl_key = module.params['client_key']
+    ssl_ca = module.params['ca_cert']
+    check_hostname = module.params['check_hostname']
+    config_file = module.params['config_file']
+
+    try:
+        cursor, _db_conn = mysql_connect(
+            module,
+            login_user,
+            login_password,
+            config_file,
+            ssl_cert,
+            ssl_key,
+            ssl_ca,
+            'mysql',
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+        )
+    except Exception as e:
+        module.fail_json(
+            msg="unable to connect to database, check login_user and "
+                "login_password are correct or %s has the credentials. "
+                "Exception message: %s" % (config_file, to_native(e))
+        )
+
+    desired_settings = {
+        'server_cert': module.params['server_cert'],
+        'server_key': module.params['server_key'],
+        'server_ca': module.params['server_ca'],
+        'require_secure_transport': module.params['require_secure_transport'],
+        'tls_version': module.params['tls_version'],
+    }
+
+    tls = MySQLTLS(module, cursor, get_server_implementation(cursor))
+
+    module.exit_json(
+        **tls.configure(
+            desired_settings,
+            reload=module.params['reload'],
+            mode=module.params['mode'],
+            check_mode=module.check_mode,
+        )
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_tls.py
+++ b/plugins/modules/mysql_tls.py
@@ -364,7 +364,7 @@ def main():
     tls = MySQLTLS(
         module,
         cursor,
-        get_server_implementation(cursor),
+        get_server_implementation(module, cursor),
         server_version=server_version,
     )
 

--- a/plugins/modules/mysql_tls.py
+++ b/plugins/modules/mysql_tls.py
@@ -11,14 +11,12 @@ DOCUMENTATION = r'''
 ---
 module: mysql_tls
 
-short_description: Manage MySQL or MariaDB TLS runtime settings
+short_description: Manage MySQL TLS runtime settings
 
 description:
-  - Manage selected TLS runtime settings for MySQL or MariaDB.
+  - Manage selected TLS runtime settings for MySQL.
   - MySQL supports certificate paths, TLS versions, secure transport, and explicit reloads.
-  - MariaDB support in this module is limited to the runtime C(require_secure_transport) setting.
-  - In this module, MariaDB does not support certificate path management, C(tls_version),
-    explicit reloads, or C(mode=persist).
+  - Runtime updates for MySQL certificate paths, TLS versions, and explicit reloads require MySQL 8.0.16 or later.
 
 author:
   - Ron Gershburg (@ronger4)
@@ -31,47 +29,41 @@ options:
     description:
       - Path to the TLS server certificate on the database host.
     type: path
-    version_added: '5.2.0'
   server_key:
     description:
       - Path to the TLS server private key on the database host.
     type: path
-    version_added: '5.2.0'
   server_ca:
     description:
       - Path to the TLS CA certificate on the database host.
     type: path
-    version_added: '5.2.0'
   require_secure_transport:
     description:
       - Require encrypted client connections.
+      - Enabling this without a working TLS configuration can lock out non-TLS clients.
     type: bool
-    version_added: '5.2.0'
   tls_version:
     description:
       - Allowed TLS protocol versions.
     type: str
-    version_added: '5.2.0'
   reload:
     description:
       - Execute C(ALTER INSTANCE RELOAD TLS) after applying changes.
       - Reload is explicit and is only attempted when settings actually change.
-      - MariaDB does not support O(reload) in this module.
+      - Runtime reload support requires MySQL 8.0.16 or later.
     type: bool
     default: false
-    version_added: '5.2.0'
   mode:
     description:
       - How runtime values are written.
       - C(global) uses C(SET GLOBAL).
       - C(persist) uses C(SET PERSIST) and depends on MySQL 8.0 or later support for that statement.
-      - In this module, C(persist) is supported only for MySQL and is rejected for MariaDB.
+      - For C(server_cert), C(server_key), C(server_ca), and C(tls_version), runtime writes require MySQL 8.0.16 or later.
     type: str
     choices:
       - global
       - persist
     default: global
-    version_added: '5.2.0'
 
 attributes:
   check_mode:
@@ -80,9 +72,7 @@ attributes:
     support: full
 
 notes:
-  - MariaDB support in this module is limited to runtime C(require_secure_transport).
-  - On MariaDB, O(server_cert), O(server_key), O(server_ca), O(tls_version), O(reload),
-    and O(mode=persist) are not supported by this module.
+  - On MySQL, O(server_cert), O(server_key), O(server_ca), O(tls_version), and O(reload) require MySQL 8.0.16 or later for runtime management.
 
 extends_documentation_fragment:
   - ansible.mysql.mysql
@@ -131,11 +121,13 @@ from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.ansible.mysql.plugins.module_utils.database import mysql_quote_identifier
 from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
     get_server_implementation,
+    get_server_version,
     mysql_common_argument_spec,
     mysql_connect,
     mysql_driver,
     mysql_driver_fail_msg,
 )
+from ansible_collections.ansible.mysql.plugins.module_utils.version import LooseVersion
 
 
 PARAM_TO_VAR = {
@@ -146,13 +138,12 @@ PARAM_TO_VAR = {
     'tls_version': 'tls_version',
 }
 
-SUPPORTED_SETTINGS = {
-    'mysql': tuple(PARAM_TO_VAR.keys()),
-    'mariadb': ('require_secure_transport',),
-}
+SUPPORTED_SETTINGS = tuple(PARAM_TO_VAR.keys())
 
 MODE_CHOICES = ('global', 'persist')
 RELOAD_QUERY = 'ALTER INSTANCE RELOAD TLS'
+MYSQL_DYNAMIC_TLS_MIN_VERSION = '8.0.16'
+MYSQL_DYNAMIC_TLS_SETTINGS = ('server_cert', 'server_key', 'server_ca', 'tls_version')
 
 
 def get_variable(cursor, mysqlvar):
@@ -190,17 +181,20 @@ def set_variable(cursor, mysqlvar, value, mode, executed_queries):
         cursor.execute(query + "%s", (value,))
         cursor.fetchall()
     except Exception as e:
-        return to_native(e)
+        if mysql_driver is not None and isinstance(e, mysql_driver.Error):
+            return to_native(e)
+        raise
 
     executed_queries.append(query + format_query_value(value))
     return True
 
 
 class MySQLTLS(object):
-    def __init__(self, module, cursor, server_implementation):
+    def __init__(self, module, cursor, server_implementation, server_version=None):
         self.module = module
         self.cursor = cursor
         self.server_implementation = server_implementation
+        self.server_version = server_version
 
     def configure(self, desired_settings, reload=False, mode='global', check_mode=False):
         self.validate_server_support(desired_settings, reload, mode)
@@ -242,39 +236,50 @@ class MySQLTLS(object):
                 self.cursor.execute(RELOAD_QUERY)
                 self.cursor.fetchall()
             except Exception as e:
-                self.module.fail_json(msg="Cannot execute SQL '%s': %s" % (RELOAD_QUERY, to_native(e)))
+                if mysql_driver is not None and isinstance(e, mysql_driver.Error):
+                    self.module.fail_json(msg="Cannot execute SQL '%s': %s" % (RELOAD_QUERY, to_native(e)))
+                raise
 
             queries.append(RELOAD_QUERY)
 
         return dict(changed=changed, queries=queries, settings=effective_settings)
 
     def validate_server_support(self, desired_settings, reload, mode):
-        if self.server_implementation != 'mariadb':
+        if self.server_implementation != 'mysql':
+            self.module.fail_json(msg='mysql_tls supports MySQL only.', changed=False)
+
+        self.validate_mysql_tls_context_support(desired_settings, reload)
+
+    def validate_mysql_tls_context_support(self, desired_settings, reload):
+        if self.server_version is None:
             return
 
-        if mode == 'persist':
-            self.module.fail_json(
-                msg='MariaDB does not support mysql_tls mode "persist"',
-                changed=False,
-            )
+        if LooseVersion(self.server_version) >= LooseVersion(MYSQL_DYNAMIC_TLS_MIN_VERSION):
+            return
 
         unsupported_settings = [
             setting_name for setting_name, value in desired_settings.items()
-            if value is not None and setting_name not in SUPPORTED_SETTINGS['mariadb']
+            if value is not None and setting_name in MYSQL_DYNAMIC_TLS_SETTINGS
         ]
         if unsupported_settings:
             self.module.fail_json(
-                msg='MariaDB does not support mysql_tls setting "%s"' % unsupported_settings[0],
+                msg='mysql_tls setting "%s" requires MySQL %s or newer' % (
+                    unsupported_settings[0],
+                    MYSQL_DYNAMIC_TLS_MIN_VERSION,
+                ),
                 changed=False,
             )
 
         if reload:
-            self.module.fail_json(msg='MariaDB does not support mysql_tls reload', changed=False)
+            self.module.fail_json(
+                msg='mysql_tls reload requires MySQL %s or newer' % MYSQL_DYNAMIC_TLS_MIN_VERSION,
+                changed=False,
+            )
 
     def get_current_settings(self):
         settings = {}
 
-        for setting_name in SUPPORTED_SETTINGS[self.server_implementation]:
+        for setting_name in SUPPORTED_SETTINGS:
             variable_name = PARAM_TO_VAR[setting_name]
             value = get_variable(self.cursor, variable_name)
             if value is None:
@@ -355,7 +360,13 @@ def main():
         'tls_version': module.params['tls_version'],
     }
 
-    tls = MySQLTLS(module, cursor, get_server_implementation(cursor))
+    server_version = get_server_version(cursor)
+    tls = MySQLTLS(
+        module,
+        cursor,
+        get_server_implementation(cursor),
+        server_version=server_version,
+    )
 
     module.exit_json(
         **tls.configure(

--- a/tests/integration/setup_tls_harness.sh
+++ b/tests/integration/setup_tls_harness.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <docker|podman> <container> [container...]" >&2
+    exit 1
+fi
+
+runtime="$1"
+shift
+containers=("$@")
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+cat >"$tmpdir/openssl.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+CN = localhost
+
+[v3_req]
+basicConstraints = critical,CA:TRUE
+keyUsage = critical,digitalSignature,keyEncipherment,keyCertSign
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+IP.1 = 127.0.0.1
+EOF
+
+openssl req -x509 -nodes -newkey rsa:2048 \
+    -keyout "$tmpdir/server-key.pem" \
+    -out "$tmpdir/server-cert.pem" \
+    -days 1 \
+    -config "$tmpdir/openssl.cnf" >/dev/null 2>&1
+
+cp "$tmpdir/server-cert.pem" "$tmpdir/ca.pem"
+
+for container in "${containers[@]}"; do
+    "$runtime" exec "$container" sh -c 'mkdir -p /etc/mysql/tls'
+    "$runtime" cp "$tmpdir/server-cert.pem" "$container:/etc/mysql/tls/server-cert.pem"
+    "$runtime" cp "$tmpdir/server-key.pem" "$container:/etc/mysql/tls/server-key.pem"
+    "$runtime" cp "$tmpdir/ca.pem" "$container:/etc/mysql/tls/ca.pem"
+
+    printf '%s\n' \
+        '[mysqld]' \
+        'ssl_ca=/etc/mysql/tls/ca.pem' \
+        'ssl_cert=/etc/mysql/tls/server-cert.pem' \
+        'ssl_key=/etc/mysql/tls/server-key.pem' \
+        'require_secure_transport=OFF' \
+        | "$runtime" exec -i "$container" sh -c 'cat > /etc/mysql/conf.d/tls.cnf'
+
+    "$runtime" exec "$container" sh -c \
+        'chown mysql:mysql /etc/mysql/tls/ca.pem /etc/mysql/tls/server-cert.pem /etc/mysql/tls/server-key.pem && chmod 0644 /etc/mysql/tls/ca.pem /etc/mysql/tls/server-cert.pem && chmod 0600 /etc/mysql/tls/server-key.pem'
+done

--- a/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_db/tasks/issue-28.yml
@@ -1,9 +1,9 @@
 ---
 - name: set fact tls_enabled
-  command: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
+  command: "{{ mysql_command }} \"-Nse SHOW VARIABLES LIKE 'ssl_ca';\""
   register: result
 - set_fact:
-    tls_enabled: "{{ 'YES' in result.stdout | bool | default('false', true) }}"
+    tls_enabled: "{{ result.stdout is search('ssl_ca\\s+.+') }}"
 
 - vars:
     mysql_parameters: &mysql_params
@@ -17,9 +17,8 @@
     # ============================================================
     - name: get server certificate
       copy:
-        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect {{ mysql_host }}:{{ mysql_primary_port }} -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
         dest: /tmp/cert.pem
-      delegate_to: localhost
 
     - name: Drop mysql user if exists
       mysql_user:

--- a/tests/integration/targets/test_mysql_info/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/issue-28.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: set fact tls_enabled
-  command: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
+  command: "{{ mysql_command }} \"-Nse SHOW VARIABLES LIKE 'ssl_ca';\""
   register: result
 - set_fact:
-    tls_enabled: "{{ 'YES' in result.stdout | bool | default('false', true) }}"
+    tls_enabled: "{{ result.stdout is search('ssl_ca\\s+.+') }}"
 
 - vars:
     mysql_parameters: &mysql_params
@@ -18,9 +18,8 @@
     # ============================================================
     - name: get server certificate
       copy:
-        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect {{ mysql_host }}:{{ mysql_primary_port }} -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
         dest: /tmp/cert.pem
-      delegate_to: localhost
 
     - name: Drop mysql user if exists
       mysql_user:

--- a/tests/integration/targets/test_mysql_query/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_query/tasks/issue-28.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: set fact tls_enabled
-  command: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
+  command: "{{ mysql_command }} \"-Nse SHOW VARIABLES LIKE 'ssl_ca';\""
   register: result
 - set_fact:
-    tls_enabled: "{{ 'YES' in result.stdout | bool | default('false', true) }}"
+    tls_enabled: "{{ result.stdout is search('ssl_ca\\s+.+') }}"
 
 - vars:
     mysql_parameters: &mysql_params
@@ -18,9 +18,8 @@
     # ============================================================
     - name: get server certificate
       copy:
-        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect {{ mysql_host }}:{{ mysql_primary_port }} -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
         dest: /tmp/cert.pem
-      delegate_to: localhost
 
     - name: Drop mysql user if exists
       mysql_user:

--- a/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: set fact tls_enabled
-  command: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
+  command: "{{ mysql_command }} \"-Nse SHOW VARIABLES LIKE 'ssl_ca';\""
   register: result
 - set_fact:
-    tls_enabled: "{{ 'YES' in result.stdout | bool | default('false', true) }}"
+    tls_enabled: "{{ result.stdout is search('ssl_ca\\s+.+') }}"
 
 - vars:
     mysql_parameters: &mysql_params
@@ -18,9 +18,8 @@
     # ============================================================
     - name: get server certificate
       copy:
-        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect {{ mysql_host }}:{{ mysql_primary_port }} -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
         dest: /tmp/cert.pem
-      delegate_to: localhost
 
     - name: Drop mysql user if exists
       mysql_user:

--- a/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_replication/tasks/issue-28.yml
@@ -33,6 +33,7 @@
       mysql_user:
         <<: *mysql_params
         name: "{{ user_name_1 }}"
+        host: "%"
         password: "{{ user_password_1 }}"
         priv: '*.*:ALL,GRANT'
         tls_requires:
@@ -81,5 +82,5 @@
       mysql_user:
         <<: *mysql_params
         name: '{{ user_name_1 }}'
-        host: '{{ gateway_addr }}'
+        host_all: true
         state: absent

--- a/tests/integration/targets/test_mysql_tls/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_tls/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for test_mysql_tls
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_tls/meta/main.yml
+++ b/tests/integration/targets/test_mysql_tls/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_tls/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_tls/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: MySQL TLS | Run integration checks
+  ansible.builtin.import_tasks: mysql_tls.yml

--- a/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
+++ b/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
@@ -1,0 +1,770 @@
+---
+# test code for the mysql_tls module
+#
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: MySQL TLS | Detect TLS support
+  ansible.builtin.command: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
+  register: mysql_tls_have_ssl
+  changed_when: false
+
+- name: MySQL TLS | Set TLS support fact
+  ansible.builtin.set_fact:
+    mysql_tls_tls_enabled: "{{ 'YES' in mysql_tls_have_ssl.stdout }}"
+
+- name: MySQL TLS | Extract server certificate for TLS-only connection tests
+  ansible.builtin.copy:
+    content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect \" ~ mysql_host ~ \":\" ~ mysql_primary_port ~ \" -showcerts 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+    dest: /tmp/mysql_tls_server_cert.pem
+    mode: '0600'
+  delegate_to: localhost
+  when: mysql_tls_tls_enabled
+
+- vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+    mysql_tls_parameters: &mysql_tls_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+      ca_cert: /tmp/mysql_tls_server_cert.pem
+      check_hostname: no
+    mysql_tls_dummy_server_cert: /tmp/mysql_tls-server-cert.pem
+    mysql_tls_dummy_server_key: /tmp/mysql_tls-server-key.pem
+    mysql_tls_dummy_server_ca: /tmp/mysql_tls-ca-cert.pem
+
+  when: db_engine == 'mysql'
+  block:
+
+    - name: MySQL TLS | Get baseline settings (no changes expected)
+      mysql_tls:
+        <<: *mysql_params
+      register: mysql_tls_initial
+
+    - name: MySQL TLS | Assert no-op baseline result
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_initial is not changed
+          - mysql_tls_initial.queries == []
+          - "'server_cert' in mysql_tls_initial.settings"
+          - "'server_key' in mysql_tls_initial.settings"
+          - "'server_ca' in mysql_tls_initial.settings"
+          - "'require_secure_transport' in mysql_tls_initial.settings"
+          - "'tls_version' in mysql_tls_initial.settings"
+
+    - name: MySQL TLS | Read baseline persisted tls_version state
+      mysql_query:
+        <<: *mysql_params
+        query: "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'tls_version'"
+      register: mysql_tls_initial_persisted_version
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Set baseline persisted tls_version facts
+      ansible.builtin.set_fact:
+        mysql_tls_initial_persisted_version_present: "{{ mysql_tls_initial_persisted_version.query_result[0] | length == 1 }}"
+        mysql_tls_initial_persisted_version_value: "{{ (mysql_tls_initial_persisted_version.query_result[0] | length == 1) | ternary(mysql_tls_initial_persisted_version.query_result[0][0].persisted_value, '') }}"
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Set alternate tls_version for change-driven tests
+      ansible.builtin.set_fact:
+        mysql_tls_alt_version: "{{ 'TLSv1.2,TLSv1.3' if mysql_tls_initial.settings.tls_version == 'TLSv1.3' else 'TLSv1.3' }}"
+
+    # ============================================================
+    # Test: tls_version in check mode, including reload prediction
+    # ============================================================
+
+    - name: MySQL TLS | Predict tls_version change in check mode
+      mysql_tls:
+        <<: *mysql_params
+        tls_version: "{{ mysql_tls_alt_version }}"
+      check_mode: true
+      register: mysql_tls_version_check_mode
+
+    - name: MySQL TLS | Verify tls_version after check mode
+      mysql_variables:
+        <<: *mysql_params
+        variable: tls_version
+      register: mysql_tls_version_after_check_mode
+
+    - name: MySQL TLS | Assert tls_version check mode did not mutate state
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_version_check_mode is changed
+          - mysql_tls_version_check_mode.queries | length == 1
+          - mysql_tls_version_check_mode.queries[0] is search('^SET GLOBAL `tls_version` = ')
+          - mysql_tls_version_after_check_mode.msg == mysql_tls_initial.settings.tls_version
+
+    - name: MySQL TLS | Predict tls_version change with reload in check mode
+      mysql_tls:
+        <<: *mysql_params
+        tls_version: "{{ mysql_tls_alt_version }}"
+        reload: true
+      check_mode: true
+      register: mysql_tls_version_reload_check_mode
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Verify tls_version after reload check mode
+      mysql_variables:
+        <<: *mysql_params
+        variable: tls_version
+      register: mysql_tls_version_after_reload_check_mode
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Assert reload prediction in check mode did not mutate state
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_version_reload_check_mode is changed
+          - mysql_tls_version_reload_check_mode.queries | length == 2
+          - mysql_tls_version_reload_check_mode.queries[0] is search('^SET GLOBAL `tls_version` = ')
+          - "'ALTER INSTANCE RELOAD TLS' in mysql_tls_version_reload_check_mode.queries"
+          - mysql_tls_version_after_reload_check_mode.msg == mysql_tls_initial.settings.tls_version
+      when: db_version is version('8.0.16', '>=')
+
+    # Try a real TLS connection path first. If the harness does not expose TLS,
+    # fall back to check_mode coverage rather than forcing an impossible path.
+    - name: MySQL TLS | Enable require_secure_transport
+      mysql_tls:
+        <<: *mysql_params
+        require_secure_transport: true
+      register: mysql_tls_require_secure_transport
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Assert require_secure_transport enable result
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_require_secure_transport is changed
+          - "'SET GLOBAL `require_secure_transport` = ON' in mysql_tls_require_secure_transport.queries"
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Re-run require_secure_transport enable for idempotency
+      mysql_tls:
+        <<: *mysql_tls_params
+        require_secure_transport: true
+      register: mysql_tls_require_secure_transport_idempotency
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Assert require_secure_transport enable idempotency
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_require_secure_transport_idempotency is not changed
+          - mysql_tls_require_secure_transport_idempotency.queries == []
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Plain TCP connection should fail when secure transport is required
+      mysql_query:
+        <<: *mysql_params
+        query: "SELECT 1 AS plain_connection"
+      register: mysql_tls_plain_query_when_secure
+      ignore_errors: true
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Assert plaintext connection is rejected
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_plain_query_when_secure is failed
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | TLS connection should succeed when secure transport is required
+      mysql_query:
+        <<: *mysql_tls_params
+        query: "SELECT 1 AS tls_connection"
+      register: mysql_tls_secure_query
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Assert TLS connection succeeds
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_secure_query is succeeded
+          - mysql_tls_secure_query.query_result[0][0].tls_connection | int == 1
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Disable require_secure_transport over TLS
+      mysql_tls:
+        <<: *mysql_tls_params
+        require_secure_transport: false
+      register: mysql_tls_disable_secure_transport
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Assert require_secure_transport was disabled safely
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_disable_secure_transport is changed
+          - "'SET GLOBAL `require_secure_transport` = OFF' in mysql_tls_disable_secure_transport.queries"
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Re-run require_secure_transport disable for idempotency
+      mysql_tls:
+        <<: *mysql_params
+        require_secure_transport: false
+      register: mysql_tls_disable_secure_transport_idempotency
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Assert require_secure_transport disable idempotency
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_disable_secure_transport_idempotency is not changed
+          - mysql_tls_disable_secure_transport_idempotency.queries == []
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Plain TCP connection should work again after disabling secure transport
+      mysql_query:
+        <<: *mysql_params
+        query: "SELECT 1 AS plain_connection_after_disable"
+      register: mysql_tls_plain_query_after_disable
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Assert plain TCP connection works again
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_plain_query_after_disable is succeeded
+          - mysql_tls_plain_query_after_disable.query_result[0][0].plain_connection_after_disable | int == 1
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Check require_secure_transport in check mode when TLS is unavailable
+      mysql_tls:
+        <<: *mysql_params
+        require_secure_transport: true
+      check_mode: true
+      register: mysql_tls_require_secure_transport_check
+      when: not mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Assert check mode fallback for require_secure_transport
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_require_secure_transport_check is changed
+          - "'SET GLOBAL `require_secure_transport` = ON' in mysql_tls_require_secure_transport_check.queries"
+      when: not mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Verify require_secure_transport stayed unchanged after check mode fallback
+      mysql_variables:
+        <<: *mysql_params
+        variable: require_secure_transport
+      register: mysql_tls_require_secure_transport_after_check
+      when: not mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Assert require_secure_transport remained unchanged
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_require_secure_transport_after_check.msg == mysql_tls_initial.settings.require_secure_transport
+      when: not mysql_tls_tls_enabled
+
+    # ============================================================
+    # Test: persist mode with a guaranteed runtime change
+    # ============================================================
+
+    - name: MySQL TLS | Set tls_version in persist mode
+      mysql_tls:
+        <<: *mysql_params
+        tls_version: "{{ mysql_tls_alt_version }}"
+        mode: persist
+      register: mysql_tls_persist_result
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Verify tls_version after persist mode
+      mysql_variables:
+        <<: *mysql_params
+        variable: tls_version
+      register: mysql_tls_version_after_persist
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Read persisted tls_version value
+      mysql_query:
+        <<: *mysql_params
+        query: "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'tls_version'"
+      register: mysql_tls_persisted_version
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Assert persist mode result
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_persist_result is changed
+          - mysql_tls_persist_result.queries | length == 1
+          - mysql_tls_persist_result.queries[0] is search('^SET PERSIST `tls_version` = ')
+          - mysql_tls_version_after_persist.msg == mysql_tls_alt_version
+          - mysql_tls_persisted_version.query_result[0] | length == 1
+          - mysql_tls_persisted_version.query_result[0][0].persisted_value == mysql_tls_alt_version
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Re-run tls_version persist mode for idempotency
+      mysql_tls:
+        <<: *mysql_params
+        tls_version: "{{ mysql_tls_alt_version }}"
+        mode: persist
+      register: mysql_tls_persist_idempotency
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Assert persist mode idempotency
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_persist_idempotency is not changed
+          - mysql_tls_persist_idempotency.queries == []
+      when: db_version is version('8.0', '>=')
+
+    # ============================================================
+    # Test: reload does not run when nothing changes
+    # ============================================================
+
+    - name: MySQL TLS | Request reload with no tls_version change
+      mysql_tls:
+        <<: *mysql_params
+        tls_version: "{{ mysql_tls_alt_version }}"
+        reload: true
+      register: mysql_tls_reload_no_change
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Assert no-op reload emits no ALTER query
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_reload_no_change is not changed
+          - mysql_tls_reload_no_change.queries == []
+      when: db_version is version('8.0.16', '>=')
+
+    # ============================================================
+    # Test: tls_version runtime change without reload
+    # ============================================================
+
+    - name: MySQL TLS | Set runtime-change tls_version target
+      ansible.builtin.set_fact:
+        mysql_tls_runtime_change_target: "{{ mysql_tls_initial.settings.tls_version if db_version is version('8.0', '>=') else mysql_tls_alt_version }}"
+
+    - name: MySQL TLS | Set tls_version without reload
+      mysql_tls:
+        <<: *mysql_params
+        tls_version: "{{ mysql_tls_runtime_change_target }}"
+      register: mysql_tls_version_result
+
+    - name: MySQL TLS | Verify tls_version after runtime change
+      mysql_variables:
+        <<: *mysql_params
+        variable: tls_version
+      register: mysql_tls_version_after_runtime_change
+
+    - name: MySQL TLS | Assert tls_version runtime change
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_version_result is changed
+          - "'SET GLOBAL `tls_version` =' in (mysql_tls_version_result.queries | join(' '))"
+          - "'ALTER INSTANCE RELOAD TLS' not in mysql_tls_version_result.queries"
+          - mysql_tls_version_after_runtime_change.msg == mysql_tls_runtime_change_target
+
+    - name: MySQL TLS | Re-run tls_version runtime change for idempotency
+      mysql_tls:
+        <<: *mysql_params
+        tls_version: "{{ mysql_tls_runtime_change_target }}"
+      register: mysql_tls_version_idempotency
+
+    - name: MySQL TLS | Assert tls_version runtime change idempotency
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_version_idempotency is not changed
+          - mysql_tls_version_idempotency.queries == []
+
+    # ============================================================
+    # Test: explicit reload with a real tls_version change
+    # ============================================================
+
+    - name: MySQL TLS | Set tls_version with explicit reload
+      mysql_tls:
+        <<: *mysql_params
+        tls_version: "{{ mysql_tls_alt_version }}"
+        reload: true
+      register: mysql_tls_reload_result
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Verify tls_version after explicit reload
+      mysql_variables:
+        <<: *mysql_params
+        variable: tls_version
+      register: mysql_tls_version_after_reload
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Assert explicit reload result
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_reload_result is changed
+          - "'ALTER INSTANCE RELOAD TLS' in mysql_tls_reload_result.queries"
+          - mysql_tls_version_after_reload.msg == mysql_tls_alt_version
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Re-run explicit reload change for idempotency
+      mysql_tls:
+        <<: *mysql_params
+        tls_version: "{{ mysql_tls_alt_version }}"
+        reload: true
+      register: mysql_tls_reload_idempotency
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Assert explicit reload idempotency
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_reload_idempotency is not changed
+          - mysql_tls_reload_idempotency.queries == []
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Set certificate paths
+      mysql_tls:
+        <<: *mysql_params
+        server_cert: "{{ mysql_tls_dummy_server_cert }}"
+        server_key: "{{ mysql_tls_dummy_server_key }}"
+        server_ca: "{{ mysql_tls_dummy_server_ca }}"
+      register: mysql_tls_cert_paths_result
+
+    - name: MySQL TLS | Verify ssl_cert after certificate path change
+      mysql_variables:
+        <<: *mysql_params
+        variable: ssl_cert
+      register: mysql_tls_ssl_cert
+
+    - name: MySQL TLS | Verify ssl_key after certificate path change
+      mysql_variables:
+        <<: *mysql_params
+        variable: ssl_key
+      register: mysql_tls_ssl_key
+
+    - name: MySQL TLS | Verify ssl_ca after certificate path change
+      mysql_variables:
+        <<: *mysql_params
+        variable: ssl_ca
+      register: mysql_tls_ssl_ca
+
+    - name: MySQL TLS | Assert certificate path change
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_cert_paths_result is changed
+          - "'SET GLOBAL `ssl_cert` =' in (mysql_tls_cert_paths_result.queries | join(' '))"
+          - "'SET GLOBAL `ssl_key` =' in (mysql_tls_cert_paths_result.queries | join(' '))"
+          - "'SET GLOBAL `ssl_ca` =' in (mysql_tls_cert_paths_result.queries | join(' '))"
+          - mysql_tls_ssl_cert.msg == mysql_tls_dummy_server_cert
+          - mysql_tls_ssl_key.msg == mysql_tls_dummy_server_key
+          - mysql_tls_ssl_ca.msg == mysql_tls_dummy_server_ca
+
+    - name: MySQL TLS | Re-run certificate path change for idempotency
+      mysql_tls:
+        <<: *mysql_params
+        server_cert: "{{ mysql_tls_dummy_server_cert }}"
+        server_key: "{{ mysql_tls_dummy_server_key }}"
+        server_ca: "{{ mysql_tls_dummy_server_ca }}"
+      register: mysql_tls_cert_paths_idempotency
+
+    - name: MySQL TLS | Assert certificate path idempotency
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_cert_paths_idempotency is not changed
+          - mysql_tls_cert_paths_idempotency.queries == []
+
+    - name: MySQL TLS | Change certificate path in check mode
+      mysql_tls:
+        <<: *mysql_params
+        server_cert: /tmp/mysql_tls-check-mode-cert.pem
+      check_mode: true
+      register: mysql_tls_cert_check_mode
+
+    - name: MySQL TLS | Verify ssl_cert after check mode
+      mysql_variables:
+        <<: *mysql_params
+        variable: ssl_cert
+      register: mysql_tls_ssl_cert_after_check_mode
+
+    - name: MySQL TLS | Assert check mode did not mutate ssl_cert
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_cert_check_mode is changed
+          - mysql_tls_cert_check_mode.queries | length == 1
+          - mysql_tls_cert_check_mode.queries[0] is search('^SET GLOBAL `ssl_cert` = ')
+          - mysql_tls_ssl_cert_after_check_mode.msg == mysql_tls_dummy_server_cert
+
+    - name: MySQL TLS | Restore baseline runtime settings
+      mysql_tls:
+        <<: *mysql_params
+        server_cert: "{{ mysql_tls_initial.settings.server_cert }}"
+        server_key: "{{ mysql_tls_initial.settings.server_key }}"
+        server_ca: "{{ mysql_tls_initial.settings.server_ca }}"
+        require_secure_transport: "{{ mysql_tls_initial.settings.require_secure_transport == 'ON' }}"
+        tls_version: "{{ mysql_tls_initial.settings.tls_version }}"
+      register: mysql_tls_restore_result
+
+    - name: MySQL TLS | Restore baseline persisted tls_version value
+      mysql_variables:
+        <<: *mysql_params
+        variable: tls_version
+        value: "{{ mysql_tls_initial_persisted_version_value }}"
+        mode: persist_only
+      register: mysql_tls_restore_persisted_version
+      when:
+        - db_version is version('8.0', '>=')
+        - mysql_tls_initial_persisted_version_present
+
+    - name: MySQL TLS | Remove persisted tls_version when baseline had none
+      mysql_query:
+        <<: *mysql_params
+        query: "RESET PERSIST tls_version"
+      register: mysql_tls_reset_persisted_version
+      when:
+        - db_version is version('8.0', '>=')
+        - not mysql_tls_initial_persisted_version_present
+
+    - name: MySQL TLS | Read persisted tls_version after cleanup
+      mysql_query:
+        <<: *mysql_params
+        query: "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'tls_version'"
+      register: mysql_tls_persisted_version_after_cleanup
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Re-read runtime settings after restore
+      mysql_tls:
+        <<: *mysql_params
+      register: mysql_tls_restored
+
+    - name: MySQL TLS | Assert baseline settings were restored
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_restored is not changed
+          - mysql_tls_restored.settings == mysql_tls_initial.settings
+
+    - name: MySQL TLS | Re-run baseline runtime restore for idempotency
+      mysql_tls:
+        <<: *mysql_params
+        server_cert: "{{ mysql_tls_initial.settings.server_cert }}"
+        server_key: "{{ mysql_tls_initial.settings.server_key }}"
+        server_ca: "{{ mysql_tls_initial.settings.server_ca }}"
+        require_secure_transport: "{{ mysql_tls_initial.settings.require_secure_transport == 'ON' }}"
+        tls_version: "{{ mysql_tls_initial.settings.tls_version }}"
+      register: mysql_tls_restore_idempotency
+
+    - name: MySQL TLS | Assert baseline runtime restore idempotency
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_restore_idempotency is not changed
+          - mysql_tls_restore_idempotency.queries == []
+
+    - name: MySQL TLS | Assert persisted tls_version row was restored
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_persisted_version_after_cleanup.query_result[0] | length == 1
+          - mysql_tls_persisted_version_after_cleanup.query_result[0][0].persisted_value == mysql_tls_initial_persisted_version_value
+      when:
+        - db_version is version('8.0', '>=')
+        - mysql_tls_initial_persisted_version_present
+
+    - name: MySQL TLS | Assert persisted tls_version row was removed
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_persisted_version_after_cleanup.query_result[0] | length == 0
+      when: db_version is version('8.0', '>=')
+
+- vars:
+    mysql_parameters: &mysql_params_mariadb
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+    mysql_tls_parameters: &mysql_tls_params_mariadb
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+      ca_cert: /tmp/mysql_tls_server_cert.pem
+      check_hostname: no
+
+  when: db_engine == 'mariadb'
+  block:
+
+    - name: MariaDB TLS | Get baseline settings (no changes expected)
+      mysql_tls:
+        <<: *mysql_params_mariadb
+      register: mariadb_tls_initial
+
+    - name: MariaDB TLS | Assert baseline result
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_initial is not changed
+          - mariadb_tls_initial.queries == []
+          - "'require_secure_transport' in mariadb_tls_initial.settings"
+
+    # Try a real TLS connection path first. If the harness does not expose TLS,
+    # fall back to check_mode coverage instead of asserting an impossible path.
+    - name: MariaDB TLS | Enable require_secure_transport
+      mysql_tls:
+        <<: *mysql_params_mariadb
+        require_secure_transport: true
+      register: mariadb_tls_require_secure_transport
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Assert require_secure_transport enable result
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_require_secure_transport is changed
+          - "'SET GLOBAL `require_secure_transport` = ON' in mariadb_tls_require_secure_transport.queries"
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Re-run require_secure_transport enable for idempotency
+      mysql_tls:
+        <<: *mysql_tls_params_mariadb
+        require_secure_transport: true
+      register: mariadb_tls_require_secure_transport_idempotency
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Assert require_secure_transport enable idempotency
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_require_secure_transport_idempotency is not changed
+          - mariadb_tls_require_secure_transport_idempotency.queries == []
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Plain TCP connection should fail when secure transport is required
+      mysql_query:
+        <<: *mysql_params_mariadb
+        query: "SELECT 1 AS plain_connection"
+      register: mariadb_tls_plain_query_when_secure
+      ignore_errors: true
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Assert plaintext connection is rejected
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_plain_query_when_secure is failed
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | TLS connection should succeed when secure transport is required
+      mysql_query:
+        <<: *mysql_tls_params_mariadb
+        query: "SELECT 1 AS tls_connection"
+      register: mariadb_tls_secure_query
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Assert TLS connection succeeds
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_secure_query is succeeded
+          - mariadb_tls_secure_query.query_result[0][0].tls_connection | int == 1
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Disable require_secure_transport over TLS
+      mysql_tls:
+        <<: *mysql_tls_params_mariadb
+        require_secure_transport: false
+      register: mariadb_tls_disable_secure_transport
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Assert require_secure_transport was disabled safely
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_disable_secure_transport is changed
+          - "'SET GLOBAL `require_secure_transport` = OFF' in mariadb_tls_disable_secure_transport.queries"
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Re-run require_secure_transport disable for idempotency
+      mysql_tls:
+        <<: *mysql_params_mariadb
+        require_secure_transport: false
+      register: mariadb_tls_disable_secure_transport_idempotency
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Assert require_secure_transport disable idempotency
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_disable_secure_transport_idempotency is not changed
+          - mariadb_tls_disable_secure_transport_idempotency.queries == []
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Plain TCP connection should work again after disabling secure transport
+      mysql_query:
+        <<: *mysql_params_mariadb
+        query: "SELECT 1 AS plain_connection_after_disable"
+      register: mariadb_tls_plain_query_after_disable
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Assert plain TCP connection works again
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_plain_query_after_disable is succeeded
+          - mariadb_tls_plain_query_after_disable.query_result[0][0].plain_connection_after_disable | int == 1
+      when: mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Check require_secure_transport in check mode when TLS is unavailable
+      mysql_tls:
+        <<: *mysql_params_mariadb
+        require_secure_transport: true
+      check_mode: true
+      register: mariadb_tls_require_secure_transport_check
+      when: not mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Assert check mode fallback for require_secure_transport
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_require_secure_transport_check is changed
+          - "'SET GLOBAL `require_secure_transport` = ON' in mariadb_tls_require_secure_transport_check.queries"
+      when: not mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Verify require_secure_transport stayed unchanged after check mode fallback
+      mysql_variables:
+        <<: *mysql_params_mariadb
+        variable: require_secure_transport
+      register: mariadb_tls_require_secure_transport_after_check
+      when: not mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | Assert require_secure_transport remained unchanged
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_require_secure_transport_after_check.msg == mariadb_tls_initial.settings.require_secure_transport
+      when: not mysql_tls_tls_enabled
+
+    - name: MariaDB TLS | server_cert should fail clearly
+      mysql_tls:
+        <<: *mysql_params_mariadb
+        server_cert: /tmp/mysql_tls-server-cert.pem
+      register: mariadb_tls_server_cert_failure
+      ignore_errors: true
+
+    - name: MariaDB TLS | Assert server_cert failure message
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_server_cert_failure is failed
+          - "'mariadb' in (mariadb_tls_server_cert_failure.msg | lower)"
+          - "'server_cert' in mariadb_tls_server_cert_failure.msg"
+
+    - name: MariaDB TLS | reload should fail clearly
+      mysql_tls:
+        <<: *mysql_params_mariadb
+        require_secure_transport: true
+        reload: true
+      register: mariadb_tls_reload_failure
+      ignore_errors: true
+
+    - name: MariaDB TLS | Assert reload failure message
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_reload_failure is failed
+          - "'mariadb' in (mariadb_tls_reload_failure.msg | lower)"
+          - "'reload' in (mariadb_tls_reload_failure.msg | lower)"
+
+    - name: MariaDB TLS | mode persist should fail clearly
+      mysql_tls:
+        <<: *mysql_params_mariadb
+        require_secure_transport: true
+        mode: persist
+      register: mariadb_tls_persist_failure
+      ignore_errors: true
+
+    - name: MariaDB TLS | Assert mode persist failure message
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_persist_failure is failed
+          - "'mariadb' in (mariadb_tls_persist_failure.msg | lower)"
+          - "'persist' in (mariadb_tls_persist_failure.msg | lower)"
+
+    - name: MariaDB TLS | Re-read runtime settings after tests
+      mysql_tls:
+        <<: *mysql_params_mariadb
+      register: mariadb_tls_restored
+
+    - name: MariaDB TLS | Assert baseline settings were restored
+      ansible.builtin.assert:
+        that:
+          - mariadb_tls_restored is not changed
+          - mariadb_tls_restored.settings == mariadb_tls_initial.settings

--- a/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
+++ b/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
@@ -18,7 +18,6 @@
     content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect \" ~ mysql_host ~ \":\" ~ mysql_primary_port ~ \" -showcerts 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
     dest: /tmp/mysql_tls_server_cert.pem
     mode: '0600'
-  delegate_to: localhost
   when: mysql_tls_tls_enabled
 
 - vars:

--- a/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
+++ b/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
@@ -623,10 +623,20 @@
       ignore_errors: true
       when: mysql_tls_tls_enabled
 
-    - name: MariaDB TLS | Assert plaintext connection is rejected
+    - name: MariaDB TLS | Check SSL status for implicit TLS connection
+      mysql_query:
+        <<: *mysql_params_mariadb
+        query: "SHOW STATUS LIKE 'Ssl_version'"
+      register: mariadb_tls_plain_query_ssl_status
+      when:
+        - mysql_tls_tls_enabled
+        - mariadb_tls_plain_query_when_secure is succeeded
+
+    - name: MariaDB TLS | Assert connection without explicit TLS options is rejected or encrypted
       ansible.builtin.assert:
         that:
-          - mariadb_tls_plain_query_when_secure is failed
+          - mariadb_tls_plain_query_when_secure is failed or mariadb_tls_plain_query_ssl_status.query_result[0] | length == 1
+          - mariadb_tls_plain_query_when_secure is failed or mariadb_tls_plain_query_ssl_status.query_result[0][0].Value | default('') | length > 0
       when: mysql_tls_tls_enabled
 
     - name: MariaDB TLS | TLS connection should succeed when secure transport is required

--- a/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
+++ b/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
@@ -5,13 +5,13 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: MySQL TLS | Detect TLS support
-  ansible.builtin.command: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
-  register: mysql_tls_have_ssl
+  ansible.builtin.command: "{{ mysql_command }} \"-Nse SHOW VARIABLES WHERE Variable_name IN ('ssl_ca', 'have_ssl');\""
+  register: mysql_tls_tls_status
   changed_when: false
 
 - name: MySQL TLS | Set TLS support fact
   ansible.builtin.set_fact:
-    mysql_tls_tls_enabled: "{{ 'YES' in mysql_tls_have_ssl.stdout }}"
+    mysql_tls_tls_enabled: "{{ 'have_ssl\tYES' in mysql_tls_tls_status.stdout or (mysql_tls_tls_status.stdout | regex_search('ssl_ca\\s+\\S+')) is not none }}"
 
 - name: MySQL TLS | Extract server certificate for TLS-only connection tests
   ansible.builtin.copy:
@@ -124,8 +124,12 @@
           - mysql_tls_version_after_reload_check_mode.msg == mysql_tls_initial.settings.tls_version
       when: db_version is version('8.0.16', '>=')
 
-    # Try a real TLS connection path first. If the harness does not expose TLS,
-    # fall back to check_mode coverage rather than forcing an impossible path.
+    - name: MySQL TLS | Assert test harness exposes TLS
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_tls_enabled | bool
+        fail_msg: test_mysql_tls requires harness-provisioned TLS for real transport checks.
+
     - name: MySQL TLS | Enable require_secure_transport
       mysql_tls:
         <<: *mysql_params
@@ -162,10 +166,20 @@
       ignore_errors: true
       when: mysql_tls_tls_enabled
 
-    - name: MySQL TLS | Assert plaintext connection is rejected
+    - name: MySQL TLS | Check SSL status for implicit TLS connection
+      mysql_query:
+        <<: *mysql_params
+        query: "SHOW STATUS LIKE 'Ssl_version'"
+      register: mysql_tls_plain_query_ssl_status
+      when:
+        - mysql_tls_tls_enabled
+        - mysql_tls_plain_query_when_secure is succeeded
+
+    - name: MySQL TLS | Assert connection without explicit TLS options is rejected or encrypted
       ansible.builtin.assert:
         that:
-          - mysql_tls_plain_query_when_secure is failed
+          - mysql_tls_plain_query_when_secure is failed or mysql_tls_plain_query_ssl_status.query_result[0] | length == 1
+          - mysql_tls_plain_query_when_secure is failed or mysql_tls_plain_query_ssl_status.query_result[0][0].Value | default('') | length > 0
       when: mysql_tls_tls_enabled
 
     - name: MySQL TLS | TLS connection should succeed when secure transport is required
@@ -223,34 +237,6 @@
           - mysql_tls_plain_query_after_disable is succeeded
           - mysql_tls_plain_query_after_disable.query_result[0][0].plain_connection_after_disable | int == 1
       when: mysql_tls_tls_enabled
-
-    - name: MySQL TLS | Check require_secure_transport in check mode when TLS is unavailable
-      mysql_tls:
-        <<: *mysql_params
-        require_secure_transport: true
-      check_mode: true
-      register: mysql_tls_require_secure_transport_check
-      when: not mysql_tls_tls_enabled
-
-    - name: MySQL TLS | Assert check mode fallback for require_secure_transport
-      ansible.builtin.assert:
-        that:
-          - mysql_tls_require_secure_transport_check is changed
-          - "'SET GLOBAL `require_secure_transport` = ON' in mysql_tls_require_secure_transport_check.queries"
-      when: not mysql_tls_tls_enabled
-
-    - name: MySQL TLS | Verify require_secure_transport stayed unchanged after check mode fallback
-      mysql_variables:
-        <<: *mysql_params
-        variable: require_secure_transport
-      register: mysql_tls_require_secure_transport_after_check
-      when: not mysql_tls_tls_enabled
-
-    - name: MySQL TLS | Assert require_secure_transport remained unchanged
-      ansible.builtin.assert:
-        that:
-          - mysql_tls_require_secure_transport_after_check.msg == mysql_tls_initial.settings.require_secure_transport
-      when: not mysql_tls_tls_enabled
 
     # ============================================================
     # Test: persist mode with a guaranteed runtime change
@@ -556,6 +542,52 @@
           - mysql_tls_persisted_version_after_cleanup.query_result[0] | length == 0
       when: db_version is version('8.0', '>=')
 
+  always:
+    - name: MySQL TLS | Always restore secure transport baseline
+      mysql_tls:
+        <<: *mysql_tls_params
+        require_secure_transport: "{{ mysql_tls_initial.settings.require_secure_transport == 'ON' }}"
+      when:
+        - mysql_tls_tls_enabled | default(false)
+        - mysql_tls_initial is defined
+        - mysql_tls_initial.settings is defined
+      ignore_errors: true
+
+    - name: MySQL TLS | Always restore runtime settings
+      mysql_tls:
+        <<: *mysql_params
+        server_cert: "{{ mysql_tls_initial.settings.server_cert }}"
+        server_key: "{{ mysql_tls_initial.settings.server_key }}"
+        server_ca: "{{ mysql_tls_initial.settings.server_ca }}"
+        require_secure_transport: "{{ mysql_tls_initial.settings.require_secure_transport == 'ON' }}"
+        tls_version: "{{ mysql_tls_initial.settings.tls_version }}"
+      when:
+        - mysql_tls_initial is defined
+        - mysql_tls_initial.settings is defined
+      ignore_errors: true
+
+    - name: MySQL TLS | Always restore persisted tls_version value
+      mysql_variables:
+        <<: *mysql_params
+        variable: tls_version
+        value: "{{ mysql_tls_initial_persisted_version_value }}"
+        mode: persist_only
+      when:
+        - db_version is version('8.0', '>=')
+        - mysql_tls_initial_persisted_version_present is defined
+        - mysql_tls_initial_persisted_version_present
+      ignore_errors: true
+
+    - name: MySQL TLS | Always remove persisted tls_version when baseline had none
+      mysql_query:
+        <<: *mysql_params
+        query: "RESET PERSIST tls_version"
+      when:
+        - db_version is version('8.0', '>=')
+        - mysql_tls_initial_persisted_version_present is defined
+        - not mysql_tls_initial_persisted_version_present
+      ignore_errors: true
+
 - vars:
     mysql_parameters: &mysql_params_mariadb
       login_user: '{{ mysql_user }}'
@@ -585,8 +617,12 @@
           - mariadb_tls_initial.queries == []
           - "'require_secure_transport' in mariadb_tls_initial.settings"
 
-    # Try a real TLS connection path first. If the harness does not expose TLS,
-    # fall back to check_mode coverage instead of asserting an impossible path.
+    - name: MariaDB TLS | Assert test harness exposes TLS
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_tls_enabled | bool
+        fail_msg: test_mysql_tls requires harness-provisioned TLS for real transport checks.
+
     - name: MariaDB TLS | Enable require_secure_transport
       mysql_tls:
         <<: *mysql_params_mariadb
@@ -695,34 +731,6 @@
           - mariadb_tls_plain_query_after_disable.query_result[0][0].plain_connection_after_disable | int == 1
       when: mysql_tls_tls_enabled
 
-    - name: MariaDB TLS | Check require_secure_transport in check mode when TLS is unavailable
-      mysql_tls:
-        <<: *mysql_params_mariadb
-        require_secure_transport: true
-      check_mode: true
-      register: mariadb_tls_require_secure_transport_check
-      when: not mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Assert check mode fallback for require_secure_transport
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_require_secure_transport_check is changed
-          - "'SET GLOBAL `require_secure_transport` = ON' in mariadb_tls_require_secure_transport_check.queries"
-      when: not mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Verify require_secure_transport stayed unchanged after check mode fallback
-      mysql_variables:
-        <<: *mysql_params_mariadb
-        variable: require_secure_transport
-      register: mariadb_tls_require_secure_transport_after_check
-      when: not mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Assert require_secure_transport remained unchanged
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_require_secure_transport_after_check.msg == mariadb_tls_initial.settings.require_secure_transport
-      when: not mysql_tls_tls_enabled
-
     - name: MariaDB TLS | server_cert should fail clearly
       mysql_tls:
         <<: *mysql_params_mariadb
@@ -777,3 +785,14 @@
         that:
           - mariadb_tls_restored is not changed
           - mariadb_tls_restored.settings == mariadb_tls_initial.settings
+
+  always:
+    - name: MariaDB TLS | Always restore secure transport baseline
+      mysql_tls:
+        <<: *mysql_tls_params_mariadb
+        require_secure_transport: "{{ mariadb_tls_initial.settings.require_secure_transport == 'ON' }}"
+      when:
+        - mysql_tls_tls_enabled | default(false)
+        - mariadb_tls_initial is defined
+        - mariadb_tls_initial.settings is defined
+      ignore_errors: true

--- a/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
+++ b/tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
@@ -69,9 +69,27 @@
         mysql_tls_initial_persisted_version_value: "{{ (mysql_tls_initial_persisted_version.query_result[0] | length == 1) | ternary(mysql_tls_initial_persisted_version.query_result[0][0].persisted_value, '') }}"
       when: db_version is version('8.0', '>=')
 
+    - name: MySQL TLS | Read baseline persisted require_secure_transport state
+      mysql_query:
+        <<: *mysql_params
+        query: "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'require_secure_transport'"
+      register: mysql_tls_initial_persisted_require_secure_transport
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Set baseline persisted require_secure_transport facts
+      ansible.builtin.set_fact:
+        mysql_tls_initial_persisted_require_secure_transport_present: "{{ mysql_tls_initial_persisted_require_secure_transport.query_result[0] | length == 1 }}"
+        mysql_tls_initial_persisted_require_secure_transport_value: "{{ (mysql_tls_initial_persisted_require_secure_transport.query_result[0] | length == 1) | ternary(mysql_tls_initial_persisted_require_secure_transport.query_result[0][0].persisted_value, '') }}"
+      when: db_version is version('8.0', '>=')
+
     - name: MySQL TLS | Set alternate tls_version for change-driven tests
       ansible.builtin.set_fact:
         mysql_tls_alt_version: "{{ 'TLSv1.2,TLSv1.3' if mysql_tls_initial.settings.tls_version == 'TLSv1.3' else 'TLSv1.3' }}"
+
+    - name: MySQL TLS | Set alternate require_secure_transport targets
+      ansible.builtin.set_fact:
+        mysql_tls_alt_require_secure_transport: "{{ mysql_tls_initial.settings.require_secure_transport != 'ON' }}"
+        mysql_tls_alt_require_secure_transport_value: "{{ 'OFF' if mysql_tls_initial.settings.require_secure_transport == 'ON' else 'ON' }}"
 
     # ============================================================
     # Test: tls_version in check mode, including reload prediction
@@ -129,6 +147,30 @@
         that:
           - mysql_tls_tls_enabled | bool
         fail_msg: test_mysql_tls requires harness-provisioned TLS for real transport checks.
+
+    - name: MySQL TLS | Predict require_secure_transport change in check mode
+      mysql_tls:
+        <<: *mysql_params
+        require_secure_transport: "{{ mysql_tls_alt_require_secure_transport }}"
+      check_mode: true
+      register: mysql_tls_require_secure_transport_check_mode
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Verify require_secure_transport after check mode
+      mysql_variables:
+        <<: *mysql_params
+        variable: require_secure_transport
+      register: mysql_tls_require_secure_transport_after_check_mode
+      when: mysql_tls_tls_enabled
+
+    - name: MySQL TLS | Assert require_secure_transport check mode did not mutate state
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_require_secure_transport_check_mode is changed
+          - mysql_tls_require_secure_transport_check_mode.queries | length == 1
+          - mysql_tls_require_secure_transport_check_mode.queries[0] == 'SET GLOBAL `require_secure_transport` = ' ~ mysql_tls_alt_require_secure_transport_value
+          - mysql_tls_require_secure_transport_after_check_mode.msg == mysql_tls_initial.settings.require_secure_transport
+      when: mysql_tls_tls_enabled
 
     - name: MySQL TLS | Enable require_secure_transport
       mysql_tls:
@@ -288,6 +330,67 @@
         that:
           - mysql_tls_persist_idempotency is not changed
           - mysql_tls_persist_idempotency.queries == []
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Set require_secure_transport in persist mode
+      mysql_tls:
+        <<: *mysql_tls_params
+        require_secure_transport: "{{ mysql_tls_alt_require_secure_transport }}"
+        mode: persist
+      register: mysql_tls_require_secure_transport_persist_result
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Verify require_secure_transport after persist mode
+      mysql_variables:
+        <<: *mysql_tls_params
+        variable: require_secure_transport
+      register: mysql_tls_require_secure_transport_after_persist
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Read persisted require_secure_transport value
+      mysql_query:
+        <<: *mysql_tls_params
+        query: "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'require_secure_transport'"
+      register: mysql_tls_persisted_require_secure_transport
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Assert require_secure_transport persist mode result
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_require_secure_transport_persist_result is changed
+          - mysql_tls_require_secure_transport_persist_result.queries | length == 1
+          - mysql_tls_require_secure_transport_persist_result.queries[0] == 'SET PERSIST `require_secure_transport` = ' ~ mysql_tls_alt_require_secure_transport_value
+          - mysql_tls_require_secure_transport_after_persist.msg == mysql_tls_alt_require_secure_transport_value
+          - mysql_tls_persisted_require_secure_transport.query_result[0] | length == 1
+          - mysql_tls_persisted_require_secure_transport.query_result[0][0].persisted_value == mysql_tls_alt_require_secure_transport_value
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Re-run require_secure_transport persist mode for idempotency
+      mysql_tls:
+        <<: *mysql_tls_params
+        require_secure_transport: "{{ mysql_tls_alt_require_secure_transport }}"
+        mode: persist
+      register: mysql_tls_require_secure_transport_persist_idempotency
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Assert require_secure_transport persist idempotency
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_require_secure_transport_persist_idempotency is not changed
+          - mysql_tls_require_secure_transport_persist_idempotency.queries == []
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Restore require_secure_transport runtime after persist test
+      mysql_tls:
+        <<: *mysql_tls_params
+        require_secure_transport: "{{ mysql_tls_initial.settings.require_secure_transport == 'ON' }}"
+      register: mysql_tls_require_secure_transport_runtime_restore
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Assert require_secure_transport runtime restore after persist test
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_require_secure_transport_runtime_restore.settings.require_secure_transport == mysql_tls_initial.settings.require_secure_transport
       when: db_version is version('8.0', '>=')
 
     # ============================================================
@@ -463,6 +566,67 @@
           - mysql_tls_cert_check_mode.queries[0] is search('^SET GLOBAL `ssl_cert` = ')
           - mysql_tls_ssl_cert_after_check_mode.msg == mysql_tls_dummy_server_cert
 
+    - name: MySQL TLS | Set certificate paths with explicit reload
+      mysql_tls:
+        <<: *mysql_params
+        server_cert: "{{ mysql_tls_initial.settings.server_cert }}"
+        server_key: "{{ mysql_tls_initial.settings.server_key }}"
+        server_ca: "{{ mysql_tls_initial.settings.server_ca }}"
+        reload: true
+      register: mysql_tls_cert_paths_reload_result
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Verify ssl_cert after certificate path reload change
+      mysql_variables:
+        <<: *mysql_params
+        variable: ssl_cert
+      register: mysql_tls_ssl_cert_after_reload_change
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Verify ssl_key after certificate path reload change
+      mysql_variables:
+        <<: *mysql_params
+        variable: ssl_key
+      register: mysql_tls_ssl_key_after_reload_change
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Verify ssl_ca after certificate path reload change
+      mysql_variables:
+        <<: *mysql_params
+        variable: ssl_ca
+      register: mysql_tls_ssl_ca_after_reload_change
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Assert certificate path reload result
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_cert_paths_reload_result is changed
+          - "'SET GLOBAL `ssl_cert` =' in (mysql_tls_cert_paths_reload_result.queries | join(' '))"
+          - "'SET GLOBAL `ssl_key` =' in (mysql_tls_cert_paths_reload_result.queries | join(' '))"
+          - "'SET GLOBAL `ssl_ca` =' in (mysql_tls_cert_paths_reload_result.queries | join(' '))"
+          - "'ALTER INSTANCE RELOAD TLS' in mysql_tls_cert_paths_reload_result.queries"
+          - mysql_tls_ssl_cert_after_reload_change.msg == mysql_tls_initial.settings.server_cert
+          - mysql_tls_ssl_key_after_reload_change.msg == mysql_tls_initial.settings.server_key
+          - mysql_tls_ssl_ca_after_reload_change.msg == mysql_tls_initial.settings.server_ca
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Re-run certificate path reload change for idempotency
+      mysql_tls:
+        <<: *mysql_params
+        server_cert: "{{ mysql_tls_initial.settings.server_cert }}"
+        server_key: "{{ mysql_tls_initial.settings.server_key }}"
+        server_ca: "{{ mysql_tls_initial.settings.server_ca }}"
+        reload: true
+      register: mysql_tls_cert_paths_reload_idempotency
+      when: db_version is version('8.0.16', '>=')
+
+    - name: MySQL TLS | Assert certificate path reload idempotency
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_cert_paths_reload_idempotency is not changed
+          - mysql_tls_cert_paths_reload_idempotency.queries == []
+      when: db_version is version('8.0.16', '>=')
+
     - name: MySQL TLS | Restore baseline runtime settings
       mysql_tls:
         <<: *mysql_params
@@ -493,11 +657,38 @@
         - db_version is version('8.0', '>=')
         - not mysql_tls_initial_persisted_version_present
 
+    - name: MySQL TLS | Restore baseline persisted require_secure_transport value
+      mysql_variables:
+        <<: *mysql_tls_params
+        variable: require_secure_transport
+        value: "{{ mysql_tls_initial_persisted_require_secure_transport_value }}"
+        mode: persist_only
+      register: mysql_tls_restore_persisted_require_secure_transport
+      when:
+        - db_version is version('8.0', '>=')
+        - mysql_tls_initial_persisted_require_secure_transport_present
+
+    - name: MySQL TLS | Remove persisted require_secure_transport when baseline had none
+      mysql_query:
+        <<: *mysql_tls_params
+        query: "RESET PERSIST require_secure_transport"
+      register: mysql_tls_reset_persisted_require_secure_transport
+      when:
+        - db_version is version('8.0', '>=')
+        - not mysql_tls_initial_persisted_require_secure_transport_present
+
     - name: MySQL TLS | Read persisted tls_version after cleanup
       mysql_query:
         <<: *mysql_params
         query: "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'tls_version'"
       register: mysql_tls_persisted_version_after_cleanup
+      when: db_version is version('8.0', '>=')
+
+    - name: MySQL TLS | Read persisted require_secure_transport after cleanup
+      mysql_query:
+        <<: *mysql_tls_params
+        query: "SELECT VARIABLE_VALUE AS persisted_value FROM performance_schema.persisted_variables WHERE VARIABLE_NAME = 'require_secure_transport'"
+      register: mysql_tls_persisted_require_secure_transport_after_cleanup
       when: db_version is version('8.0', '>=')
 
     - name: MySQL TLS | Re-read runtime settings after restore
@@ -540,7 +731,26 @@
       ansible.builtin.assert:
         that:
           - mysql_tls_persisted_version_after_cleanup.query_result[0] | length == 0
-      when: db_version is version('8.0', '>=')
+      when:
+        - db_version is version('8.0', '>=')
+        - not mysql_tls_initial_persisted_version_present
+
+    - name: MySQL TLS | Assert persisted require_secure_transport row was restored
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_persisted_require_secure_transport_after_cleanup.query_result[0] | length == 1
+          - mysql_tls_persisted_require_secure_transport_after_cleanup.query_result[0][0].persisted_value == mysql_tls_initial_persisted_require_secure_transport_value
+      when:
+        - db_version is version('8.0', '>=')
+        - mysql_tls_initial_persisted_require_secure_transport_present
+
+    - name: MySQL TLS | Assert persisted require_secure_transport row was removed
+      ansible.builtin.assert:
+        that:
+          - mysql_tls_persisted_require_secure_transport_after_cleanup.query_result[0] | length == 0
+      when:
+        - db_version is version('8.0', '>=')
+        - not mysql_tls_initial_persisted_require_secure_transport_present
 
   always:
     - name: MySQL TLS | Always restore secure transport baseline
@@ -588,211 +798,24 @@
         - not mysql_tls_initial_persisted_version_present
       ignore_errors: true
 
-- vars:
-    mysql_parameters: &mysql_params_mariadb
-      login_user: '{{ mysql_user }}'
-      login_password: '{{ mysql_password }}'
-      login_host: '{{ mysql_host }}'
-      login_port: '{{ mysql_primary_port }}'
-    mysql_tls_parameters: &mysql_tls_params_mariadb
-      login_user: '{{ mysql_user }}'
-      login_password: '{{ mysql_password }}'
-      login_host: '{{ mysql_host }}'
-      login_port: '{{ mysql_primary_port }}'
-      ca_cert: /tmp/mysql_tls_server_cert.pem
-      check_hostname: no
-
-  when: db_engine == 'mariadb'
-  block:
-
-    - name: MariaDB TLS | Get baseline settings (no changes expected)
-      mysql_tls:
-        <<: *mysql_params_mariadb
-      register: mariadb_tls_initial
-
-    - name: MariaDB TLS | Assert baseline result
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_initial is not changed
-          - mariadb_tls_initial.queries == []
-          - "'require_secure_transport' in mariadb_tls_initial.settings"
-
-    - name: MariaDB TLS | Assert test harness exposes TLS
-      ansible.builtin.assert:
-        that:
-          - mysql_tls_tls_enabled | bool
-        fail_msg: test_mysql_tls requires harness-provisioned TLS for real transport checks.
-
-    - name: MariaDB TLS | Enable require_secure_transport
-      mysql_tls:
-        <<: *mysql_params_mariadb
-        require_secure_transport: true
-      register: mariadb_tls_require_secure_transport
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Assert require_secure_transport enable result
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_require_secure_transport is changed
-          - "'SET GLOBAL `require_secure_transport` = ON' in mariadb_tls_require_secure_transport.queries"
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Re-run require_secure_transport enable for idempotency
-      mysql_tls:
-        <<: *mysql_tls_params_mariadb
-        require_secure_transport: true
-      register: mariadb_tls_require_secure_transport_idempotency
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Assert require_secure_transport enable idempotency
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_require_secure_transport_idempotency is not changed
-          - mariadb_tls_require_secure_transport_idempotency.queries == []
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Plain TCP connection should fail when secure transport is required
-      mysql_query:
-        <<: *mysql_params_mariadb
-        query: "SELECT 1 AS plain_connection"
-      register: mariadb_tls_plain_query_when_secure
-      ignore_errors: true
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Check SSL status for implicit TLS connection
-      mysql_query:
-        <<: *mysql_params_mariadb
-        query: "SHOW STATUS LIKE 'Ssl_version'"
-      register: mariadb_tls_plain_query_ssl_status
+    - name: MySQL TLS | Always restore persisted require_secure_transport value
+      mysql_variables:
+        <<: *mysql_tls_params
+        variable: require_secure_transport
+        value: "{{ mysql_tls_initial_persisted_require_secure_transport_value }}"
+        mode: persist_only
       when:
-        - mysql_tls_tls_enabled
-        - mariadb_tls_plain_query_when_secure is succeeded
+        - db_version is version('8.0', '>=')
+        - mysql_tls_initial_persisted_require_secure_transport_present is defined
+        - mysql_tls_initial_persisted_require_secure_transport_present
+      ignore_errors: true
 
-    - name: MariaDB TLS | Assert connection without explicit TLS options is rejected or encrypted
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_plain_query_when_secure is failed or mariadb_tls_plain_query_ssl_status.query_result[0] | length == 1
-          - mariadb_tls_plain_query_when_secure is failed or mariadb_tls_plain_query_ssl_status.query_result[0][0].Value | default('') | length > 0
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | TLS connection should succeed when secure transport is required
+    - name: MySQL TLS | Always remove persisted require_secure_transport when baseline had none
       mysql_query:
-        <<: *mysql_tls_params_mariadb
-        query: "SELECT 1 AS tls_connection"
-      register: mariadb_tls_secure_query
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Assert TLS connection succeeds
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_secure_query is succeeded
-          - mariadb_tls_secure_query.query_result[0][0].tls_connection | int == 1
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Disable require_secure_transport over TLS
-      mysql_tls:
-        <<: *mysql_tls_params_mariadb
-        require_secure_transport: false
-      register: mariadb_tls_disable_secure_transport
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Assert require_secure_transport was disabled safely
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_disable_secure_transport is changed
-          - "'SET GLOBAL `require_secure_transport` = OFF' in mariadb_tls_disable_secure_transport.queries"
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Re-run require_secure_transport disable for idempotency
-      mysql_tls:
-        <<: *mysql_params_mariadb
-        require_secure_transport: false
-      register: mariadb_tls_disable_secure_transport_idempotency
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Assert require_secure_transport disable idempotency
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_disable_secure_transport_idempotency is not changed
-          - mariadb_tls_disable_secure_transport_idempotency.queries == []
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Plain TCP connection should work again after disabling secure transport
-      mysql_query:
-        <<: *mysql_params_mariadb
-        query: "SELECT 1 AS plain_connection_after_disable"
-      register: mariadb_tls_plain_query_after_disable
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | Assert plain TCP connection works again
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_plain_query_after_disable is succeeded
-          - mariadb_tls_plain_query_after_disable.query_result[0][0].plain_connection_after_disable | int == 1
-      when: mysql_tls_tls_enabled
-
-    - name: MariaDB TLS | server_cert should fail clearly
-      mysql_tls:
-        <<: *mysql_params_mariadb
-        server_cert: /tmp/mysql_tls-server-cert.pem
-      register: mariadb_tls_server_cert_failure
-      ignore_errors: true
-
-    - name: MariaDB TLS | Assert server_cert failure message
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_server_cert_failure is failed
-          - "'mariadb' in (mariadb_tls_server_cert_failure.msg | lower)"
-          - "'server_cert' in mariadb_tls_server_cert_failure.msg"
-
-    - name: MariaDB TLS | reload should fail clearly
-      mysql_tls:
-        <<: *mysql_params_mariadb
-        require_secure_transport: true
-        reload: true
-      register: mariadb_tls_reload_failure
-      ignore_errors: true
-
-    - name: MariaDB TLS | Assert reload failure message
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_reload_failure is failed
-          - "'mariadb' in (mariadb_tls_reload_failure.msg | lower)"
-          - "'reload' in (mariadb_tls_reload_failure.msg | lower)"
-
-    - name: MariaDB TLS | mode persist should fail clearly
-      mysql_tls:
-        <<: *mysql_params_mariadb
-        require_secure_transport: true
-        mode: persist
-      register: mariadb_tls_persist_failure
-      ignore_errors: true
-
-    - name: MariaDB TLS | Assert mode persist failure message
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_persist_failure is failed
-          - "'mariadb' in (mariadb_tls_persist_failure.msg | lower)"
-          - "'persist' in (mariadb_tls_persist_failure.msg | lower)"
-
-    - name: MariaDB TLS | Re-read runtime settings after tests
-      mysql_tls:
-        <<: *mysql_params_mariadb
-      register: mariadb_tls_restored
-
-    - name: MariaDB TLS | Assert baseline settings were restored
-      ansible.builtin.assert:
-        that:
-          - mariadb_tls_restored is not changed
-          - mariadb_tls_restored.settings == mariadb_tls_initial.settings
-
-  always:
-    - name: MariaDB TLS | Always restore secure transport baseline
-      mysql_tls:
-        <<: *mysql_tls_params_mariadb
-        require_secure_transport: "{{ mariadb_tls_initial.settings.require_secure_transport == 'ON' }}"
+        <<: *mysql_tls_params
+        query: "RESET PERSIST require_secure_transport"
       when:
-        - mysql_tls_tls_enabled | default(false)
-        - mariadb_tls_initial is defined
-        - mariadb_tls_initial.settings is defined
+        - db_version is version('8.0', '>=')
+        - mysql_tls_initial_persisted_require_secure_transport_present is defined
+        - not mysql_tls_initial_persisted_require_secure_transport_present
       ignore_errors: true

--- a/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-121.yml
@@ -11,9 +11,8 @@
 
     - name: Issue-121 | Setup | Get server certificate
       copy:
-        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect {{ mysql_host }}:3307 -showcerts 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect {{ mysql_host }}:{{ mysql_primary_port }} -showcerts 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
         dest: /tmp/cert.pem
-      delegate_to: localhost
 
     - name: Issue-121 | Drop mysql user if exists
       mysql_user:

--- a/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_user/tasks/issue-28.yml
@@ -1,9 +1,9 @@
 ---
 - name: set fact tls_enabled
-  command: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
+  command: "{{ mysql_command }} \"-Nse SHOW VARIABLES LIKE 'ssl_ca';\""
   register: result
 - set_fact:
-    tls_enabled: "{{ 'YES' in result.stdout | bool | default('false', true) }}"
+    tls_enabled: "{{ result.stdout is search('ssl_ca\\s+.+') }}"
 
 - vars:
     mysql_parameters: &mysql_params
@@ -17,9 +17,8 @@
     # ============================================================
     - name: Issue-28 | Setup | Get server certificate
       copy:
-        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect {{ mysql_host }}:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect {{ mysql_host }}:{{ mysql_primary_port }} -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
         dest: /tmp/cert.pem
-      delegate_to: localhost
 
     - name: Issue-28 | Setup | Drop mysql user if exists
       mysql_user:

--- a/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
+++ b/tests/integration/targets/test_mysql_variables/tasks/issue-28.yml
@@ -1,12 +1,12 @@
 ---
 - name: set fact tls_enabled
   ansible.builtin.command:
-    cmd: "{{ mysql_command }} \"-e SHOW VARIABLES LIKE 'have_ssl';\""
+    cmd: "{{ mysql_command }} \"-Nse SHOW VARIABLES LIKE 'ssl_ca';\""
   register: result
 
 - name: Set tls_enabled fact
   ansible.builtin.set_fact:
-    tls_enabled: "{{ 'YES' in result.stdout | bool | default('false', true) }}"
+    tls_enabled: "{{ result.stdout is search('ssl_ca\\s+.+') }}"
 
 - vars:
     mysql_parameters: &mysql_params
@@ -20,9 +20,8 @@
     # ============================================================
     - name: get server certificate
       ansible.builtin.copy:
-        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect localhost:3307 -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
+        content: "{{ lookup('pipe', \"openssl s_client -starttls mysql -connect {{ mysql_host }}:{{ mysql_primary_port }} -showcerts 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'\") }}"
         dest: /tmp/cert.pem
-      delegate_to: localhost
 
     - name: Drop mysql user if exists
       ansible.mysql.mysql_user:

--- a/tests/unit/plugins/modules/test_mysql_tls.py
+++ b/tests/unit/plugins/modules/test_mysql_tls.py
@@ -1,0 +1,362 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.ansible.mysql.plugins.modules.mysql_tls import MySQLTLS
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class FakeCursor:
+    """Minimal cursor double that tracks executed queries and fakes SHOW VARIABLES."""
+
+    TLS_VARS = frozenset(('ssl_cert', 'ssl_key', 'ssl_ca',
+                          'require_secure_transport', 'tls_version'))
+
+    def __init__(self, variables=None):
+        self.variables = dict(variables or {})
+        self.executed = []
+        self._rows = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+        upper = query.strip().upper()
+
+        if upper.startswith("SHOW") and "VARIABLE_NAME" in upper.upper():
+            var_name = params[0]
+            if var_name in self.variables:
+                self._rows = [(var_name, self.variables[var_name])]
+            else:
+                self._rows = []
+            return
+
+        if upper.startswith("SET GLOBAL ") or upper.startswith("SET PERSIST "):
+            # Extract variable name between backticks
+            var_name = query.split('`')[1]
+            self.variables[var_name] = params[0]
+            self._rows = []
+            return
+
+        if upper == "ALTER INSTANCE RELOAD TLS":
+            self._rows = []
+            return
+
+        raise AssertionError("Unexpected query: %s (params=%s)" % (query, params))
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return list(self._rows)
+
+
+class ModuleStub:
+    def fail_json(self, **kwargs):
+        raise RuntimeError(kwargs.get('msg', 'fail_json called'))
+
+
+def _make_mysql_cursor(overrides=None):
+    """Return a FakeCursor with reasonable MySQL TLS defaults."""
+    defaults = {
+        'ssl_cert': '',
+        'ssl_key': '',
+        'ssl_ca': '',
+        'require_secure_transport': 'OFF',
+        'tls_version': 'TLSv1.2,TLSv1.3',
+    }
+    if overrides:
+        defaults.update(overrides)
+    return FakeCursor(defaults)
+
+
+def _make_mariadb_cursor(overrides=None):
+    """Return a FakeCursor representing a MariaDB server (minimal TLS variables)."""
+    defaults = {
+        'require_secure_transport': 'OFF',
+    }
+    if overrides:
+        defaults.update(overrides)
+    return FakeCursor(defaults)
+
+
+# ---------------------------------------------------------------------------
+# MySQL - basic configure behaviour
+# ---------------------------------------------------------------------------
+
+def test_configure_returns_unchanged_when_settings_already_match():
+    cursor = _make_mysql_cursor({
+        'ssl_cert': '/etc/mysql/ssl/server-cert.pem',
+        'require_secure_transport': 'ON',
+    })
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+
+    result = tls.configure({
+        'server_cert': '/etc/mysql/ssl/server-cert.pem',
+        'require_secure_transport': True,
+    })
+
+    assert result['changed'] is False
+    assert result['queries'] == []
+
+
+def test_configure_changes_require_secure_transport():
+    cursor = _make_mysql_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+    result = tls.configure({'require_secure_transport': True})
+
+    assert result['changed'] is True
+    assert any('require_secure_transport' in q for q in result['queries'])
+    assert cursor.variables['require_secure_transport'] == 'ON'
+
+
+def test_configure_changes_cert_paths():
+    cursor = _make_mysql_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+    result = tls.configure({
+        'server_cert': '/etc/mysql/ssl/server-cert.pem',
+        'server_key': '/etc/mysql/ssl/server-key.pem',
+        'server_ca': '/etc/mysql/ssl/ca-cert.pem',
+    })
+
+    assert result['changed'] is True
+    assert cursor.variables['ssl_cert'] == '/etc/mysql/ssl/server-cert.pem'
+    assert cursor.variables['ssl_key'] == '/etc/mysql/ssl/server-key.pem'
+    assert cursor.variables['ssl_ca'] == '/etc/mysql/ssl/ca-cert.pem'
+
+
+def test_configure_changes_tls_version():
+    cursor = _make_mysql_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+    result = tls.configure({'tls_version': 'TLSv1.3'})
+
+    assert result['changed'] is True
+    assert any(
+        q.startswith('SET GLOBAL ') and '`tls_version`' in q and 'TLSv1.3' in q
+        for q in result['queries']
+    )
+    assert cursor.variables['tls_version'] == 'TLSv1.3'
+
+
+def test_configure_returns_effective_settings():
+    cursor = _make_mysql_cursor({
+        'ssl_cert': '/etc/mysql/ssl/server-cert.pem',
+        'require_secure_transport': 'ON',
+        'tls_version': 'TLSv1.3',
+    })
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+    result = tls.configure({})
+
+    assert 'settings' in result
+    assert result['settings']['server_cert'] == '/etc/mysql/ssl/server-cert.pem'
+    assert result['settings']['require_secure_transport'] == 'ON'
+    assert result['settings']['tls_version'] == 'TLSv1.3'
+    assert 'ssl_cert' not in result['settings']
+
+
+# ---------------------------------------------------------------------------
+# MySQL - check mode
+# ---------------------------------------------------------------------------
+
+def test_configure_in_check_mode_predicts_changes_without_writes():
+    cursor = _make_mysql_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+    result = tls.configure(
+        {'require_secure_transport': True},
+        check_mode=True,
+    )
+
+    assert result['changed'] is True
+    assert any('require_secure_transport' in q for q in result['queries'])
+    # The variable must NOT have been written
+    assert cursor.variables['require_secure_transport'] == 'OFF'
+    assert not any(
+        q.strip().upper().startswith('SET ') for q, _p in cursor.executed
+    )
+
+
+# ---------------------------------------------------------------------------
+# MySQL - reload
+# ---------------------------------------------------------------------------
+
+def test_configure_with_reload_executes_alter_instance_reload_tls():
+    cursor = _make_mysql_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+    result = tls.configure(
+        {'require_secure_transport': True},
+        reload=True,
+    )
+
+    assert result['changed'] is True
+    assert 'ALTER INSTANCE RELOAD TLS' in result['queries']
+    assert any(
+        q == 'ALTER INSTANCE RELOAD TLS' for q, _p in cursor.executed
+    )
+
+
+def test_configure_with_reload_in_check_mode_includes_reload_query():
+    cursor = _make_mysql_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+    result = tls.configure(
+        {'require_secure_transport': True},
+        reload=True,
+        check_mode=True,
+    )
+
+    assert result['changed'] is True
+    assert 'ALTER INSTANCE RELOAD TLS' in result['queries']
+    assert not any(
+        q == 'ALTER INSTANCE RELOAD TLS' for q, _p in cursor.executed
+    )
+
+
+def test_configure_tls_context_change_does_not_reload_by_default():
+    cursor = _make_mysql_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+    result = tls.configure({
+        'server_cert': '/etc/mysql/ssl/server-cert.pem',
+    })
+
+    assert result['changed'] is True
+    assert any('`ssl_cert`' in q for q in result['queries'])
+    assert 'ALTER INSTANCE RELOAD TLS' not in result['queries']
+    assert not any(
+        q == 'ALTER INSTANCE RELOAD TLS' for q, _p in cursor.executed
+    )
+
+
+# ---------------------------------------------------------------------------
+# MySQL - persist mode
+# ---------------------------------------------------------------------------
+
+def test_configure_with_global_mode_uses_set_global():
+    cursor = _make_mysql_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+    result = tls.configure(
+        {'require_secure_transport': True},
+        mode='global',
+    )
+
+    assert result['changed'] is True
+    assert any(
+        q.startswith('SET GLOBAL ') and '`require_secure_transport`' in q
+        for q in result['queries']
+    )
+    assert not any('SET PERSIST' in q for q in result['queries'])
+
+
+def test_configure_with_persist_mode_uses_set_persist():
+    cursor = _make_mysql_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+    result = tls.configure(
+        {'require_secure_transport': True},
+        mode='persist',
+    )
+
+    assert result['changed'] is True
+    assert any('SET PERSIST' in q for q in result['queries'])
+    assert not any('SET GLOBAL' in q for q in result['queries'])
+
+
+# ---------------------------------------------------------------------------
+# MariaDB - restrictions
+# ---------------------------------------------------------------------------
+
+def test_mariadb_fails_for_server_cert():
+    cursor = _make_mariadb_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tls.configure({'server_cert': '/etc/mysql/ssl/server-cert.pem'})
+
+    assert 'mariadb' in str(exc_info.value).lower() or 'not supported' in str(exc_info.value).lower()
+
+
+def test_mariadb_fails_for_server_key():
+    cursor = _make_mariadb_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
+
+    with pytest.raises(RuntimeError):
+        tls.configure({'server_key': '/etc/mysql/ssl/server-key.pem'})
+
+
+def test_mariadb_fails_for_server_ca():
+    cursor = _make_mariadb_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
+
+    with pytest.raises(RuntimeError):
+        tls.configure({'server_ca': '/etc/mysql/ssl/ca-cert.pem'})
+
+
+def test_mariadb_fails_for_tls_version():
+    cursor = _make_mariadb_cursor()
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tls.configure({'tls_version': 'TLSv1.3'})
+
+    assert 'mariadb' in str(exc_info.value).lower() or 'not supported' in str(exc_info.value).lower()
+
+
+def test_mariadb_fails_for_reload():
+    cursor = _make_mariadb_cursor({'require_secure_transport': 'OFF'})
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tls.configure({'require_secure_transport': True}, reload=True)
+
+    assert 'mariadb' in str(exc_info.value).lower() or 'not supported' in str(exc_info.value).lower()
+
+
+def test_mariadb_fails_for_persist_mode():
+    cursor = _make_mariadb_cursor({'require_secure_transport': 'OFF'})
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tls.configure({'require_secure_transport': True}, mode='persist')
+
+    message = str(exc_info.value).lower()
+    assert 'mariadb' in message
+    assert 'persist' in message
+
+
+def test_mariadb_supports_require_secure_transport():
+    cursor = _make_mariadb_cursor({'require_secure_transport': 'OFF'})
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
+    result = tls.configure({'require_secure_transport': True})
+
+    assert result['changed'] is True
+    assert cursor.variables['require_secure_transport'] == 'ON'
+
+
+def test_mariadb_returns_unchanged_when_require_secure_transport_matches():
+    cursor = _make_mariadb_cursor({'require_secure_transport': 'ON'})
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
+    result = tls.configure({'require_secure_transport': True})
+
+    assert result['changed'] is False
+    assert result['queries'] == []

--- a/tests/unit/plugins/modules/test_mysql_tls.py
+++ b/tests/unit/plugins/modules/test_mysql_tls.py
@@ -5,6 +5,7 @@ __metaclass__ = type
 
 import pytest
 
+from ansible_collections.ansible.mysql.plugins.modules import mysql_tls as mysql_tls_module
 from ansible_collections.ansible.mysql.plugins.modules.mysql_tls import MySQLTLS
 
 
@@ -18,8 +19,11 @@ class FakeCursor:
     TLS_VARS = frozenset(('ssl_cert', 'ssl_key', 'ssl_ca',
                           'require_secure_transport', 'tls_version'))
 
-    def __init__(self, variables=None):
+    def __init__(self, variables=None, server_version='8.0.34', write_error=None, reload_error=None):
         self.variables = dict(variables or {})
+        self.server_version = server_version
+        self.write_error = write_error
+        self.reload_error = reload_error
         self.executed = []
         self._rows = []
 
@@ -27,6 +31,10 @@ class FakeCursor:
         self.executed.append((query, params))
 
         upper = query.strip().upper()
+
+        if upper.startswith("SELECT VERSION()"):
+            self._rows = [(self.server_version,)]
+            return
 
         if upper.startswith("SHOW") and "VARIABLE_NAME" in upper.upper():
             var_name = params[0]
@@ -37,6 +45,8 @@ class FakeCursor:
             return
 
         if upper.startswith("SET GLOBAL ") or upper.startswith("SET PERSIST "):
+            if self.write_error is not None:
+                raise self.write_error
             # Extract variable name between backticks
             var_name = query.split('`')[1]
             self.variables[var_name] = params[0]
@@ -44,6 +54,8 @@ class FakeCursor:
             return
 
         if upper == "ALTER INSTANCE RELOAD TLS":
+            if self.reload_error is not None:
+                raise self.reload_error
             self._rows = []
             return
 
@@ -61,7 +73,11 @@ class ModuleStub:
         raise RuntimeError(kwargs.get('msg', 'fail_json called'))
 
 
-def _make_mysql_cursor(overrides=None):
+class DummyDriverError(Exception):
+    pass
+
+
+def _make_mysql_cursor(overrides=None, server_version='8.0.34', write_error=None, reload_error=None):
     """Return a FakeCursor with reasonable MySQL TLS defaults."""
     defaults = {
         'ssl_cert': '',
@@ -72,17 +88,12 @@ def _make_mysql_cursor(overrides=None):
     }
     if overrides:
         defaults.update(overrides)
-    return FakeCursor(defaults)
-
-
-def _make_mariadb_cursor(overrides=None):
-    """Return a FakeCursor representing a MariaDB server (minimal TLS variables)."""
-    defaults = {
-        'require_secure_transport': 'OFF',
-    }
-    if overrides:
-        defaults.update(overrides)
-    return FakeCursor(defaults)
+    return FakeCursor(
+        defaults,
+        server_version=server_version,
+        write_error=write_error,
+        reload_error=reload_error,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +175,55 @@ def test_configure_returns_effective_settings():
     assert 'ssl_cert' not in result['settings']
 
 
+def test_configure_fails_when_tls_setting_is_not_available():
+    cursor = _make_mysql_cursor({'tls_version': None})
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tls.configure({})
+
+    assert 'TLS setting "tls_version" is not available on this server.' == str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# MySQL - version guard
+# ---------------------------------------------------------------------------
+
+def test_mysql_fails_for_tls_context_change_before_8_0_16():
+    cursor = _make_mysql_cursor(server_version='8.0.15')
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql', server_version='8.0.15')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tls.configure({'server_cert': '/etc/mysql/ssl/server-cert.pem'})
+
+    assert '8.0.16' in str(exc_info.value)
+    assert 'server_cert' in str(exc_info.value)
+
+
+def test_mysql_fails_for_reload_before_8_0_16():
+    cursor = _make_mysql_cursor(server_version='8.0.15')
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql', server_version='8.0.15')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tls.configure({'require_secure_transport': True}, reload=True)
+
+    assert '8.0.16' in str(exc_info.value)
+    assert 'reload' in str(exc_info.value).lower()
+
+
+def test_mysql_allows_require_secure_transport_before_8_0_16():
+    cursor = _make_mysql_cursor(server_version='5.7.35')
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql', server_version='5.7.35')
+    result = tls.configure({'require_secure_transport': True})
+
+    assert result['changed'] is True
+    assert cursor.variables['require_secure_transport'] == 'ON'
+
+
 # ---------------------------------------------------------------------------
 # MySQL - check mode
 # ---------------------------------------------------------------------------
@@ -239,6 +299,63 @@ def test_configure_tls_context_change_does_not_reload_by_default():
     )
 
 
+def test_configure_does_not_swallow_non_driver_write_errors():
+    cursor = _make_mysql_cursor(write_error=TypeError('bad write parameters'))
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql', server_version='8.0.34')
+
+    with pytest.raises(TypeError) as exc_info:
+        tls.configure({'require_secure_transport': True})
+
+    assert 'bad write parameters' in str(exc_info.value)
+
+
+def test_configure_does_not_swallow_non_driver_reload_errors():
+    cursor = _make_mysql_cursor(reload_error=TypeError('bad reload call'))
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql', server_version='8.0.34')
+
+    with pytest.raises(TypeError) as exc_info:
+        tls.configure({'require_secure_transport': True}, reload=True)
+
+    assert 'bad reload call' in str(exc_info.value)
+
+
+def test_configure_surfaces_driver_write_errors(monkeypatch):
+    cursor = _make_mysql_cursor(write_error=DummyDriverError('db write failure'))
+
+    monkeypatch.setattr(
+        mysql_tls_module,
+        'mysql_driver',
+        type('FakeDriver', (), {'Error': DummyDriverError}),
+    )
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql', server_version='8.0.34')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tls.configure({'require_secure_transport': True})
+
+    assert 'db write failure' in str(exc_info.value)
+
+
+def test_configure_surfaces_driver_reload_errors(monkeypatch):
+    cursor = _make_mysql_cursor(reload_error=DummyDriverError('db reload failure'))
+
+    monkeypatch.setattr(
+        mysql_tls_module,
+        'mysql_driver',
+        type('FakeDriver', (), {'Error': DummyDriverError}),
+    )
+
+    tls = MySQLTLS(ModuleStub(), cursor, 'mysql', server_version='8.0.34')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tls.configure({'require_secure_transport': True}, reload=True)
+
+    assert "ALTER INSTANCE RELOAD TLS" in str(exc_info.value)
+    assert 'db reload failure' in str(exc_info.value)
+
+
 # ---------------------------------------------------------------------------
 # MySQL - persist mode
 # ---------------------------------------------------------------------------
@@ -272,91 +389,3 @@ def test_configure_with_persist_mode_uses_set_persist():
     assert result['changed'] is True
     assert any('SET PERSIST' in q for q in result['queries'])
     assert not any('SET GLOBAL' in q for q in result['queries'])
-
-
-# ---------------------------------------------------------------------------
-# MariaDB - restrictions
-# ---------------------------------------------------------------------------
-
-def test_mariadb_fails_for_server_cert():
-    cursor = _make_mariadb_cursor()
-
-    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
-
-    with pytest.raises(RuntimeError) as exc_info:
-        tls.configure({'server_cert': '/etc/mysql/ssl/server-cert.pem'})
-
-    assert 'mariadb' in str(exc_info.value).lower() or 'not supported' in str(exc_info.value).lower()
-
-
-def test_mariadb_fails_for_server_key():
-    cursor = _make_mariadb_cursor()
-
-    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
-
-    with pytest.raises(RuntimeError):
-        tls.configure({'server_key': '/etc/mysql/ssl/server-key.pem'})
-
-
-def test_mariadb_fails_for_server_ca():
-    cursor = _make_mariadb_cursor()
-
-    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
-
-    with pytest.raises(RuntimeError):
-        tls.configure({'server_ca': '/etc/mysql/ssl/ca-cert.pem'})
-
-
-def test_mariadb_fails_for_tls_version():
-    cursor = _make_mariadb_cursor()
-
-    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
-
-    with pytest.raises(RuntimeError) as exc_info:
-        tls.configure({'tls_version': 'TLSv1.3'})
-
-    assert 'mariadb' in str(exc_info.value).lower() or 'not supported' in str(exc_info.value).lower()
-
-
-def test_mariadb_fails_for_reload():
-    cursor = _make_mariadb_cursor({'require_secure_transport': 'OFF'})
-
-    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
-
-    with pytest.raises(RuntimeError) as exc_info:
-        tls.configure({'require_secure_transport': True}, reload=True)
-
-    assert 'mariadb' in str(exc_info.value).lower() or 'not supported' in str(exc_info.value).lower()
-
-
-def test_mariadb_fails_for_persist_mode():
-    cursor = _make_mariadb_cursor({'require_secure_transport': 'OFF'})
-
-    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
-
-    with pytest.raises(RuntimeError) as exc_info:
-        tls.configure({'require_secure_transport': True}, mode='persist')
-
-    message = str(exc_info.value).lower()
-    assert 'mariadb' in message
-    assert 'persist' in message
-
-
-def test_mariadb_supports_require_secure_transport():
-    cursor = _make_mariadb_cursor({'require_secure_transport': 'OFF'})
-
-    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
-    result = tls.configure({'require_secure_transport': True})
-
-    assert result['changed'] is True
-    assert cursor.variables['require_secure_transport'] == 'ON'
-
-
-def test_mariadb_returns_unchanged_when_require_secure_transport_matches():
-    cursor = _make_mariadb_cursor({'require_secure_transport': 'ON'})
-
-    tls = MySQLTLS(ModuleStub(), cursor, 'mariadb')
-    result = tls.configure({'require_secure_transport': True})
-
-    assert result['changed'] is False
-    assert result['queries'] == []

--- a/tests/unit/plugins/modules/test_mysql_tls.py
+++ b/tests/unit/plugins/modules/test_mysql_tls.py
@@ -3,10 +3,22 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from contextlib import contextmanager
+import json
+import sys
+
 import pytest
 
+from ansible.module_utils import basic
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_bytes
+try:
+    from ansible.module_utils.testing import patch_module_args  # pyright: ignore[reportMissingImports]
+except ImportError:
+    patch_module_args = None
+
 from ansible_collections.ansible.mysql.plugins.modules import mysql_tls as mysql_tls_module
-from ansible_collections.ansible.mysql.plugins.modules.mysql_tls import MySQLTLS
+from ansible_collections.ansible.mysql.plugins.modules.mysql_tls import MySQLTLS, main
 
 
 # ---------------------------------------------------------------------------
@@ -73,8 +85,48 @@ class ModuleStub:
         raise RuntimeError(kwargs.get('msg', 'fail_json called'))
 
 
+class AnsibleExitJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    raise AnsibleExitJson(kwargs)
+
+
 class DummyDriverError(Exception):
     pass
+
+
+@contextmanager
+def set_module_args(args):
+    module_args = dict(args)
+
+    original_argv = sys.argv[:]
+    sys.argv = ['ansible_unittest']
+
+    try:
+        if patch_module_args is not None:
+            with patch_module_args(module_args):
+                yield
+            return
+
+        original_args = getattr(basic, '_ANSIBLE_ARGS', None)
+        original_profile = getattr(basic, '_ANSIBLE_PROFILE', None)
+        had_profile = hasattr(basic, '_ANSIBLE_PROFILE')
+
+        basic._ANSIBLE_ARGS = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': module_args}))
+        basic._ANSIBLE_PROFILE = 'legacy'
+
+        try:
+            yield
+        finally:
+            basic._ANSIBLE_ARGS = original_args
+            if had_profile:
+                basic._ANSIBLE_PROFILE = original_profile
+            else:
+                delattr(basic, '_ANSIBLE_PROFILE')
+    finally:
+        sys.argv = original_argv
 
 
 def _make_mysql_cursor(overrides=None, server_version='8.0.34', write_error=None, reload_error=None):
@@ -389,3 +441,38 @@ def test_configure_with_persist_mode_uses_set_persist():
     assert result['changed'] is True
     assert any('SET PERSIST' in q for q in result['queries'])
     assert not any('SET GLOBAL' in q for q in result['queries'])
+
+
+def test_main_passes_module_to_get_server_implementation(monkeypatch):
+    cursor = _make_mysql_cursor()
+    implementation_args = []
+
+    monkeypatch.setattr(AnsibleModule, 'exit_json', exit_json)
+    monkeypatch.setattr(
+        mysql_tls_module,
+        'mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        mysql_tls_module,
+        'mysql_connect',
+        lambda *args, **kwargs: (cursor, object()),
+    )
+
+    def fake_get_server_implementation(module, db_cursor):
+        implementation_args.append((module, db_cursor))
+        return 'mysql'
+
+    monkeypatch.setattr(
+        mysql_tls_module,
+        'get_server_implementation',
+        fake_get_server_implementation,
+    )
+
+    with set_module_args({'login_unix_socket': '/run/mysqld/mysqld.sock'}):
+        with pytest.raises(AnsibleExitJson):
+            main()
+
+    assert len(implementation_args) == 1
+    assert isinstance(implementation_args[0][0], AnsibleModule)
+    assert implementation_args[0][1] is cursor


### PR DESCRIPTION
#### SUMMARY
- add a new `mysql_tls` module to manage MySQL TLS runtime settings plus the supported MariaDB `require_secure_transport` subset

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/mysql_tls.py
- tests/unit/plugins/modules/test_mysql_tls.py
- tests/integration/targets/test_mysql_tls/defaults/main.yml
- tests/integration/targets/test_mysql_tls/meta/main.yml
- tests/integration/targets/test_mysql_tls/tasks/main.yml
- tests/integration/targets/test_mysql_tls/tasks/mysql_tls.yml
- meta/runtime.yml
- README.md

#### ADDITIONAL INFORMATION
- MariaDB support is intentionally limited to runtime `require_secure_transport`; unsupported settings fail clearly
- Created with the help of GPT5.4 with human in the loop and manual testing
