### PR TITLE
Add mysql_replication_filter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Every voice is important and every idea is valuable. If you have something on yo
   - [mysql_perf_schema](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_perf_schema_module.html)
   - [mysql_query](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_query_module.html)
   - [mysql_replication](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_replication_module.html)
+  - [mysql_replication_filter](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_replication_filter_module.html)
   - [mysql_resource_group](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_resource_group_module.html)
   - [mysql_resource_group_info](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_resource_group_info_module.html)
   - [mysql_role](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_role_module.html)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -9,6 +9,7 @@ action_groups:
     - mysql_perf_schema
     - mysql_query
     - mysql_replication
+    - mysql_replication_filter
     - mysql_resource_group
     - mysql_resource_group_info
     - mysql_role

--- a/plugins/modules/mysql_replication_filter.py
+++ b/plugins/modules/mysql_replication_filter.py
@@ -1,0 +1,532 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_replication_filter
+
+short_description: Manage MySQL or MariaDB replication filters
+
+description:
+  - Manage replica-side replication filters declaratively.
+  - MySQL uses C(CHANGE REPLICATION FILTER).
+  - MariaDB uses C(SET GLOBAL replicate_*) variables.
+  - Changes are runtime only and are not persisted across restart by this module.
+
+author:
+  - Ron Gershburg (@ronger4)
+
+version_added: '5.2.0'
+
+options:
+  replicate_do_db:
+    description:
+      - Databases that should be replicated.
+      - Provide an empty list to clear the filter.
+    type: list
+    elements: str
+  replicate_ignore_db:
+    description:
+      - Databases that should be ignored during replication.
+      - Provide an empty list to clear the filter.
+    type: list
+    elements: str
+  replicate_do_table:
+    description:
+      - Fully qualified tables that should be replicated.
+      - Values must use C(database.table) syntax.
+      - Provide an empty list to clear the filter.
+    type: list
+    elements: str
+  replicate_ignore_table:
+    description:
+      - Fully qualified tables that should be ignored during replication.
+      - Values must use C(database.table) syntax.
+      - Provide an empty list to clear the filter.
+    type: list
+    elements: str
+  replicate_wild_do_table:
+    description:
+      - Wildcard table patterns that should be replicated.
+      - Provide an empty list to clear the filter.
+    type: list
+    elements: str
+  replicate_wild_ignore_table:
+    description:
+      - Wildcard table patterns that should be ignored during replication.
+      - Provide an empty list to clear the filter.
+    type: list
+    elements: str
+  channel:
+    description:
+      - MySQL replication channel name.
+      - Supported only for MySQL.
+    type: str
+  connection_name:
+    description:
+      - MariaDB replication connection name.
+      - Supported only for MariaDB multi-source replication.
+    type: str
+
+notes:
+  - Compatible with MariaDB or MySQL.
+  - At least one replication filter option must be provided.
+  - Unspecified filters are left unchanged.
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+extends_documentation_fragment:
+  - ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Ignore one database on a MySQL replica
+  ansible.mysql.mysql_replication_filter:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    replicate_ignore_db:
+      - audit
+
+- name: Set one channel-specific MySQL filter
+  ansible.mysql.mysql_replication_filter:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    channel: analytics
+    replicate_do_db:
+      - reporting
+
+- name: Clear one MariaDB wildcard filter
+  ansible.mysql.mysql_replication_filter:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    replicate_wild_ignore_table: []
+'''
+
+RETURN = r'''
+queries:
+  description: Executed SQL statements or predicted SQL statements in check mode.
+  returned: always
+  type: list
+  elements: str
+filters:
+  description: Effective normalized filter state after execution or prediction.
+  returned: always
+  type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.ansible.mysql.plugins.module_utils.database import check_input, mysql_quote_identifier
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    get_server_implementation,
+    get_server_version,
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils.version import LooseVersion
+
+
+FILTER_DEFINITIONS = {
+    'replicate_do_db': {
+        'mysql_name': 'REPLICATE_DO_DB',
+        'mariadb_name': 'replicate_do_db',
+        'value_kind': 'database',
+    },
+    'replicate_ignore_db': {
+        'mysql_name': 'REPLICATE_IGNORE_DB',
+        'mariadb_name': 'replicate_ignore_db',
+        'value_kind': 'database',
+    },
+    'replicate_do_table': {
+        'mysql_name': 'REPLICATE_DO_TABLE',
+        'mariadb_name': 'replicate_do_table',
+        'value_kind': 'table',
+    },
+    'replicate_ignore_table': {
+        'mysql_name': 'REPLICATE_IGNORE_TABLE',
+        'mariadb_name': 'replicate_ignore_table',
+        'value_kind': 'table',
+    },
+    'replicate_wild_do_table': {
+        'mysql_name': 'REPLICATE_WILD_DO_TABLE',
+        'mariadb_name': 'replicate_wild_do_table',
+        'value_kind': 'pattern',
+    },
+    'replicate_wild_ignore_table': {
+        'mysql_name': 'REPLICATE_WILD_IGNORE_TABLE',
+        'mariadb_name': 'replicate_wild_ignore_table',
+        'value_kind': 'pattern',
+    },
+}
+
+MYSQL_FILTER_NAME_TO_PARAM = dict(
+    (definition['mysql_name'], param)
+    for param, definition in FILTER_DEFINITIONS.items()
+)
+
+
+def normalize_filter_values(values):
+    normalized = []
+
+    for value in values:
+        value = value.strip()
+        if not value:
+            continue
+        normalized.append(value)
+
+    return sorted(set(normalized))
+
+
+def normalize_mysql_filter_rows(rows):
+    filters = _empty_filters()
+
+    for row in rows:
+        param = MYSQL_FILTER_NAME_TO_PARAM.get(row['FILTER_NAME'])
+        if not param:
+            continue
+        filters[param] = normalize_filter_values(_split_filter_rule(row.get('FILTER_RULE', '')))
+
+    return filters
+
+
+def normalize_mariadb_filter_values(variables):
+    filters = _empty_filters()
+
+    for param, definition in FILTER_DEFINITIONS.items():
+        raw_value = variables.get(definition['mariadb_name'], '')
+        filters[param] = normalize_filter_values(_split_filter_rule(raw_value))
+
+    return filters
+
+
+def plan_filter_changes(desired_filters, current_filters, query_builder):
+    planned_filters = dict((name, list(values)) for name, values in current_filters.items())
+    queries = []
+
+    for param, desired_values in desired_filters.items():
+        if desired_values is None:
+            continue
+
+        normalized_values = normalize_filter_values(desired_values)
+        planned_filters[param] = normalized_values
+
+        if current_filters.get(param, []) != normalized_values:
+            queries.append(query_builder(param, normalized_values))
+
+    return {
+        'changed': bool(queries),
+        'queries': queries,
+        'filters': planned_filters,
+    }
+
+
+def build_mysql_filter_query(filter_name, value_kind, values, channel=''):
+    values_sql = _build_mysql_filter_values(value_kind, values)
+    query = 'CHANGE REPLICATION FILTER %s = (%s)' % (filter_name, values_sql)
+
+    if channel:
+        query += ' FOR CHANNEL %s' % _quote_sql_string(channel)
+
+    return {
+        'sql': query,
+        'params': (),
+        'display': query,
+    }
+
+
+def build_mariadb_set_query(variable_name, values):
+    value = ','.join(normalize_filter_values(values))
+    identifier = mysql_quote_identifier(variable_name, 'vars')
+    query = 'SET GLOBAL %s = %%s' % identifier
+
+    return {
+        'sql': query,
+        'params': (value,),
+        'display': 'SET GLOBAL %s = %s' % (identifier, _quote_sql_string(value)),
+    }
+
+
+def build_mysql_query_from_param(param, values, channel=''):
+    definition = FILTER_DEFINITIONS[param]
+    return build_mysql_filter_query(
+        definition['mysql_name'],
+        definition['value_kind'],
+        values,
+        channel=channel,
+    )
+
+
+def build_mariadb_query_from_param(param, values):
+    definition = FILTER_DEFINITIONS[param]
+    return build_mariadb_set_query(definition['mariadb_name'], values)
+
+
+def _empty_filters():
+    return dict((name, []) for name in FILTER_DEFINITIONS)
+
+
+def _split_filter_rule(value):
+    if not value:
+        return []
+
+    return [item.strip() for item in value.split(',')]
+
+
+def _build_mysql_filter_values(value_kind, values):
+    normalized = normalize_filter_values(values)
+    if not normalized:
+        return ''
+
+    if value_kind == 'pattern':
+        return ','.join(_quote_sql_string(value) for value in normalized)
+
+    return ','.join(mysql_quote_identifier(value, value_kind) for value in normalized)
+
+
+def _quote_sql_string(value):
+    return "'%s'" % value.replace('\\', '\\\\').replace("'", "''")
+
+
+def _uses_database_table_syntax(value):
+    database_name, separator, table_name = value.partition('.')
+    return bool(separator and database_name and table_name and '.' not in table_name)
+
+
+def get_mysql_filter_rows(cursor, channel=''):
+    if channel:
+        cursor.execute(
+            'SELECT CHANNEL_NAME, FILTER_NAME, FILTER_RULE '
+            'FROM performance_schema.replication_applier_filters WHERE CHANNEL_NAME = %s',
+            (channel,),
+        )
+    else:
+        cursor.execute(
+            'SELECT FILTER_NAME, FILTER_RULE FROM performance_schema.replication_applier_global_filters'
+        )
+
+    return cursor.fetchall()
+
+
+def supports_mariadb_connection_name(server_version):
+    return LooseVersion(server_version) >= LooseVersion('10.0.1')
+
+
+def get_mariadb_filter_values(module, cursor, server_version, connection_name=''):
+    if connection_name and not supports_mariadb_connection_name(server_version):
+        module.fail_json(msg='connection_name requires MariaDB 10.0.1 or newer')
+
+    if connection_name:
+        replica_term = 'REPLICA' if LooseVersion(server_version) >= LooseVersion('10.5.1') else 'SLAVE'
+        cursor.execute('SHOW %s %s STATUS' % (replica_term, _quote_sql_string(connection_name)))
+        rows = cursor.fetchall()
+        if rows:
+            row = rows[0]
+            return {
+                'replicate_do_db': row.get('Replicate_Do_DB', ''),
+                'replicate_ignore_db': row.get('Replicate_Ignore_DB', ''),
+                'replicate_do_table': row.get('Replicate_Do_Table', ''),
+                'replicate_ignore_table': row.get('Replicate_Ignore_Table', ''),
+                'replicate_wild_do_table': row.get('Replicate_Wild_Do_Table', ''),
+                'replicate_wild_ignore_table': row.get('Replicate_Wild_Ignore_Table', ''),
+            }
+        return dict((variable_name, '') for variable_name in FILTER_DEFINITIONS)
+
+    variables = {}
+    for definition in FILTER_DEFINITIONS.values():
+        variable_name = definition['mariadb_name']
+        cursor.execute('SELECT @@GLOBAL.%s AS Value' % variable_name)
+        rows = cursor.fetchall()
+        variables[variable_name] = _extract_variable_value(rows)
+
+    return variables
+
+
+def _extract_variable_value(rows):
+    if not rows:
+        return ''
+
+    row = rows[0]
+    if isinstance(row, dict):
+        return row.get('Value', row.get('VALUE', ''))
+
+    if len(row) == 1:
+        return row[0]
+
+    return row[1]
+
+
+class MySQLReplicationFilter(object):
+    def __init__(self, module, cursor, server_implementation, server_version):
+        self.module = module
+        self.cursor = cursor
+        self.server_implementation = server_implementation
+        self.server_version = server_version
+
+    def apply(self, desired_filters, channel='', connection_name=''):
+        self.validate_filters(desired_filters)
+        self.validate_target(channel, connection_name)
+
+        if self.server_implementation == 'mysql':
+            def build_query(param, values):
+                return build_mysql_query_from_param(param, values, channel=channel)
+
+            planned = plan_filter_changes(
+                desired_filters,
+                normalize_mysql_filter_rows(get_mysql_filter_rows(self.cursor, channel=channel)),
+                build_query,
+            )
+        elif self.server_implementation == 'mariadb':
+            planned = plan_filter_changes(
+                desired_filters,
+                normalize_mariadb_filter_values(get_mariadb_filter_values(
+                    self.module,
+                    self.cursor,
+                    self.server_version,
+                    connection_name=connection_name,
+                )),
+                build_mariadb_query_from_param,
+            )
+        else:
+            self.module.fail_json(
+                msg='mysql_replication_filter supports only MySQL or MariaDB, got "%s"' % self.server_implementation
+            )
+
+        if not self.module.check_mode:
+            self.execute_queries(planned['queries'], connection_name=connection_name)
+
+        return {
+            'changed': planned['changed'],
+            'queries': [query['display'] for query in planned['queries']],
+            'filters': planned['filters'],
+        }
+
+    def execute_queries(self, queries, connection_name=''):
+        if self.server_implementation == 'mariadb' and connection_name:
+            self.cursor.execute('SET @@default_master_connection = %s', (connection_name,))
+            self.cursor.fetchall()
+
+        try:
+            for query in queries:
+                if query['params']:
+                    self.cursor.execute(query['sql'], query['params'])
+                else:
+                    self.cursor.execute(query['sql'])
+                self.cursor.fetchall()
+        finally:
+            if self.server_implementation == 'mariadb' and connection_name:
+                self.cursor.execute('SET @@default_master_connection = %s', ('',))
+                self.cursor.fetchall()
+
+    def validate_filters(self, desired_filters):
+        for param, values in desired_filters.items():
+            if values is None:
+                continue
+            check_input(self.module, values)
+            values_with_commas = [value for value in values if ',' in value]
+            if values_with_commas:
+                self.module.fail_json(
+                    msg='replication filter values cannot contain commas: %s' % ', '.join(values_with_commas)
+                )
+            if FILTER_DEFINITIONS[param]['value_kind'] in ('table', 'pattern'):
+                invalid_values = [value for value in values if not _uses_database_table_syntax(value)]
+                if invalid_values:
+                    self.module.fail_json(
+                        msg='%s values must use database.table syntax: %s' % (param, ', '.join(invalid_values))
+                    )
+
+    def validate_target(self, channel, connection_name):
+        check_input(self.module, channel, connection_name)
+
+        if self.server_implementation == 'mysql' and connection_name:
+            self.module.fail_json(msg='connection_name is supported only for MariaDB')
+
+        if self.server_implementation == 'mariadb' and channel:
+            self.module.fail_json(msg='channel is supported only for MySQL')
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    for name in FILTER_DEFINITIONS:
+        argument_spec[name] = dict(type='list', elements='str')
+
+    argument_spec.update(
+        channel=dict(type='str'),
+        connection_name=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[['channel', 'connection_name']],
+        supports_check_mode=True,
+    )
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    desired_filters = dict((name, module.params[name]) for name in FILTER_DEFINITIONS)
+    if not any(values is not None for values in desired_filters.values()):
+        module.fail_json(msg='at least one replication filter option must be provided')
+
+    connect_timeout = module.params['connect_timeout']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    ssl_cert = module.params['client_cert']
+    ssl_key = module.params['client_key']
+    ssl_ca = module.params['ca_cert']
+    check_hostname = module.params['check_hostname']
+    config_file = module.params['config_file']
+
+    try:
+        cursor, _db_conn = mysql_connect(
+            module,
+            login_user,
+            login_password,
+            config_file,
+            ssl_cert,
+            ssl_key,
+            ssl_ca,
+            None,
+            cursor_class='DictCursor',
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+        )
+    except Exception as e:
+        module.fail_json(
+            msg=(
+                "unable to connect to database, check login_user and "
+                "login_password are correct or %s has the credentials. "
+                "Exception message: %s" % (config_file, to_native(e))
+            )
+        )
+
+    executor = MySQLReplicationFilter(
+        module,
+        cursor,
+        get_server_implementation(cursor),
+        get_server_version(cursor),
+    )
+
+    try:
+        module.exit_json(
+            **executor.apply(
+                desired_filters,
+                channel=module.params['channel'],
+                connection_name=module.params['connection_name'],
+            )
+        )
+    except ValueError as e:
+        module.fail_json(msg='invalid replication filter request: %s' % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_replication_filter.py
+++ b/plugins/modules/mysql_replication_filter.py
@@ -18,6 +18,7 @@ description:
   - MySQL uses C(CHANGE REPLICATION FILTER).
   - MariaDB uses C(SET GLOBAL replicate_*) variables.
   - Changes are runtime only and are not persisted across restart by this module.
+  - Persist filter settings separately through server configuration if they must survive a restart.
 
 author:
   - Ron Gershburg (@ronger4)
@@ -54,12 +55,14 @@ options:
   replicate_wild_do_table:
     description:
       - Wildcard table patterns that should be replicated.
+      - Values must use C(database.table) syntax with C(%) and C(_) wildcards.
       - Provide an empty list to clear the filter.
     type: list
     elements: str
   replicate_wild_ignore_table:
     description:
       - Wildcard table patterns that should be ignored during replication.
+      - Values must use C(database.table) syntax with C(%) and C(_) wildcards.
       - Provide an empty list to clear the filter.
     type: list
     elements: str
@@ -96,10 +99,42 @@ EXAMPLES = r'''
     replicate_ignore_db:
       - audit
 
+- name: Replicate selected tables on a MySQL replica
+  ansible.mysql.mysql_replication_filter:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    replicate_do_table:
+      - app.orders
+      - reporting.summary
+
+- name: Set wildcard filters on a MySQL replica
+  ansible.mysql.mysql_replication_filter:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    replicate_wild_do_table:
+      - app.%
+      - reporting.sales_%
+    replicate_wild_ignore_table:
+      - archive.old_%
+      - tmp.%
+
+- name: Set multiple MySQL filters in one task
+  ansible.mysql.mysql_replication_filter:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    replicate_do_db:
+      - app
+    replicate_ignore_table:
+      - archive.events
+
 - name: Set one channel-specific MySQL filter
   ansible.mysql.mysql_replication_filter:
     login_unix_socket: /run/mysqld/mysqld.sock
     channel: analytics
+    replicate_do_db:
+      - reporting
+
+- name: Set one named MariaDB replication filter
+  ansible.mysql.mysql_replication_filter:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    connection_name: analytics
     replicate_do_db:
       - reporting
 
@@ -115,10 +150,52 @@ queries:
   returned: always
   type: list
   elements: str
+  sample:
+    - CHANGE REPLICATION FILTER REPLICATE_DO_DB = (`app`,`reporting`)
 filters:
   description: Effective normalized filter state after execution or prediction.
   returned: always
   type: dict
+  contains:
+    replicate_do_db:
+      description: Databases that should be replicated.
+      returned: always
+      type: list
+      elements: str
+    replicate_ignore_db:
+      description: Databases that should be ignored during replication.
+      returned: always
+      type: list
+      elements: str
+    replicate_do_table:
+      description: Fully qualified tables that should be replicated.
+      returned: always
+      type: list
+      elements: str
+    replicate_ignore_table:
+      description: Fully qualified tables that should be ignored during replication.
+      returned: always
+      type: list
+      elements: str
+    replicate_wild_do_table:
+      description: Wildcard table patterns that should be replicated.
+      returned: always
+      type: list
+      elements: str
+    replicate_wild_ignore_table:
+      description: Wildcard table patterns that should be ignored during replication.
+      returned: always
+      type: list
+      elements: str
+  sample:
+    replicate_do_db:
+      - app
+      - reporting
+    replicate_ignore_db: []
+    replicate_do_table: []
+    replicate_ignore_table: []
+    replicate_wild_do_table: []
+    replicate_wild_ignore_table: []
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -339,7 +416,7 @@ def get_mariadb_filter_values(module, cursor, server_version, connection_name=''
                 'replicate_wild_do_table': row.get('Replicate_Wild_Do_Table', ''),
                 'replicate_wild_ignore_table': row.get('Replicate_Wild_Ignore_Table', ''),
             }
-        return dict((variable_name, '') for variable_name in FILTER_DEFINITIONS)
+        return dict((param, '') for param in FILTER_DEFINITIONS)
 
     variables = {}
     for definition in FILTER_DEFINITIONS.values():

--- a/tests/integration/targets/test_mysql_replication_filter/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_replication_filter/defaults/main.yml
@@ -1,0 +1,11 @@
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307
+mysql_replica1_port: 3308
+mysql_replica2_port: 3309
+
+replication_user: replication_user
+replication_pass: replication_pass
+test_channel: test_channel-1
+test_connection_name: test_connection_name_1

--- a/tests/integration/targets/test_mysql_replication_filter/meta/main.yml
+++ b/tests/integration/targets/test_mysql_replication_filter/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_replication_filter/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_replication_filter/tasks/main.yml
@@ -35,44 +35,6 @@
     replicate_wild_do_table_csv: app.%,reporting.sales_%
     replicate_wild_ignore_table_csv: archive.old_%,tmp.%
   block:
-    - name: Replication filter | Start replica1 before MySQL global tests
-      ansible.mysql.mysql_replication:
-        <<: *mysql_params
-        login_port: '{{ mysql_replica1_port }}'
-        mode: startreplica
-      register: result
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Assert replica1 start for MySQL global tests
-      ansible.builtin.assert:
-        that:
-          - result is changed or 'already started' in (result.msg | default('') | lower)
-          - result.queries == ["START SLAVE"] or result.queries == ["START REPLICA"]
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Stop replica1 before MySQL global tests
-      ansible.mysql.mysql_replication:
-        <<: *mysql_params
-        login_port: '{{ mysql_replica1_port }}'
-        mode: stopreplica
-      register: result
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Assert replica1 stop for MySQL global tests
-      ansible.builtin.assert:
-        that:
-          - result is changed
-          - result.queries == ["STOP SLAVE"] or result.queries == ["STOP REPLICA"]
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
     - name: Replication filter | Clear MySQL global filters baseline
       ansible.mysql.mysql_replication_filter:
         <<: *mysql_params
@@ -382,25 +344,6 @@
         - db_engine == 'mysql'
         - db_version is version('9.0', '<')
 
-    - name: Replication filter | Start replica1 after MySQL global tests
-      ansible.mysql.mysql_replication:
-        <<: *mysql_params
-        login_port: '{{ mysql_replica1_port }}'
-        mode: startreplica
-      register: result
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Assert replica1 start after MySQL global tests
-      ansible.builtin.assert:
-        that:
-          - result is changed or 'already started' in (result.msg | default('') | lower)
-          - result.queries == ["START SLAVE"] or result.queries == ["START REPLICA"]
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
     - name: Replication filter | Get primary status for MySQL channel tests
       ansible.mysql.mysql_replication:
         <<: *mysql_params
@@ -433,46 +376,6 @@
         that:
           - result is changed
           - result.queries | length == 1
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Start MySQL channel on replica2
-      ansible.mysql.mysql_replication:
-        <<: *mysql_params
-        login_port: '{{ mysql_replica2_port }}'
-        mode: startreplica
-        channel: '{{ test_channel }}'
-      register: result
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Assert MySQL channel start
-      ansible.builtin.assert:
-        that:
-          - result is changed
-          - result.queries == ["START SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["START REPLICA FOR CHANNEL '{{ test_channel }}'"]
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Stop MySQL channel before filter tests
-      ansible.mysql.mysql_replication:
-        <<: *mysql_params
-        login_port: '{{ mysql_replica2_port }}'
-        mode: stopreplica
-        channel: '{{ test_channel }}'
-      register: result
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Assert MySQL channel stop
-      ansible.builtin.assert:
-        that:
-          - result is changed
-          - result.queries == ["STOP SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["STOP REPLICA FOR CHANNEL '{{ test_channel }}'"]
       when:
         - db_engine == 'mysql'
         - db_version is version('9.0', '<')
@@ -676,58 +579,6 @@
         - db_engine == 'mysql'
         - db_version is version('9.0', '<')
 
-    - name: Replication filter | Start MySQL channel after filter tests
-      ansible.mysql.mysql_replication:
-        <<: *mysql_params
-        login_port: '{{ mysql_replica2_port }}'
-        mode: startreplica
-        channel: '{{ test_channel }}'
-      register: result
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Assert MySQL channel restart
-      ansible.builtin.assert:
-        that:
-          - result is changed
-          - result.queries == ["START SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["START REPLICA FOR CHANNEL '{{ test_channel }}'"]
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Get MySQL channel replica status
-      ansible.mysql.mysql_replication:
-        <<: *mysql_params
-        login_port: '{{ mysql_replica2_port }}'
-        mode: getreplica
-        channel: '{{ test_channel }}'
-      register: replica_status
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Assert MySQL channel replica status
-      ansible.builtin.assert:
-        that:
-          - replica_status.Is_Replica is truthy(convert_bool=True)
-          - replica_status.Channel_Name == test_channel
-          - replica_status is not changed
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
-    - name: Replication filter | Stop MySQL channel for cleanup
-      ansible.mysql.mysql_replication:
-        <<: *mysql_params
-        login_port: '{{ mysql_replica2_port }}'
-        mode: stopreplica
-        channel: '{{ test_channel }}'
-      register: result
-      when:
-        - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
-
     - name: Replication filter | Reset MySQL channel for cleanup
       ansible.mysql.mysql_replication:
         <<: *mysql_params
@@ -744,6 +595,19 @@
         that:
           - result is changed
           - result.queries == ["RESET SLAVE ALL FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["RESET REPLICA ALL FOR CHANNEL '{{ test_channel }}'"]
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Wait for MySQL primary replica list to clear after channel cleanup
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_primary_port }}'
+        query: "SHOW REPLICAS"
+      register: result
+      until: result.query_result[0] | length == 0
+      retries: 10
+      delay: 1
       when:
         - db_engine == 'mysql'
         - db_version is version('9.0', '<')

--- a/tests/integration/targets/test_mysql_replication_filter/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_replication_filter/tasks/main.yml
@@ -1,0 +1,1212 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: Replication filter | Run tests
+  vars:
+    mysql_params: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+    replicate_do_db_values: &replicate_do_db_values
+      - app
+      - reporting
+    replicate_ignore_db_values: &replicate_ignore_db_values
+      - archive
+      - scratch
+    replicate_do_table_values: &replicate_do_table_values
+      - app.orders
+      - reporting.summary
+    replicate_ignore_table_values: &replicate_ignore_table_values
+      - archive.events
+      - tmp.sessions
+    replicate_wild_do_table_values: &replicate_wild_do_table_values
+      - app.%
+      - reporting.sales_%
+    replicate_wild_ignore_table_values: &replicate_wild_ignore_table_values
+      - archive.old_%
+      - tmp.%
+    replicate_do_db_csv: app,reporting
+    replicate_ignore_db_csv: archive,scratch
+    replicate_do_table_csv: app.orders,reporting.summary
+    replicate_ignore_table_csv: archive.events,tmp.sessions
+    replicate_wild_do_table_csv: app.%,reporting.sales_%
+    replicate_wild_ignore_table_csv: archive.old_%,tmp.%
+  block:
+    - name: Replication filter | Start replica1 before MySQL global tests
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        mode: startreplica
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert replica1 start for MySQL global tests
+      ansible.builtin.assert:
+        that:
+          - result is changed or 'already started' in (result.msg | default('') | lower)
+          - result.queries == ["START SLAVE"] or result.queries == ["START REPLICA"]
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Stop replica1 before MySQL global tests
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        mode: stopreplica
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert replica1 stop for MySQL global tests
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries == ["STOP SLAVE"] or result.queries == ["STOP REPLICA"]
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Clear MySQL global filters baseline
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: []
+        replicate_ignore_db: []
+        replicate_do_table: []
+        replicate_ignore_table: []
+        replicate_wild_do_table: []
+        replicate_wild_ignore_table: []
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Re-clear MySQL global filters baseline
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: []
+        replicate_ignore_db: []
+        replicate_do_table: []
+        replicate_ignore_table: []
+        replicate_wild_do_table: []
+        replicate_wild_ignore_table: []
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL global baseline clear idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Apply MySQL global filters in check mode
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: *replicate_do_db_values
+        replicate_ignore_db: *replicate_ignore_db_values
+        replicate_do_table: *replicate_do_table_values
+        replicate_ignore_table: *replicate_ignore_table_values
+        replicate_wild_do_table: *replicate_wild_do_table_values
+        replicate_wild_ignore_table: *replicate_wild_ignore_table_values
+      check_mode: true
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL global check mode result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 6
+          - result.filters.replicate_do_db == replicate_do_db_values
+          - result.filters.replicate_ignore_db == replicate_ignore_db_values
+          - result.filters.replicate_do_table == replicate_do_table_values
+          - result.filters.replicate_ignore_table == replicate_ignore_table_values
+          - result.filters.replicate_wild_do_table == replicate_wild_do_table_values
+          - result.filters.replicate_wild_ignore_table == replicate_wild_ignore_table_values
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Verify MySQL global filters stayed unchanged after check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        query:
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_DO_DB'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_IGNORE_DB'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_DO_TABLE'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_IGNORE_TABLE'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_WILD_DO_TABLE'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_WILD_IGNORE_TABLE'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL global filters stayed unchanged after check mode
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0] | length == 0 or result.query_result[0][0]['FILTER_RULE'] == ''
+          - result.query_result[1] | length == 0 or result.query_result[1][0]['FILTER_RULE'] == ''
+          - result.query_result[2] | length == 0 or result.query_result[2][0]['FILTER_RULE'] == ''
+          - result.query_result[3] | length == 0 or result.query_result[3][0]['FILTER_RULE'] == ''
+          - result.query_result[4] | length == 0 or result.query_result[4][0]['FILTER_RULE'] == ''
+          - result.query_result[5] | length == 0 or result.query_result[5][0]['FILTER_RULE'] == ''
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Apply MySQL global filters
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: *replicate_do_db_values
+        replicate_ignore_db: *replicate_ignore_db_values
+        replicate_do_table: *replicate_do_table_values
+        replicate_ignore_table: *replicate_ignore_table_values
+        replicate_wild_do_table: *replicate_wild_do_table_values
+        replicate_wild_ignore_table: *replicate_wild_ignore_table_values
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL global apply result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 6
+          - result.filters.replicate_do_db == replicate_do_db_values
+          - result.filters.replicate_ignore_db == replicate_ignore_db_values
+          - result.filters.replicate_do_table == replicate_do_table_values
+          - result.filters.replicate_ignore_table == replicate_ignore_table_values
+          - result.filters.replicate_wild_do_table == replicate_wild_do_table_values
+          - result.filters.replicate_wild_ignore_table == replicate_wild_ignore_table_values
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Verify MySQL global filters in Performance Schema
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        query:
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_DO_DB'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_IGNORE_DB'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_DO_TABLE'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_IGNORE_TABLE'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_WILD_DO_TABLE'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_WILD_IGNORE_TABLE'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL global filter state
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['FILTER_RULE'] == replicate_do_db_csv
+          - result.query_result[1][0]['FILTER_RULE'] == replicate_ignore_db_csv
+          - result.query_result[2][0]['FILTER_RULE'] == replicate_do_table_csv
+          - result.query_result[3][0]['FILTER_RULE'] == replicate_ignore_table_csv
+          - result.query_result[4][0]['FILTER_RULE'] == replicate_wild_do_table_csv
+          - result.query_result[5][0]['FILTER_RULE'] == replicate_wild_ignore_table_csv
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Re-apply MySQL global filters
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: *replicate_do_db_values
+        replicate_ignore_db: *replicate_ignore_db_values
+        replicate_do_table: *replicate_do_table_values
+        replicate_ignore_table: *replicate_ignore_table_values
+        replicate_wild_do_table: *replicate_wild_do_table_values
+        replicate_wild_ignore_table: *replicate_wild_ignore_table_values
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL global idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Clear MySQL global filters
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: []
+        replicate_ignore_db: []
+        replicate_do_table: []
+        replicate_ignore_table: []
+        replicate_wild_do_table: []
+        replicate_wild_ignore_table: []
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL global clear result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 6
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Verify MySQL global filters were cleared
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        query:
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_DO_DB'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_IGNORE_DB'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_DO_TABLE'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_IGNORE_TABLE'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_WILD_DO_TABLE'
+          - >
+            SELECT FILTER_RULE
+            FROM performance_schema.replication_applier_global_filters
+            WHERE FILTER_NAME = 'REPLICATE_WILD_IGNORE_TABLE'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL global filters were cleared
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0] | length == 0 or result.query_result[0][0]['FILTER_RULE'] == ''
+          - result.query_result[1] | length == 0 or result.query_result[1][0]['FILTER_RULE'] == ''
+          - result.query_result[2] | length == 0 or result.query_result[2][0]['FILTER_RULE'] == ''
+          - result.query_result[3] | length == 0 or result.query_result[3][0]['FILTER_RULE'] == ''
+          - result.query_result[4] | length == 0 or result.query_result[4][0]['FILTER_RULE'] == ''
+          - result.query_result[5] | length == 0 or result.query_result[5][0]['FILTER_RULE'] == ''
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Re-clear MySQL global filters
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: []
+        replicate_ignore_db: []
+        replicate_do_table: []
+        replicate_ignore_table: []
+        replicate_wild_do_table: []
+        replicate_wild_ignore_table: []
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL global clear idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Start replica1 after MySQL global tests
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        mode: startreplica
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert replica1 start after MySQL global tests
+      ansible.builtin.assert:
+        that:
+          - result is changed or 'already started' in (result.msg | default('') | lower)
+          - result.queries == ["START SLAVE"] or result.queries == ["START REPLICA"]
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Get primary status for MySQL channel tests
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_primary_port }}'
+        mode: getprimary
+      register: mysql_primary_status
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Configure MySQL channel on replica2
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        mode: changeprimary
+        primary_host: '{{ mysql_host }}'
+        primary_port: '{{ mysql_primary_port }}'
+        primary_user: '{{ replication_user }}'
+        primary_password: '{{ replication_pass }}'
+        primary_log_file: '{{ mysql_primary_status.File }}'
+        primary_log_pos: '{{ mysql_primary_status.Position }}'
+        channel: '{{ test_channel }}'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel configuration
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 1
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Start MySQL channel on replica2
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        mode: startreplica
+        channel: '{{ test_channel }}'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel start
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries == ["START SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["START REPLICA FOR CHANNEL '{{ test_channel }}'"]
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Stop MySQL channel before filter tests
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        mode: stopreplica
+        channel: '{{ test_channel }}'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel stop
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries == ["STOP SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["STOP REPLICA FOR CHANNEL '{{ test_channel }}'"]
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Clear MySQL channel filter baseline
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        channel: '{{ test_channel }}'
+        replicate_do_db: []
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Re-clear MySQL channel filter baseline
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        channel: '{{ test_channel }}'
+        replicate_do_db: []
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel baseline clear idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Apply MySQL channel filter in check mode
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        channel: '{{ test_channel }}'
+        replicate_do_db:
+          - reporting
+      check_mode: true
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel check mode result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 1
+          - result.filters.replicate_do_db == ['reporting']
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Verify MySQL channel filter stayed unchanged after check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        query: >
+          SELECT FILTER_RULE
+          FROM performance_schema.replication_applier_filters
+          WHERE CHANNEL_NAME = '{{ test_channel }}'
+            AND FILTER_NAME = 'REPLICATE_DO_DB'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel filter stayed unchanged after check mode
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0] | length == 0 or result.query_result[0][0]['FILTER_RULE'] == ''
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Apply MySQL channel filter
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        channel: '{{ test_channel }}'
+        replicate_do_db:
+          - reporting
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel apply result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 1
+          - result.filters.replicate_do_db == ['reporting']
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Verify MySQL channel filter in Performance Schema
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        query: >
+          SELECT FILTER_RULE
+          FROM performance_schema.replication_applier_filters
+          WHERE CHANNEL_NAME = '{{ test_channel }}'
+            AND FILTER_NAME = 'REPLICATE_DO_DB'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel filter state
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['FILTER_RULE'] == 'reporting'
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Re-apply MySQL channel filter
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        channel: '{{ test_channel }}'
+        replicate_do_db:
+          - reporting
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Clear MySQL channel filter
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        channel: '{{ test_channel }}'
+        replicate_do_db: []
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel clear result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 1
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Verify MySQL channel filter was cleared
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        query: >
+          SELECT FILTER_RULE
+          FROM performance_schema.replication_applier_filters
+          WHERE CHANNEL_NAME = '{{ test_channel }}'
+            AND FILTER_NAME = 'REPLICATE_DO_DB'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel filter was cleared
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0] | length == 0 or result.query_result[0][0]['FILTER_RULE'] == ''
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Re-clear MySQL channel filter
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        channel: '{{ test_channel }}'
+        replicate_do_db: []
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel clear idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Start MySQL channel after filter tests
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        mode: startreplica
+        channel: '{{ test_channel }}'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel restart
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries == ["START SLAVE FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["START REPLICA FOR CHANNEL '{{ test_channel }}'"]
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Get MySQL channel replica status
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        mode: getreplica
+        channel: '{{ test_channel }}'
+      register: replica_status
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel replica status
+      ansible.builtin.assert:
+        that:
+          - replica_status.Is_Replica is truthy(convert_bool=True)
+          - replica_status.Channel_Name == test_channel
+          - replica_status is not changed
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Stop MySQL channel for cleanup
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        mode: stopreplica
+        channel: '{{ test_channel }}'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Reset MySQL channel for cleanup
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        mode: resetreplicaall
+        channel: '{{ test_channel }}'
+      register: result
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Assert MySQL channel cleanup reset
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries == ["RESET SLAVE ALL FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["RESET REPLICA ALL FOR CHANNEL '{{ test_channel }}'"]
+      when:
+        - db_engine == 'mysql'
+        - db_version is version('9.0', '<')
+
+    - name: Replication filter | Start replica1 before MariaDB global tests
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        mode: startreplica
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert replica1 start for MariaDB global tests
+      ansible.builtin.assert:
+        that:
+          - result is changed or 'already started' in (result.msg | default('') | lower)
+          - result.queries == ["START SLAVE"] or result.queries == ["START REPLICA"]
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Stop replica1 before MariaDB global tests
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        mode: stopreplica
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert replica1 stop for MariaDB global tests
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries == ["STOP SLAVE"] or result.queries == ["STOP REPLICA"]
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Clear MariaDB global filters baseline
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: []
+        replicate_ignore_db: []
+        replicate_do_table: []
+        replicate_ignore_table: []
+        replicate_wild_do_table: []
+        replicate_wild_ignore_table: []
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Re-clear MariaDB global filters baseline
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: []
+        replicate_ignore_db: []
+        replicate_do_table: []
+        replicate_ignore_table: []
+        replicate_wild_do_table: []
+        replicate_wild_ignore_table: []
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB global baseline clear idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Apply MariaDB global filters in check mode
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: *replicate_do_db_values
+        replicate_ignore_db: *replicate_ignore_db_values
+        replicate_do_table: *replicate_do_table_values
+        replicate_ignore_table: *replicate_ignore_table_values
+        replicate_wild_do_table: *replicate_wild_do_table_values
+        replicate_wild_ignore_table: *replicate_wild_ignore_table_values
+      check_mode: true
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB check mode result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 6
+          - result.filters.replicate_do_db == replicate_do_db_values
+          - result.filters.replicate_ignore_db == replicate_ignore_db_values
+          - result.filters.replicate_do_table == replicate_do_table_values
+          - result.filters.replicate_ignore_table == replicate_ignore_table_values
+          - result.filters.replicate_wild_do_table == replicate_wild_do_table_values
+          - result.filters.replicate_wild_ignore_table == replicate_wild_ignore_table_values
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Verify MariaDB filters stayed unchanged after check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_do_db'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_ignore_db'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_do_table'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_ignore_table'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_wild_do_table'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_wild_ignore_table'"
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB filters stayed unchanged after check mode
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['Value'] == ''
+          - result.query_result[1][0]['Value'] == ''
+          - result.query_result[2][0]['Value'] == ''
+          - result.query_result[3][0]['Value'] == ''
+          - result.query_result[4][0]['Value'] == ''
+          - result.query_result[5][0]['Value'] == ''
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Apply MariaDB global filters
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: *replicate_do_db_values
+        replicate_ignore_db: *replicate_ignore_db_values
+        replicate_do_table: *replicate_do_table_values
+        replicate_ignore_table: *replicate_ignore_table_values
+        replicate_wild_do_table: *replicate_wild_do_table_values
+        replicate_wild_ignore_table: *replicate_wild_ignore_table_values
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB apply result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 6
+          - result.filters.replicate_do_db == replicate_do_db_values
+          - result.filters.replicate_ignore_db == replicate_ignore_db_values
+          - result.filters.replicate_do_table == replicate_do_table_values
+          - result.filters.replicate_ignore_table == replicate_ignore_table_values
+          - result.filters.replicate_wild_do_table == replicate_wild_do_table_values
+          - result.filters.replicate_wild_ignore_table == replicate_wild_ignore_table_values
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Verify MariaDB filter variables
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_do_db'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_ignore_db'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_do_table'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_ignore_table'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_wild_do_table'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_wild_ignore_table'"
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB filter state
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['Value'].split(',') | sort == replicate_do_db_values | sort
+          - result.query_result[1][0]['Value'].split(',') | sort == replicate_ignore_db_values | sort
+          - result.query_result[2][0]['Value'].split(',') | sort == replicate_do_table_values | sort
+          - result.query_result[3][0]['Value'].split(',') | sort == replicate_ignore_table_values | sort
+          - result.query_result[4][0]['Value'].split(',') | sort == replicate_wild_do_table_values | sort
+          - result.query_result[5][0]['Value'].split(',') | sort == replicate_wild_ignore_table_values | sort
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Re-apply MariaDB global filters
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: *replicate_do_db_values
+        replicate_ignore_db: *replicate_ignore_db_values
+        replicate_do_table: *replicate_do_table_values
+        replicate_ignore_table: *replicate_ignore_table_values
+        replicate_wild_do_table: *replicate_wild_do_table_values
+        replicate_wild_ignore_table: *replicate_wild_ignore_table_values
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Clear MariaDB global filters
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: []
+        replicate_ignore_db: []
+        replicate_do_table: []
+        replicate_ignore_table: []
+        replicate_wild_do_table: []
+        replicate_wild_ignore_table: []
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB clear result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 6
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Verify MariaDB filters were cleared
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        query:
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_do_db'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_ignore_db'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_do_table'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_ignore_table'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_wild_do_table'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_wild_ignore_table'"
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB filters were cleared
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['Value'] == ''
+          - result.query_result[1][0]['Value'] == ''
+          - result.query_result[2][0]['Value'] == ''
+          - result.query_result[3][0]['Value'] == ''
+          - result.query_result[4][0]['Value'] == ''
+          - result.query_result[5][0]['Value'] == ''
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Re-clear MariaDB global filters
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        replicate_do_db: []
+        replicate_ignore_db: []
+        replicate_do_table: []
+        replicate_ignore_table: []
+        replicate_wild_do_table: []
+        replicate_wild_ignore_table: []
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB global clear idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Start replica1 after MariaDB global tests
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica1_port }}'
+        mode: startreplica
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert replica1 start after MariaDB global tests
+      ansible.builtin.assert:
+        that:
+          - result is changed or 'already started' in (result.msg | default('') | lower)
+          - result.queries == ["START SLAVE"] or result.queries == ["START REPLICA"]
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Get primary status for MariaDB connection_name tests
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_primary_port }}'
+        mode: getprimary
+      register: mysql_primary_status
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Configure MariaDB named replication connection on replica2
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        mode: changeprimary
+        primary_host: '{{ mysql_host }}'
+        primary_port: '{{ mysql_primary_port }}'
+        primary_user: '{{ replication_user }}'
+        primary_password: '{{ replication_pass }}'
+        primary_log_file: '{{ mysql_primary_status.File }}'
+        primary_log_pos: '{{ mysql_primary_status.Position }}'
+        connection_name: '{{ test_connection_name }}'
+        fail_on_error: true
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB named connection configuration
+      ansible.builtin.assert:
+        that:
+          - result is changed
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Start MariaDB named replication connection on replica2
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        mode: startreplica
+        connection_name: '{{ test_connection_name }}'
+        fail_on_error: true
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB named connection start
+      ansible.builtin.assert:
+        that:
+          - result is changed or 'already started' in (result.msg | default('') | lower)
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Stop MariaDB named replication connection on replica2
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        mode: stopreplica
+        connection_name: '{{ test_connection_name }}'
+        fail_on_error: true
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB named connection stop
+      ansible.builtin.assert:
+        that:
+          - result is changed
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Clear MariaDB connection_name filter baseline
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        connection_name: '{{ test_connection_name }}'
+        replicate_do_db: []
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Re-clear MariaDB connection_name filter baseline
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        connection_name: '{{ test_connection_name }}'
+        replicate_do_db: []
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB connection_name baseline clear idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Apply MariaDB connection_name filter in check mode
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        connection_name: '{{ test_connection_name }}'
+        replicate_do_db:
+          - reporting
+      check_mode: true
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB connection_name check mode result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries == ["SET GLOBAL `replicate_do_db` = 'reporting'"]
+          - result.filters.replicate_do_db == ['reporting']
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Verify MariaDB connection_name filter stayed unchanged after check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        query:
+          - "SET @@default_master_connection='{{ test_connection_name }}'"
+          - "SHOW GLOBAL VARIABLES LIKE 'replicate_do_db'"
+          - "SET @@default_master_connection=''"
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB connection_name filter stayed unchanged after check mode
+      ansible.builtin.assert:
+        that:
+          - result.query_result[1][0]['Value'] == ''
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Apply MariaDB connection_name filter
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        connection_name: '{{ test_connection_name }}'
+        replicate_do_db:
+          - reporting
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB connection_name apply result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.filters.replicate_do_db == ['reporting']
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Re-apply MariaDB connection_name filter
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        connection_name: '{{ test_connection_name }}'
+        replicate_do_db:
+          - reporting
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB connection_name idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Clear MariaDB connection_name filter
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        connection_name: '{{ test_connection_name }}'
+        replicate_do_db: []
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB connection_name clear result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries == ["SET GLOBAL `replicate_do_db` = ''"]
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Re-clear MariaDB connection_name filter
+      ansible.mysql.mysql_replication_filter:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        connection_name: '{{ test_connection_name }}'
+        replicate_do_db: []
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB connection_name clear idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Reset MariaDB named replication connection on replica2
+      ansible.mysql.mysql_replication:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        mode: resetreplicaall
+        connection_name: '{{ test_connection_name }}'
+        fail_on_error: true
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB named connection reset
+      ansible.builtin.assert:
+        that:
+          - result is changed
+      when: db_engine == 'mariadb'

--- a/tests/integration/targets/test_mysql_replication_filter/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_replication_filter/tasks/main.yml
@@ -47,7 +47,6 @@
         replicate_wild_ignore_table: []
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Re-clear MySQL global filters baseline
       ansible.mysql.mysql_replication_filter:
@@ -62,7 +61,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL global baseline clear idempotency
       ansible.builtin.assert:
@@ -70,7 +68,6 @@
           - result is not changed
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Apply MySQL global filters in check mode
       ansible.mysql.mysql_replication_filter:
@@ -86,7 +83,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL global check mode result
       ansible.builtin.assert:
@@ -101,7 +97,6 @@
           - result.filters.replicate_wild_ignore_table == replicate_wild_ignore_table_values
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Verify MySQL global filters stayed unchanged after check mode
       ansible.mysql.mysql_query:
@@ -135,7 +130,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL global filters stayed unchanged after check mode
       ansible.builtin.assert:
@@ -148,7 +142,6 @@
           - result.query_result[5] | length == 0 or result.query_result[5][0]['FILTER_RULE'] == ''
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Apply MySQL global filters
       ansible.mysql.mysql_replication_filter:
@@ -163,7 +156,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL global apply result
       ansible.builtin.assert:
@@ -178,7 +170,6 @@
           - result.filters.replicate_wild_ignore_table == replicate_wild_ignore_table_values
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Verify MySQL global filters in Performance Schema
       ansible.mysql.mysql_query:
@@ -212,7 +203,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL global filter state
       ansible.builtin.assert:
@@ -225,7 +215,6 @@
           - result.query_result[5][0]['FILTER_RULE'] == replicate_wild_ignore_table_csv
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Re-apply MySQL global filters
       ansible.mysql.mysql_replication_filter:
@@ -240,7 +229,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL global idempotency
       ansible.builtin.assert:
@@ -248,7 +236,6 @@
           - result is not changed
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Clear MySQL global filters
       ansible.mysql.mysql_replication_filter:
@@ -263,7 +250,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL global clear result
       ansible.builtin.assert:
@@ -272,7 +258,6 @@
           - result.queries | length == 6
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Verify MySQL global filters were cleared
       ansible.mysql.mysql_query:
@@ -306,7 +291,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL global filters were cleared
       ansible.builtin.assert:
@@ -319,7 +303,6 @@
           - result.query_result[5] | length == 0 or result.query_result[5][0]['FILTER_RULE'] == ''
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Re-clear MySQL global filters
       ansible.mysql.mysql_replication_filter:
@@ -334,7 +317,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL global clear idempotency
       ansible.builtin.assert:
@@ -342,7 +324,6 @@
           - result is not changed
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Get primary status for MySQL channel tests
       ansible.mysql.mysql_replication:
@@ -352,7 +333,6 @@
       register: mysql_primary_status
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Configure MySQL channel on replica2
       ansible.mysql.mysql_replication:
@@ -369,7 +349,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL channel configuration
       ansible.builtin.assert:
@@ -378,7 +357,6 @@
           - result.queries | length == 1
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Clear MySQL channel filter baseline
       ansible.mysql.mysql_replication_filter:
@@ -388,7 +366,6 @@
         replicate_do_db: []
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Re-clear MySQL channel filter baseline
       ansible.mysql.mysql_replication_filter:
@@ -399,7 +376,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL channel baseline clear idempotency
       ansible.builtin.assert:
@@ -407,7 +383,6 @@
           - result is not changed
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Apply MySQL channel filter in check mode
       ansible.mysql.mysql_replication_filter:
@@ -420,7 +395,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL channel check mode result
       ansible.builtin.assert:
@@ -430,7 +404,6 @@
           - result.filters.replicate_do_db == ['reporting']
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Verify MySQL channel filter stayed unchanged after check mode
       ansible.mysql.mysql_query:
@@ -444,7 +417,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL channel filter stayed unchanged after check mode
       ansible.builtin.assert:
@@ -452,7 +424,6 @@
           - result.query_result[0] | length == 0 or result.query_result[0][0]['FILTER_RULE'] == ''
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Apply MySQL channel filter
       ansible.mysql.mysql_replication_filter:
@@ -464,7 +435,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL channel apply result
       ansible.builtin.assert:
@@ -474,7 +444,6 @@
           - result.filters.replicate_do_db == ['reporting']
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Verify MySQL channel filter in Performance Schema
       ansible.mysql.mysql_query:
@@ -488,7 +457,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL channel filter state
       ansible.builtin.assert:
@@ -496,7 +464,6 @@
           - result.query_result[0][0]['FILTER_RULE'] == 'reporting'
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Re-apply MySQL channel filter
       ansible.mysql.mysql_replication_filter:
@@ -508,7 +475,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL channel idempotency
       ansible.builtin.assert:
@@ -516,7 +482,6 @@
           - result is not changed
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Clear MySQL channel filter
       ansible.mysql.mysql_replication_filter:
@@ -527,7 +492,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL channel clear result
       ansible.builtin.assert:
@@ -536,7 +500,6 @@
           - result.queries | length == 1
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Verify MySQL channel filter was cleared
       ansible.mysql.mysql_query:
@@ -550,7 +513,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL channel filter was cleared
       ansible.builtin.assert:
@@ -558,7 +520,6 @@
           - result.query_result[0] | length == 0 or result.query_result[0][0]['FILTER_RULE'] == ''
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Re-clear MySQL channel filter
       ansible.mysql.mysql_replication_filter:
@@ -569,7 +530,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL channel clear idempotency
       ansible.builtin.assert:
@@ -577,7 +537,6 @@
           - result is not changed
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Reset MySQL channel for cleanup
       ansible.mysql.mysql_replication:
@@ -588,7 +547,6 @@
       register: result
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Assert MySQL channel cleanup reset
       ansible.builtin.assert:
@@ -597,7 +555,6 @@
           - result.queries == ["RESET SLAVE ALL FOR CHANNEL '{{ test_channel }}'"] or result.queries == ["RESET REPLICA ALL FOR CHANNEL '{{ test_channel }}'"]
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Wait for MySQL primary replica list to clear after channel cleanup
       ansible.mysql.mysql_query:
@@ -610,7 +567,6 @@
       delay: 1
       when:
         - db_engine == 'mysql'
-        - db_version is version('9.0', '<')
 
     - name: Replication filter | Start replica1 before MariaDB global tests
       ansible.mysql.mysql_replication:
@@ -1009,7 +965,24 @@
       ansible.builtin.assert:
         that:
           - result is changed
+          - result.queries == ["SET GLOBAL `replicate_do_db` = 'reporting'"]
           - result.filters.replicate_do_db == ['reporting']
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Verify MariaDB connection_name filter after apply
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        query: >-
+          SHOW {{ 'REPLICA' if db_version is version('10.5.1', '>=') else 'SLAVE' }}
+          '{{ test_connection_name }}' STATUS
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB connection_name filter state after apply
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['Replicate_Do_DB'] == 'reporting'
       when: db_engine == 'mariadb'
 
     - name: Replication filter | Re-apply MariaDB connection_name filter
@@ -1042,6 +1015,22 @@
         that:
           - result is changed
           - result.queries == ["SET GLOBAL `replicate_do_db` = ''"]
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Verify MariaDB connection_name filter after clear
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_port: '{{ mysql_replica2_port }}'
+        query: >-
+          SHOW {{ 'REPLICA' if db_version is version('10.5.1', '>=') else 'SLAVE' }}
+          '{{ test_connection_name }}' STATUS
+      register: result
+      when: db_engine == 'mariadb'
+
+    - name: Replication filter | Assert MariaDB connection_name filter state after clear
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['Replicate_Do_DB'] == ''
       when: db_engine == 'mariadb'
 
     - name: Replication filter | Re-clear MariaDB connection_name filter

--- a/tests/unit/plugins/modules/test_mysql_replication_filter.py
+++ b/tests/unit/plugins/modules/test_mysql_replication_filter.py
@@ -1,0 +1,753 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from contextlib import contextmanager
+import importlib
+import json
+import sys
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_bytes
+try:
+    from ansible.module_utils.testing import patch_module_args  # pyright: ignore[reportMissingImports]
+except ImportError:
+    patch_module_args = None
+
+MYSQL_REPLICATION_FILTER_MODULE = 'ansible_collections.ansible.mysql.plugins.modules.mysql_replication_filter'
+
+try:
+    mysql_replication_filter_module = importlib.import_module(MYSQL_REPLICATION_FILTER_MODULE)
+except ModuleNotFoundError as exc:
+    if exc.name != MYSQL_REPLICATION_FILTER_MODULE:
+        raise
+    MySQLReplicationFilter = None
+    _IMPORT_ERROR = (
+        "mysql_replication_filter module not yet implemented - create "
+        "plugins/modules/mysql_replication_filter.py first. Original error: %s" % exc
+    )
+else:
+    build_mariadb_set_query = mysql_replication_filter_module.build_mariadb_set_query
+    build_mysql_filter_query = mysql_replication_filter_module.build_mysql_filter_query
+    get_mariadb_filter_values = mysql_replication_filter_module.get_mariadb_filter_values
+    get_mysql_filter_rows = mysql_replication_filter_module.get_mysql_filter_rows
+    MySQLReplicationFilter = mysql_replication_filter_module.MySQLReplicationFilter
+    normalize_filter_values = mysql_replication_filter_module.normalize_filter_values
+    normalize_mariadb_filter_values = mysql_replication_filter_module.normalize_mariadb_filter_values
+    normalize_mysql_filter_rows = mysql_replication_filter_module.normalize_mysql_filter_rows
+    plan_filter_changes = mysql_replication_filter_module.plan_filter_changes
+    supports_mariadb_connection_name = mysql_replication_filter_module.supports_mariadb_connection_name
+    _IMPORT_ERROR = None
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+@contextmanager
+def set_module_args(args):
+    module_args = dict(args)
+    original_argv = sys.argv[:]
+    sys.argv = ['ansible_unittest']
+
+    try:
+        if patch_module_args is not None:
+            with patch_module_args(module_args):
+                yield
+            return
+
+        original_args = getattr(basic, '_ANSIBLE_ARGS', None)
+        original_profile = getattr(basic, '_ANSIBLE_PROFILE', None)
+        had_profile = hasattr(basic, '_ANSIBLE_PROFILE')
+
+        basic._ANSIBLE_ARGS = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': module_args}))
+        basic._ANSIBLE_PROFILE = 'legacy'
+
+        try:
+            yield
+        finally:
+            basic._ANSIBLE_ARGS = original_args
+            if had_profile:
+                basic._ANSIBLE_PROFILE = original_profile
+            else:
+                delattr(basic, '_ANSIBLE_PROFILE')
+    finally:
+        sys.argv = original_argv
+
+
+def _require_module():
+    if _IMPORT_ERROR:
+        pytest.fail(_IMPORT_ERROR)
+
+
+class FakeCursor(object):
+    def __init__(self, version='8.4.0-mysql', global_rows=None, channel_rows=None, variables=None, connection_variables=None):
+        self.version = version
+        self.global_rows = list(global_rows or [])
+        self.channel_rows = dict(channel_rows or {})
+        self.variables = dict(variables or {})
+        self.connection_variables = dict(connection_variables or {})
+        self.default_master_connection = ''
+        self.executed = []
+        self._rows = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+        if query == 'SELECT VERSION() AS version':
+            self._rows = [{'version': self.version}]
+            return
+
+        if query == 'SELECT FILTER_NAME, FILTER_RULE FROM performance_schema.replication_applier_global_filters':
+            self._rows = list(self.global_rows)
+            return
+
+        if query == (
+            'SELECT CHANNEL_NAME, FILTER_NAME, FILTER_RULE '
+            'FROM performance_schema.replication_applier_filters WHERE CHANNEL_NAME = %s'
+        ):
+            self._rows = list(self.channel_rows.get(params[0], []))
+            return
+
+        if query.startswith('CHANGE REPLICATION FILTER '):
+            self._rows = []
+            return
+
+        if query == 'SHOW GLOBAL VARIABLES WHERE Variable_name = %s':
+            variable_name = params[0]
+            active_variables = self.variables
+            if self.default_master_connection:
+                active_variables = self.connection_variables.get(self.default_master_connection, {})
+            if variable_name in active_variables:
+                self._rows = [(variable_name, active_variables[variable_name])]
+            else:
+                self._rows = []
+            return
+
+        if query.startswith('SELECT @@GLOBAL.') and query.endswith(' AS Value'):
+            variable_name = query[len('SELECT @@GLOBAL.'): -len(' AS Value')]
+            active_variables = self.variables
+            if self.default_master_connection:
+                active_variables = self.connection_variables.get(self.default_master_connection, {})
+            self._rows = [{'Value': active_variables.get(variable_name, '')}]
+            return
+
+        if query.startswith("SHOW REPLICA '") and query.endswith("' STATUS"):
+            connection_name = query[len("SHOW REPLICA '"): -len("' STATUS")]
+            active_variables = self.connection_variables.get(connection_name, {})
+            self._rows = [{
+                'Replicate_Do_DB': active_variables.get('replicate_do_db', ''),
+                'Replicate_Ignore_DB': active_variables.get('replicate_ignore_db', ''),
+                'Replicate_Do_Table': active_variables.get('replicate_do_table', ''),
+                'Replicate_Ignore_Table': active_variables.get('replicate_ignore_table', ''),
+                'Replicate_Wild_Do_Table': active_variables.get('replicate_wild_do_table', ''),
+                'Replicate_Wild_Ignore_Table': active_variables.get('replicate_wild_ignore_table', ''),
+            }]
+            return
+
+        if query == 'SET @@default_master_connection = %s':
+            self.default_master_connection = params[0]
+            self._rows = []
+            return
+
+        if query.startswith('SET GLOBAL '):
+            variable_name = query.split('`')[1]
+            active_variables = self.variables
+            if self.default_master_connection:
+                active_variables = self.connection_variables.setdefault(self.default_master_connection, {})
+            active_variables[variable_name] = params[0]
+            self._rows = []
+            return
+
+        raise AssertionError('Unexpected query: %s (params=%s)' % (query, params))
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return list(self._rows)
+
+
+class ModuleStub(object):
+    def __init__(self, check_mode=False):
+        self.check_mode = check_mode
+
+    def fail_json(self, **kwargs):
+        raise RuntimeError(kwargs.get('msg', 'fail_json called'))
+
+
+class CursorStub(object):
+    def __init__(self, responses=None, version='10.11.0-MariaDB'):
+        self.responses = list(responses or [])
+        self.version = version
+        self.executed = []
+        self._version_requested = False
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+        if query == 'SELECT VERSION() AS version':
+            self._version_requested = True
+
+    def fetchone(self):
+        if self._version_requested:
+            self._version_requested = False
+            return {'version': self.version}
+        if self.responses:
+            rows = self.responses.pop(0)
+            return rows[0] if rows else None
+        return None
+
+    def fetchall(self):
+        if self.responses:
+            return self.responses.pop(0)
+        return []
+
+
+def test_module_is_importable():
+    _require_module()
+
+
+def test_normalize_filter_values_orders_and_deduplicates_items():
+    _require_module()
+
+    assert normalize_filter_values([' reporting ', 'analytics', 'reporting']) == [
+        'analytics',
+        'reporting',
+    ]
+
+
+def test_normalize_mysql_filter_rows_maps_filter_names_and_empty_rules():
+    _require_module()
+
+    rows = [
+        {
+            'FILTER_NAME': 'REPLICATE_IGNORE_DB',
+            'FILTER_RULE': 'reporting,analytics',
+        },
+        {
+            'FILTER_NAME': 'REPLICATE_DO_TABLE',
+            'FILTER_RULE': 'app.orders,reporting.summary',
+        },
+        {
+            'FILTER_NAME': 'REPLICATE_WILD_IGNORE_TABLE',
+            'FILTER_RULE': '',
+        },
+    ]
+
+    assert normalize_mysql_filter_rows(rows) == {
+        'replicate_do_db': [],
+        'replicate_ignore_db': ['analytics', 'reporting'],
+        'replicate_do_table': ['app.orders', 'reporting.summary'],
+        'replicate_ignore_table': [],
+        'replicate_wild_do_table': [],
+        'replicate_wild_ignore_table': [],
+    }
+
+
+def test_normalize_mariadb_filter_values_maps_csv_rules():
+    _require_module()
+
+    variables = {
+        'replicate_do_db': 'app,reporting',
+        'replicate_ignore_db': '',
+        'replicate_do_table': 'app.orders,reporting.summary',
+        'replicate_ignore_table': '',
+        'replicate_wild_do_table': 'app.%,reporting.sales_%',
+        'replicate_wild_ignore_table': '',
+    }
+
+    assert normalize_mariadb_filter_values(variables) == {
+        'replicate_do_db': ['app', 'reporting'],
+        'replicate_ignore_db': [],
+        'replicate_do_table': ['app.orders', 'reporting.summary'],
+        'replicate_ignore_table': [],
+        'replicate_wild_do_table': ['app.%', 'reporting.sales_%'],
+        'replicate_wild_ignore_table': [],
+    }
+
+
+def test_plan_filter_changes_updates_only_requested_filters():
+    _require_module()
+
+    current_filters = {
+        'replicate_do_db': ['app'],
+        'replicate_ignore_db': ['archive'],
+        'replicate_do_table': [],
+        'replicate_ignore_table': [],
+        'replicate_wild_do_table': [],
+        'replicate_wild_ignore_table': [],
+    }
+
+    planned = plan_filter_changes(
+        {
+            'replicate_do_db': None,
+            'replicate_ignore_db': ['reporting', 'analytics'],
+        },
+        current_filters,
+        lambda param, values: {
+            'sql': param,
+            'params': tuple(values),
+            'display': '%s=%s' % (param, ','.join(values)),
+        },
+    )
+
+    assert planned['changed'] is True
+    assert planned['queries'] == [
+        {
+            'sql': 'replicate_ignore_db',
+            'params': ('analytics', 'reporting'),
+            'display': 'replicate_ignore_db=analytics,reporting',
+        }
+    ]
+    assert planned['filters'] == {
+        'replicate_do_db': ['app'],
+        'replicate_ignore_db': ['analytics', 'reporting'],
+        'replicate_do_table': [],
+        'replicate_ignore_table': [],
+        'replicate_wild_do_table': [],
+        'replicate_wild_ignore_table': [],
+    }
+
+
+def test_plan_filter_changes_treats_order_only_difference_as_idempotent():
+    _require_module()
+
+    planned = plan_filter_changes(
+        {'replicate_ignore_db': ['reporting', 'analytics']},
+        {
+            'replicate_do_db': [],
+            'replicate_ignore_db': ['analytics', 'reporting'],
+            'replicate_do_table': [],
+            'replicate_ignore_table': [],
+            'replicate_wild_do_table': [],
+            'replicate_wild_ignore_table': [],
+        },
+        lambda param, values: {'sql': param, 'params': tuple(values), 'display': param},
+    )
+
+    assert planned['changed'] is False
+    assert planned['queries'] == []
+
+
+def test_build_mysql_filter_query_quotes_identifier_values_and_channel():
+    _require_module()
+
+    assert build_mysql_filter_query(
+        'REPLICATE_IGNORE_DB',
+        'database',
+        ['reporting', 'analytics'],
+        channel=r'analytics\channel',
+    ) == {
+        'sql': (
+            "CHANGE REPLICATION FILTER REPLICATE_IGNORE_DB = (`analytics`,`reporting`) "
+            r"FOR CHANNEL 'analytics\\channel'"
+        ),
+        'params': (),
+        'display': (
+            "CHANGE REPLICATION FILTER REPLICATE_IGNORE_DB = (`analytics`,`reporting`) "
+            r"FOR CHANNEL 'analytics\\channel'"
+        ),
+    }
+
+
+def test_build_mysql_filter_query_quotes_wildcard_values_and_clears_empty_lists():
+    _require_module()
+
+    assert build_mysql_filter_query(
+        'REPLICATE_WILD_IGNORE_TABLE',
+        'pattern',
+        ['reporting.sales_%', r'tmp.\_%'],
+    ) == {
+        'sql': r"CHANGE REPLICATION FILTER REPLICATE_WILD_IGNORE_TABLE = ('reporting.sales_%','tmp.\\_%')",
+        'params': (),
+        'display': r"CHANGE REPLICATION FILTER REPLICATE_WILD_IGNORE_TABLE = ('reporting.sales_%','tmp.\\_%')",
+    }
+
+    assert build_mysql_filter_query('REPLICATE_DO_DB', 'database', []) == {
+        'sql': "CHANGE REPLICATION FILTER REPLICATE_DO_DB = ()",
+        'params': (),
+        'display': "CHANGE REPLICATION FILTER REPLICATE_DO_DB = ()",
+    }
+
+
+def test_build_mariadb_set_query_uses_csv_values_and_clear():
+    _require_module()
+
+    assert build_mariadb_set_query('replicate_do_db', ['reporting', 'analytics']) == {
+        'sql': "SET GLOBAL `replicate_do_db` = %s",
+        'params': ('analytics,reporting',),
+        'display': "SET GLOBAL `replicate_do_db` = 'analytics,reporting'",
+    }
+
+    assert build_mariadb_set_query('replicate_do_db', []) == {
+        'sql': "SET GLOBAL `replicate_do_db` = %s",
+        'params': ('',),
+        'display': "SET GLOBAL `replicate_do_db` = ''",
+    }
+
+
+def test_get_mysql_filter_rows_uses_channel_table():
+    _require_module()
+
+    cursor = CursorStub([[
+        {
+            'CHANNEL_NAME': 'analytics',
+            'FILTER_NAME': 'REPLICATE_DO_DB',
+            'FILTER_RULE': 'reporting,app',
+        }
+    ]])
+
+    assert get_mysql_filter_rows(cursor, channel='analytics') == [
+        {
+            'CHANNEL_NAME': 'analytics',
+            'FILTER_NAME': 'REPLICATE_DO_DB',
+            'FILTER_RULE': 'reporting,app',
+        }
+    ]
+    assert cursor.executed == [
+        (
+            'SELECT CHANNEL_NAME, FILTER_NAME, FILTER_RULE '
+            'FROM performance_schema.replication_applier_filters WHERE CHANNEL_NAME = %s',
+            ('analytics',),
+        )
+    ]
+
+
+def test_supports_mariadb_connection_name_checks_version_threshold():
+    _require_module()
+
+    assert supports_mariadb_connection_name('10.0.0-MariaDB') is False
+    assert supports_mariadb_connection_name('10.0.1-MariaDB') is True
+
+
+def test_get_mariadb_filter_values_uses_connection_status_context():
+    _require_module()
+
+    cursor = CursorStub([[
+        {
+            'Replicate_Do_DB': 'app,reporting',
+            'Replicate_Ignore_DB': '',
+            'Replicate_Do_Table': 'app.orders',
+            'Replicate_Ignore_Table': '',
+            'Replicate_Wild_Do_Table': 'reporting.sales_%',
+            'Replicate_Wild_Ignore_Table': '',
+        }
+    ]])
+
+    assert get_mariadb_filter_values(
+        ModuleStub(),
+        cursor,
+        '10.11.0-MariaDB',
+        connection_name=r'analytics\path',
+    ) == {
+        'replicate_do_db': 'app,reporting',
+        'replicate_ignore_db': '',
+        'replicate_do_table': 'app.orders',
+        'replicate_ignore_table': '',
+        'replicate_wild_do_table': 'reporting.sales_%',
+        'replicate_wild_ignore_table': '',
+    }
+    assert cursor.executed == [
+        (r"SHOW REPLICA 'analytics\\path' STATUS", None),
+    ]
+
+
+def test_get_mariadb_filter_values_reads_global_variables_without_connection_name():
+    _require_module()
+
+    cursor = CursorStub([
+        [('app,reporting',)],
+        [('',)],
+        [('app.orders',)],
+        [('',)],
+        [('reporting.sales_%',)],
+        [('',)],
+    ])
+
+    assert get_mariadb_filter_values(ModuleStub(), cursor, '10.11.0-MariaDB') == {
+        'replicate_do_db': 'app,reporting',
+        'replicate_ignore_db': '',
+        'replicate_do_table': 'app.orders',
+        'replicate_ignore_table': '',
+        'replicate_wild_do_table': 'reporting.sales_%',
+        'replicate_wild_ignore_table': '',
+    }
+    assert cursor.executed == [
+        ('SELECT @@GLOBAL.replicate_do_db AS Value', None),
+        ('SELECT @@GLOBAL.replicate_ignore_db AS Value', None),
+        ('SELECT @@GLOBAL.replicate_do_table AS Value', None),
+        ('SELECT @@GLOBAL.replicate_ignore_table AS Value', None),
+        ('SELECT @@GLOBAL.replicate_wild_do_table AS Value', None),
+        ('SELECT @@GLOBAL.replicate_wild_ignore_table AS Value', None),
+    ]
+
+
+def test_get_mariadb_filter_values_rejects_connection_name_on_old_versions():
+    _require_module()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        get_mariadb_filter_values(ModuleStub(), CursorStub(), '10.0.0-MariaDB', connection_name='analytics')
+
+    assert str(exc_info.value) == 'connection_name requires MariaDB 10.0.1 or newer'
+
+
+def test_apply_mysql_check_mode_predicts_channel_query_without_writes():
+    _require_module()
+
+    cursor = FakeCursor(channel_rows={
+        'analytics-channel': [
+            {
+                'CHANNEL_NAME': 'analytics-channel',
+                'FILTER_NAME': 'REPLICATE_IGNORE_DB',
+                'FILTER_RULE': 'archive',
+            }
+        ]
+    })
+
+    manager = MySQLReplicationFilter(ModuleStub(check_mode=True), cursor, 'mysql', '8.4.0')
+    result = manager.apply(
+        {'replicate_ignore_db': ['reporting', 'analytics']},
+        channel='analytics-channel',
+    )
+
+    assert result == {
+        'changed': True,
+        'queries': [
+            (
+                "CHANGE REPLICATION FILTER REPLICATE_IGNORE_DB = (`analytics`,`reporting`) "
+                "FOR CHANNEL 'analytics-channel'"
+            )
+        ],
+        'filters': {
+            'replicate_do_db': [],
+            'replicate_ignore_db': ['analytics', 'reporting'],
+            'replicate_do_table': [],
+            'replicate_ignore_table': [],
+            'replicate_wild_do_table': [],
+            'replicate_wild_ignore_table': [],
+        },
+    }
+    assert cursor.executed == [
+        (
+            'SELECT CHANNEL_NAME, FILTER_NAME, FILTER_RULE '
+            'FROM performance_schema.replication_applier_filters WHERE CHANNEL_NAME = %s',
+            ('analytics-channel',),
+        )
+    ]
+
+
+def test_apply_mysql_executes_change_query_in_real_mode():
+    _require_module()
+
+    cursor = FakeCursor(global_rows=[])
+
+    manager = MySQLReplicationFilter(ModuleStub(check_mode=False), cursor, 'mysql', '8.4.0')
+    result = manager.apply({'replicate_do_db': ['app']})
+
+    assert result == {
+        'changed': True,
+        'queries': [
+            "CHANGE REPLICATION FILTER REPLICATE_DO_DB = (`app`)",
+        ],
+        'filters': {
+            'replicate_do_db': ['app'],
+            'replicate_ignore_db': [],
+            'replicate_do_table': [],
+            'replicate_ignore_table': [],
+            'replicate_wild_do_table': [],
+            'replicate_wild_ignore_table': [],
+        },
+    }
+    assert cursor.executed == [
+        ('SELECT FILTER_NAME, FILTER_RULE FROM performance_schema.replication_applier_global_filters', None),
+        ('CHANGE REPLICATION FILTER REPLICATE_DO_DB = (`app`)', None),
+    ]
+
+
+def test_apply_mysql_returns_unchanged_when_filter_matches_different_order():
+    _require_module()
+
+    cursor = FakeCursor(global_rows=[
+        {
+            'FILTER_NAME': 'REPLICATE_IGNORE_DB',
+            'FILTER_RULE': 'analytics,reporting',
+        }
+    ])
+
+    manager = MySQLReplicationFilter(ModuleStub(check_mode=False), cursor, 'mysql', '8.4.0')
+    result = manager.apply({'replicate_ignore_db': ['reporting', 'analytics']})
+
+    assert result['changed'] is False
+    assert result['queries'] == []
+    assert cursor.executed == [
+        ('SELECT FILTER_NAME, FILTER_RULE FROM performance_schema.replication_applier_global_filters', None),
+    ]
+
+
+def test_apply_mysql_rejects_connection_name():
+    _require_module()
+
+    manager = MySQLReplicationFilter(ModuleStub(check_mode=False), FakeCursor(), 'mysql', '8.4.0')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        manager.apply({'replicate_do_db': ['app']}, connection_name='analytics')
+
+    assert str(exc_info.value) == 'connection_name is supported only for MariaDB'
+
+
+def test_apply_rejects_filter_values_containing_commas():
+    _require_module()
+
+    manager = MySQLReplicationFilter(ModuleStub(check_mode=False), FakeCursor(), 'mysql', '8.4.0')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        manager.apply({'replicate_do_db': ['bad,name']})
+
+    assert str(exc_info.value) == 'replication filter values cannot contain commas: bad,name'
+
+
+def test_apply_rejects_invalid_table_filter_value():
+    _require_module()
+
+    manager = MySQLReplicationFilter(ModuleStub(check_mode=False), FakeCursor(), 'mysql', '8.4.0')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        manager.apply({'replicate_do_table': ['missing_separator']})
+
+    assert str(exc_info.value) == 'replicate_do_table values must use database.table syntax: missing_separator'
+
+
+def test_apply_mariadb_check_mode_predicts_changes_without_writes():
+    _require_module()
+
+    cursor = FakeCursor(
+        version='10.11.0-MariaDB',
+        connection_variables={
+            'analytics': {
+                'replicate_do_db': 'archive',
+                'replicate_ignore_db': '',
+                'replicate_do_table': '',
+                'replicate_ignore_table': '',
+                'replicate_wild_do_table': '',
+                'replicate_wild_ignore_table': '',
+            }
+        },
+    )
+
+    manager = MySQLReplicationFilter(ModuleStub(check_mode=True), cursor, 'mariadb', '10.11.0-MariaDB')
+    result = manager.apply(
+        {'replicate_do_db': ['reporting', 'app']},
+        connection_name='analytics',
+    )
+
+    assert result == {
+        'changed': True,
+        'queries': [
+            "SET GLOBAL `replicate_do_db` = 'app,reporting'",
+        ],
+        'filters': {
+            'replicate_do_db': ['app', 'reporting'],
+            'replicate_ignore_db': [],
+            'replicate_do_table': [],
+            'replicate_ignore_table': [],
+            'replicate_wild_do_table': [],
+            'replicate_wild_ignore_table': [],
+        },
+    }
+    assert cursor.executed == [
+        ("SHOW REPLICA 'analytics' STATUS", None),
+    ]
+    assert cursor.connection_variables['analytics']['replicate_do_db'] == 'archive'
+
+
+def test_apply_mariadb_executes_queries_with_connection_context():
+    _require_module()
+
+    cursor = FakeCursor(
+        version='10.11.0-MariaDB',
+        connection_variables={
+            'analytics': {
+                'replicate_do_db': '',
+                'replicate_ignore_db': '',
+                'replicate_do_table': '',
+                'replicate_ignore_table': '',
+                'replicate_wild_do_table': '',
+                'replicate_wild_ignore_table': '',
+            }
+        },
+    )
+
+    manager = MySQLReplicationFilter(ModuleStub(check_mode=False), cursor, 'mariadb', '10.11.0-MariaDB')
+    result = manager.apply(
+        {'replicate_ignore_db': ['archive', 'analytics']},
+        connection_name='analytics',
+    )
+
+    assert result == {
+        'changed': True,
+        'queries': [
+            "SET GLOBAL `replicate_ignore_db` = 'analytics,archive'",
+        ],
+        'filters': {
+            'replicate_do_db': [],
+            'replicate_ignore_db': ['analytics', 'archive'],
+            'replicate_do_table': [],
+            'replicate_ignore_table': [],
+            'replicate_wild_do_table': [],
+            'replicate_wild_ignore_table': [],
+        },
+    }
+    assert cursor.connection_variables['analytics']['replicate_ignore_db'] == 'analytics,archive'
+    assert cursor.executed == [
+        ("SHOW REPLICA 'analytics' STATUS", None),
+        ('SET @@default_master_connection = %s', ('analytics',)),
+        ('SET GLOBAL `replicate_ignore_db` = %s', ('analytics,archive',)),
+        ('SET @@default_master_connection = %s', ('',)),
+    ]
+
+
+def test_apply_mariadb_rejects_channel():
+    _require_module()
+
+    manager = MySQLReplicationFilter(ModuleStub(check_mode=False), FakeCursor(version='10.11.0-MariaDB'), 'mariadb', '10.11.0-MariaDB')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        manager.apply({'replicate_do_db': ['app']}, channel='analytics')
+
+    assert str(exc_info.value) == 'channel is supported only for MySQL'
+
+
+def test_main_requires_at_least_one_filter_before_connect(monkeypatch):
+    _require_module()
+
+    with set_module_args({'login_unix_socket': '/run/mysqld/mysqld.sock'}):
+        monkeypatch.setattr(AnsibleModule, 'exit_json', exit_json)
+        monkeypatch.setattr(AnsibleModule, 'fail_json', fail_json)
+        monkeypatch.setattr(mysql_replication_filter_module, 'mysql_driver', object())
+
+        def unexpected_connect(*args, **kwargs):
+            raise AssertionError('mysql_connect should not be called')
+
+        monkeypatch.setattr(mysql_replication_filter_module, 'mysql_connect', unexpected_connect)
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            mysql_replication_filter_module.main()
+
+    assert exc.value.args[0]['msg'] == 'at least one replication filter option must be provided'

--- a/tests/unit/plugins/modules/test_mysql_replication_filter.py
+++ b/tests/unit/plugins/modules/test_mysql_replication_filter.py
@@ -149,8 +149,11 @@ class FakeCursor(object):
             self._rows = [{'Value': active_variables.get(variable_name, '')}]
             return
 
-        if query.startswith("SHOW REPLICA '") and query.endswith("' STATUS"):
-            connection_name = query[len("SHOW REPLICA '"): -len("' STATUS")]
+        if (
+            query.startswith("SHOW REPLICA '") or query.startswith("SHOW SLAVE '")
+        ) and query.endswith("' STATUS"):
+            prefix = "SHOW REPLICA '" if query.startswith("SHOW REPLICA '") else "SHOW SLAVE '"
+            connection_name = query[len(prefix): -len("' STATUS")]
             active_variables = self.connection_variables.get(connection_name, {})
             self._rows = [{
                 'Replicate_Do_DB': active_variables.get('replicate_do_db', ''),
@@ -469,6 +472,38 @@ def test_get_mariadb_filter_values_uses_connection_status_context():
     ]
 
 
+def test_get_mariadb_filter_values_uses_legacy_slave_status_context():
+    _require_module()
+
+    cursor = CursorStub([[
+        {
+            'Replicate_Do_DB': 'app,reporting',
+            'Replicate_Ignore_DB': '',
+            'Replicate_Do_Table': 'app.orders',
+            'Replicate_Ignore_Table': '',
+            'Replicate_Wild_Do_Table': 'reporting.sales_%',
+            'Replicate_Wild_Ignore_Table': '',
+        }
+    ]])
+
+    assert get_mariadb_filter_values(
+        ModuleStub(),
+        cursor,
+        '10.0.1-MariaDB',
+        connection_name='analytics',
+    ) == {
+        'replicate_do_db': 'app,reporting',
+        'replicate_ignore_db': '',
+        'replicate_do_table': 'app.orders',
+        'replicate_ignore_table': '',
+        'replicate_wild_do_table': 'reporting.sales_%',
+        'replicate_wild_ignore_table': '',
+    }
+    assert cursor.executed == [
+        ("SHOW SLAVE 'analytics' STATUS", None),
+    ]
+
+
 def test_get_mariadb_filter_values_reads_global_variables_without_connection_name():
     _require_module()
 
@@ -632,6 +667,18 @@ def test_apply_rejects_invalid_table_filter_value():
         manager.apply({'replicate_do_table': ['missing_separator']})
 
     assert str(exc_info.value) == 'replicate_do_table values must use database.table syntax: missing_separator'
+
+
+@pytest.mark.parametrize('param', ('replicate_wild_do_table', 'replicate_wild_ignore_table'))
+def test_apply_rejects_invalid_wildcard_filter_value(param):
+    _require_module()
+
+    manager = MySQLReplicationFilter(ModuleStub(check_mode=False), FakeCursor(), 'mysql', '8.4.0')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        manager.apply({param: ['missing_separator']})
+
+    assert str(exc_info.value) == '%s values must use database.table syntax: missing_separator' % param
 
 
 def test_apply_mariadb_check_mode_predicts_changes_without_writes():


### PR DESCRIPTION
#### SUMMARY
- add a new `mysql_replication_filter` module to manage MySQL and MariaDB replica-side replication filters declaratively
- support MySQL global and channel filters plus MariaDB global and `connection_name` filter management with full check mode and idempotency

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- `README.md`
- `meta/runtime.yml`
- `plugins/modules/mysql_replication_filter.py`
- `tests/integration/targets/test_mysql_replication_filter/defaults/main.yml`
- `tests/integration/targets/test_mysql_replication_filter/meta/main.yml`
- `tests/integration/targets/test_mysql_replication_filter/tasks/main.yml`
- `tests/unit/plugins/modules/test_mysql_replication_filter.py`

#### ADDITIONAL INFORMATION
- Used GPT5.4 with human in the loop and manual testing
