### PR TITLE
add mysql tablespace modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Every voice is important and every idea is valuable. If you have something on yo
   - [mysql_resource_group_info](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_resource_group_info_module.html)
   - [mysql_role](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_role_module.html)
   - [mysql_slow_log](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_slow_log_module.html)
+  - [mysql_tablespace](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_tablespace_module.html)
+  - [mysql_tablespace_info](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_tablespace_info_module.html)
   - [mysql_tls](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_tls_module.html)
   - [mysql_user](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_user_module.html)
   - [mysql_variables](https://docs.ansible.com/ansible/devel/collections/ansible/mysql/mysql_variables_module.html)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -14,6 +14,8 @@ action_groups:
     - mysql_resource_group_info
     - mysql_role
     - mysql_slow_log
+    - mysql_tablespace
+    - mysql_tablespace_info
     - mysql_tls
     - mysql_user
     - mysql_variables

--- a/plugins/module_utils/tablespace.py
+++ b/plugins/module_utils/tablespace.py
@@ -39,7 +39,7 @@ def get_server_version_tuple(cursor):
 
 
 def ensure_tablespaces_supported(module, cursor):
-    if get_server_implementation(cursor) != 'mysql':
+    if get_server_implementation(module, cursor) != 'mysql':
         module.fail_json(msg='Tablespace operations are supported only by MySQL.')
 
     server_version = get_server_version_tuple(cursor)

--- a/plugins/module_utils/tablespace.py
+++ b/plugins/module_utils/tablespace.py
@@ -1,0 +1,210 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Simplified BSD License (see simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.common.text.converters import to_native
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    get_server_implementation,
+    get_server_version,
+)
+
+
+MYSQL_TABLESPACES_MIN_VERSION = (5, 7, 6)
+MYSQL_TABLESPACE_ENCRYPTION_MIN_VERSION = (8, 0, 13)
+MYSQL_TABLESPACE_STATE_MIN_VERSION = (8, 0, 14)
+MYSQL_80_METADATA_FAMILY_MIN_VERSION = (8, 0, 0)
+
+
+def get_server_version_tuple(cursor):
+    version = get_server_version(cursor).split('-', 1)[0]
+    version_tuple = []
+
+    for part in version.split('.'):
+        digits = ''.join(char for char in part if char.isdigit())
+        if not digits:
+            break
+        version_tuple.append(int(digits))
+
+    while len(version_tuple) < 3:
+        version_tuple.append(0)
+
+    return tuple(version_tuple[:3])
+
+
+def ensure_tablespaces_supported(module, cursor):
+    if get_server_implementation(cursor) != 'mysql':
+        module.fail_json(msg='Tablespace operations are supported only by MySQL.')
+
+    server_version = get_server_version_tuple(cursor)
+    if server_version < MYSQL_TABLESPACES_MIN_VERSION:
+        module.fail_json(
+            msg='Tablespace operations require MySQL %s or later.'
+            % _format_version(MYSQL_TABLESPACES_MIN_VERSION)
+        )
+
+    return server_version
+
+
+def get_mysql_tablespaces(cursor, server_version, name=None, module=None):
+    if server_version < MYSQL_80_METADATA_FAMILY_MIN_VERSION:
+        query = _get_mysql_57_tablespaces_query()
+    else:
+        query = _get_mysql_80_tablespaces_query(server_version)
+
+    params = None
+    if name is not None:
+        query += ' AND f.TABLESPACE_NAME = %s'
+        params = (name,)
+
+    query += _get_mysql_tablespaces_group_by(server_version)
+    return _fetch_normalized_rows(cursor, query, params, module=module)
+
+
+def get_mysql_tablespace(cursor, server_version, name, module=None):
+    tablespaces = get_mysql_tablespaces(cursor, server_version, name=name, module=module)
+    if not tablespaces:
+        return None
+    return tablespaces[0]
+
+
+def _normalize_mysql_tablespace_row(row):
+    return {
+        'server_implementation': 'mysql',
+        'name': row['TABLESPACE_NAME'],
+        'space_id': _to_int_or_none(_first_defined(row, 'FILE_ID', 'SPACE')),
+        'engine': row['ENGINE'],
+        'file_type': row.get('FILE_TYPE'),
+        'extent_size': _to_int_or_none(row.get('EXTENT_SIZE')),
+        'autoextend_size': _to_int_or_none(row.get('AUTOEXTEND_SIZE')),
+        'maximum_size': _to_int_or_none(row.get('MAXIMUM_SIZE')),
+        'datafile': row.get('FILE_NAME'),
+        'filesystem_block_size': _to_int_or_none(row.get('FS_BLOCK_SIZE')),
+        'status': row.get('STATUS'),
+        'comment': row.get('EXTRA'),
+        'page_size': _to_int_or_none(row.get('PAGE_SIZE')),
+        'file_size': _to_int_or_none(row.get('FILE_SIZE')),
+        'allocated_size': _to_int_or_none(row.get('ALLOCATED_SIZE')),
+        'zip_page_size': _to_int_or_none(row.get('ZIP_PAGE_SIZE')),
+        'space_type': row.get('SPACE_TYPE'),
+        'state': row.get('STATE'),
+        'encryption': row.get('ENCRYPTION'),
+        'attached_tables': _to_list_or_empty(row.get('ATTACHED_TABLES')),
+    }
+
+
+def _fetch_normalized_rows(cursor, query, params, module=None):
+    try:
+        if params:
+            cursor.execute(query, params)
+        else:
+            cursor.execute(query)
+
+        rows = cursor.fetchall()
+    except Exception as e:
+        if module is not None:
+            module.fail_json(msg="Cannot execute SQL '%s': %s" % (query, to_native(e)))
+        raise
+
+    return [
+        _normalize_mysql_tablespace_row(row)
+        for row in rows
+    ]
+
+
+def _get_mysql_57_tablespaces_query():
+    return (
+        'SELECT f.FILE_ID, f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME, '
+        'f.FILE_TYPE, f.ENGINE, f.EXTENT_SIZE, f.AUTOEXTEND_SIZE, f.MAXIMUM_SIZE, '
+        'f.STATUS, f.EXTRA, ts.FS_BLOCK_SIZE, ts.FILE_SIZE, ts.ALLOCATED_SIZE, '
+        'ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE, ts.SPACE_TYPE, '
+        "NULL AS ENCRYPTION, NULL AS STATE, GROUP_CONCAT(t.NAME ORDER BY t.NAME SEPARATOR ',') "
+        'AS ATTACHED_TABLES '
+        'FROM INFORMATION_SCHEMA.FILES AS f '
+        'LEFT JOIN INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES AS ts ON ts.SPACE = f.FILE_ID '
+        'LEFT JOIN INFORMATION_SCHEMA.INNODB_SYS_DATAFILES AS df ON df.SPACE = ts.SPACE '
+        'LEFT JOIN INFORMATION_SCHEMA.INNODB_SYS_TABLES AS t ON t.SPACE = ts.SPACE '
+        "WHERE f.ENGINE = 'InnoDB' AND f.FILE_TYPE = 'TABLESPACE' AND ts.SPACE_TYPE = 'General'"
+    )
+
+
+def _get_mysql_80_tablespaces_query(server_version):
+    return (
+        'SELECT f.FILE_ID, f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME, '
+        'f.FILE_TYPE, f.ENGINE, f.EXTENT_SIZE, f.AUTOEXTEND_SIZE, f.MAXIMUM_SIZE, '
+        'f.STATUS, f.EXTRA, ts.FS_BLOCK_SIZE, ts.FILE_SIZE, '
+        'ts.ALLOCATED_SIZE, ts.PAGE_SIZE, '
+        '%s'
+        "GROUP_CONCAT(t.NAME ORDER BY t.NAME SEPARATOR ',') AS ATTACHED_TABLES "
+        'FROM INFORMATION_SCHEMA.FILES AS f '
+        'LEFT JOIN INFORMATION_SCHEMA.INNODB_TABLESPACES AS ts ON ts.SPACE = f.FILE_ID '
+        'LEFT JOIN INFORMATION_SCHEMA.INNODB_DATAFILES AS df ON df.SPACE = ts.SPACE '
+        'LEFT JOIN INFORMATION_SCHEMA.INNODB_TABLES AS t ON t.SPACE = ts.SPACE '
+        "WHERE f.ENGINE = 'InnoDB' AND f.FILE_TYPE = 'TABLESPACE' AND ts.SPACE_TYPE = 'General'"
+    ) % _get_mysql_80_tablespaces_metadata_columns(server_version)
+
+
+def _get_mysql_tablespaces_group_by(server_version):
+    if server_version < MYSQL_80_METADATA_FAMILY_MIN_VERSION:
+        return (
+            ' GROUP BY f.FILE_ID, f.TABLESPACE_NAME, df.PATH, f.FILE_NAME, f.FILE_TYPE, '
+            'f.ENGINE, f.EXTENT_SIZE, f.AUTOEXTEND_SIZE, f.MAXIMUM_SIZE, '
+            'f.STATUS, f.EXTRA, ts.FS_BLOCK_SIZE, ts.FILE_SIZE, ts.ALLOCATED_SIZE, '
+            'ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE, ts.SPACE_TYPE ORDER BY f.TABLESPACE_NAME'
+        )
+
+    query = (
+        ' GROUP BY f.FILE_ID, f.TABLESPACE_NAME, df.PATH, f.FILE_NAME, f.FILE_TYPE, '
+        'f.ENGINE, f.EXTENT_SIZE, f.AUTOEXTEND_SIZE, f.MAXIMUM_SIZE, '
+        'f.STATUS, f.EXTRA, ts.FS_BLOCK_SIZE, ts.FILE_SIZE, '
+        'ts.ALLOCATED_SIZE, ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE, ts.SPACE_TYPE'
+    )
+
+    if server_version >= MYSQL_TABLESPACE_ENCRYPTION_MIN_VERSION:
+        query += ', ts.ENCRYPTION'
+
+    if server_version >= MYSQL_TABLESPACE_STATE_MIN_VERSION:
+        query += ', ts.STATE'
+
+    return query + ' ORDER BY f.TABLESPACE_NAME'
+
+
+def _get_mysql_80_tablespaces_metadata_columns(server_version):
+    if server_version < MYSQL_TABLESPACE_ENCRYPTION_MIN_VERSION:
+        return 'ts.ZIP_PAGE_SIZE, ts.SPACE_TYPE, NULL AS ENCRYPTION, NULL AS STATE, '
+
+    if server_version < MYSQL_TABLESPACE_STATE_MIN_VERSION:
+        return 'ts.ZIP_PAGE_SIZE, ts.SPACE_TYPE, ts.ENCRYPTION, NULL AS STATE, '
+
+    return 'ts.ZIP_PAGE_SIZE, ts.SPACE_TYPE, ts.ENCRYPTION, ts.STATE, '
+
+
+def _first_defined(row, *keys):
+    for key in keys:
+        if key in row and row[key] is not None:
+            return row[key]
+    return None
+
+
+def _to_int_or_none(value):
+    if value is None:
+        return None
+    return int(value)
+
+
+def _to_list_or_empty(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
+def _format_version(version):
+    return '.'.join(str(part) for part in version)

--- a/plugins/module_utils/tablespace.py
+++ b/plugins/module_utils/tablespace.py
@@ -78,7 +78,7 @@ def _normalize_mysql_tablespace_row(row):
     return {
         'server_implementation': 'mysql',
         'name': row['TABLESPACE_NAME'],
-        'space_id': _to_int_or_none(_first_defined(row, 'FILE_ID', 'SPACE')),
+        'space_id': _to_int_or_none(row.get('FILE_ID')),
         'engine': row['ENGINE'],
         'file_type': row.get('FILE_TYPE'),
         'extent_size': _to_int_or_none(row.get('EXTENT_SIZE')),

--- a/plugins/modules/mysql_tablespace.py
+++ b/plugins/modules/mysql_tablespace.py
@@ -123,6 +123,13 @@ EXAMPLES = r'''
     datafile: ./app_data.ibd
     login_unix_socket: /run/mysqld/mysqld.sock
 
+- name: Create a MySQL general tablespace with file block and autoextend settings
+  ansible.mysql.mysql_tablespace:
+    name: analytics_data
+    datafile: ./analytics_data.ibd
+    file_block_size: 8192
+    autoextend_size: 4194304
+
 - name: Enable encryption on a MySQL tablespace
   ansible.mysql.mysql_tablespace:
     name: app_data
@@ -152,6 +159,41 @@ tablespace:
     - In create check mode, this is a predicted subset derived from requested values because no post-create server metadata exists yet.
   returned: when O(state) is V(present)
   type: dict
+  contains:
+    server_implementation:
+      description: Server implementation that produced the result.
+      type: str
+      sample: mysql
+    name:
+      description: Tablespace name after module execution.
+      type: str
+      sample: app_data
+    datafile:
+      description: Tablespace datafile path when available.
+      type: str
+      sample: ./app_data.ibd
+    autoextend_size:
+      description: Autoextend size in bytes when available.
+      type: int
+      sample: 4194304
+    encryption:
+      description: Encryption state when available.
+      type: str
+      sample: N
+    page_size:
+      description: InnoDB page size in bytes when available.
+      type: int
+      sample: 16384
+    zip_page_size:
+      description: Compressed page size in bytes when available.
+      type: int
+      sample: 8192
+    attached_tables:
+      description: Tables attached to the tablespace when the server exposes them.
+      type: list
+      elements: str
+      sample:
+        - app/orders
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -212,6 +254,8 @@ def validate_file_block_size_input(file_block_size):
 
 def get_tablespace_file_block_size(tablespace):
     zip_page_size = tablespace.get('zip_page_size')
+    # A ZIP page size of 0 means "not compressed", so the intentional falsy check
+    # falls back to page_size instead of treating 0 as an actual file block size.
     if zip_page_size:
         return zip_page_size
     return tablespace.get('page_size')
@@ -287,7 +331,7 @@ def build_create_query(name, datafile=None, file_block_size=None, encryption=Non
     return ' '.join(query)
 
 
-def build_alter_queries(name, current, rename_to=None, encryption=None, autoextend_size=None):
+def build_alter_queries(current, rename_to=None, encryption=None, autoextend_size=None):
     queries = []
     target_name = current['name']
 
@@ -612,7 +656,6 @@ def main():
         )
 
     queries = build_alter_queries(
-        current['name'],
         current,
         rename_to=rename_to,
         encryption=encryption,

--- a/plugins/modules/mysql_tablespace.py
+++ b/plugins/modules/mysql_tablespace.py
@@ -1,0 +1,653 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible community
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_tablespace
+
+short_description: Manage MySQL InnoDB general tablespaces
+
+description:
+  - Create, update, rename, or drop MySQL InnoDB general tablespaces.
+  - Supports general tablespace lifecycle operations on MySQL servers.
+  - Key rotation is outside this module's scope because MySQL exposes it through
+    C(ALTER INSTANCE ROTATE INNODB MASTER KEY), not as a per-tablespace lifecycle action.
+
+version_added: '5.2.0'
+
+options:
+  name:
+    description:
+      - Name of the tablespace to manage.
+    type: str
+    required: true
+    version_added: '5.2.0'
+  state:
+    description:
+      - If V(present), create the tablespace when it does not exist.
+      - If V(present), alter mutable tablespace attributes when it already exists.
+      - If V(absent), drop the tablespace.
+    type: str
+    choices: [absent, present]
+    default: present
+    version_added: '5.2.0'
+  datafile:
+    description:
+      - Tablespace datafile path.
+      - Create-only.
+      - Required on MySQL versions earlier than V(8.0.14).
+      - Optional on MySQL V(8.0.14) and later.
+    type: str
+    version_added: '5.2.0'
+  file_block_size:
+    description:
+      - File block size for the general tablespace.
+      - Create-only.
+      - Existing tablespaces are compared best-effort using available metadata.
+      - Deeper semantic validation is left to MySQL because valid values depend on
+        C(innodb_page_size) and compressed-page rules rather than a standalone whitelist.
+    type: int
+    version_added: '5.2.0'
+  encryption:
+    description:
+      - Whether the general tablespace should be encrypted.
+      - Uses MySQL literal values V(Y) or V(N).
+      - Supported on MySQL V(8.0.13) and later.
+      - Can be set during create or alter.
+      - Does not rotate InnoDB master keys. Key rotation remains an instance-level
+        operation exposed through C(ALTER INSTANCE ROTATE INNODB MASTER KEY).
+    type: str
+    version_added: '5.2.0'
+  rename_to:
+    description:
+      - Rename the tablespace to this new name.
+      - Alter-only.
+      - Supported on MySQL V(8.0.3) and later.
+      - Cannot be used with O(state=absent).
+    type: str
+    version_added: '5.2.0'
+  autoextend_size:
+    description:
+      - Tablespace autoextend size in bytes.
+      - Supported on MySQL V(8.0.23) and later.
+      - Can be set during create or alter.
+    type: int
+    version_added: '5.2.0'
+
+notes:
+  - Compatible with MySQL only.
+  - O(datafile) and O(file_block_size) are create-only options.
+  - O(rename_to) is an alter-only option.
+  - Key rotation is outside this module's scope because MySQL exposes it with
+    C(ALTER INSTANCE ROTATE INNODB MASTER KEY).
+  - Metadata reads used for idempotency and post-change verification may require the C(PROCESS) privilege.
+  - C(DROP TABLESPACE) requires the tablespace to be empty.
+
+attributes:
+  check_mode:
+    support: full
+    details:
+      - In check mode the module reads current tablespace state and reports the DDL it would run without executing it.
+  idempotent:
+    support: full
+    details:
+      - The module emits DDL only when the requested tablespace lifecycle state differs from the current server state.
+
+seealso:
+  - module: ansible.mysql.mysql_tablespace_info
+  - name: MySQL ALTER INSTANCE reference
+    description: Reference for instance-level operations such as C(ALTER INSTANCE ROTATE INNODB MASTER KEY).
+    link: https://dev.mysql.com/doc/refman/8.4/en/alter-instance.html
+  - name: MySQL CREATE TABLESPACE reference
+    description: Complete reference of the CREATE TABLESPACE command documentation.
+    link: https://dev.mysql.com/doc/refman/8.4/en/create-tablespace.html
+  - name: MySQL ALTER TABLESPACE reference
+    description: Complete reference of the ALTER TABLESPACE command documentation.
+    link: https://dev.mysql.com/doc/refman/8.4/en/alter-tablespace.html
+  - name: MySQL DROP TABLESPACE reference
+    description: Complete reference of the DROP TABLESPACE command documentation.
+    link: https://dev.mysql.com/doc/refman/8.4/en/drop-tablespace.html
+
+author:
+  - Ron Gershburg (@ronger4)
+
+extends_documentation_fragment:
+  - ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+# If you encounter the "Please explicitly state intended protocol" error,
+# use the login_unix_socket argument
+- name: Create a MySQL general tablespace
+  ansible.mysql.mysql_tablespace:
+    name: app_data
+    datafile: ./app_data.ibd
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Enable encryption on a MySQL tablespace
+  ansible.mysql.mysql_tablespace:
+    name: app_data
+    encryption: Y
+
+- name: Rename a MySQL tablespace
+  ansible.mysql.mysql_tablespace:
+    name: app_data
+    rename_to: archive_data
+
+- name: Drop an empty MySQL tablespace
+  ansible.mysql.mysql_tablespace:
+    name: archive_data
+    state: absent
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed queries.
+  returned: when changed
+  type: list
+  sample:
+    - CREATE TABLESPACE `app_data` ADD DATAFILE './app_data.ibd' ENGINE = InnoDB
+tablespace:
+  description:
+    - Normalized representation of the MySQL tablespace after module execution when server metadata is available.
+    - In create check mode, this is a predicted subset derived from requested values because no post-create server metadata exists yet.
+  returned: when O(state) is V(present)
+  type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.ansible.mysql.plugins.module_utils.database import (
+    check_input,
+    mysql_quote_identifier,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils.tablespace import (
+    ensure_tablespaces_supported,
+    get_mysql_tablespace,
+)
+
+AUTOEXTEND_SIZE_INCREMENT = 4 * 1024 * 1024
+MYSQL_TABLESPACE_RENAME_MIN_VERSION = (8, 0, 3)
+MYSQL_TABLESPACE_ENCRYPTION_MIN_VERSION = (8, 0, 13)
+MYSQL_TABLESPACE_OPTIONAL_DATAFILE_MIN_VERSION = (8, 0, 14)
+MYSQL_TABLESPACE_AUTOEXTEND_SIZE_MIN_VERSION = (8, 0, 23)
+
+
+def normalize_tablespace_encryption(encryption):
+    if encryption is None:
+        return None
+
+    encryption = encryption.upper()
+    if encryption not in ('Y', 'N'):
+        raise ValueError("encryption must be either 'Y' or 'N'")
+
+    return encryption
+
+
+def validate_autoextend_size_input(autoextend_size):
+    if autoextend_size is None:
+        return None
+
+    if autoextend_size < 0 or autoextend_size % AUTOEXTEND_SIZE_INCREMENT != 0:
+        raise ValueError('autoextend_size must be a non-negative multiple of 4MB (4194304 bytes)')
+
+    return autoextend_size
+
+
+def validate_file_block_size_input(file_block_size):
+    if file_block_size is None:
+        return None
+
+    if file_block_size <= 0:
+        raise ValueError('file_block_size must be a positive integer')
+
+    return file_block_size
+
+
+def get_tablespace_file_block_size(tablespace):
+    zip_page_size = tablespace.get('zip_page_size')
+    if zip_page_size:
+        return zip_page_size
+    return tablespace.get('page_size')
+
+
+def validate_tablespace_rename(server_version, rename):
+    return _validate_version_gated_value(
+        server_version,
+        rename,
+        MYSQL_TABLESPACE_RENAME_MIN_VERSION,
+        'rename',
+    )
+
+
+def validate_tablespace_encryption(server_version, encryption):
+    return _validate_version_gated_value(
+        server_version,
+        encryption,
+        MYSQL_TABLESPACE_ENCRYPTION_MIN_VERSION,
+        'encryption',
+    )
+
+
+def validate_tablespace_autoextend_size(server_version, autoextend_size):
+    return _validate_version_gated_value(
+        server_version,
+        autoextend_size,
+        MYSQL_TABLESPACE_AUTOEXTEND_SIZE_MIN_VERSION,
+        'autoextend_size',
+    )
+
+
+def validate_tablespace_datafile(server_version, datafile):
+    if datafile is None and server_version < MYSQL_TABLESPACE_OPTIONAL_DATAFILE_MIN_VERSION:
+        raise ValueError(
+            'datafile is required for MySQL versions earlier than %s'
+            % _format_version(MYSQL_TABLESPACE_OPTIONAL_DATAFILE_MIN_VERSION)
+        )
+    return datafile
+
+
+def _validate_version_gated_value(server_version, value, minimum_version, option_name):
+    if value is None:
+        return None
+    if server_version < minimum_version:
+        raise ValueError(
+            '%s requires MySQL %s or later'
+            % (option_name, _format_version(minimum_version))
+        )
+    return value
+
+
+def _format_version(version):
+    return '.'.join(str(part) for part in version)
+
+
+def build_create_query(name, datafile=None, file_block_size=None, encryption=None, autoextend_size=None):
+    query = ['CREATE TABLESPACE %s' % mysql_quote_identifier(name, 'role')]
+
+    if datafile is not None:
+        query.append('ADD DATAFILE %s' % quote_sql_value(datafile))
+
+    if autoextend_size is not None:
+        query.append('AUTOEXTEND_SIZE = %s' % autoextend_size)
+
+    if file_block_size is not None:
+        query.append('FILE_BLOCK_SIZE = %s' % file_block_size)
+
+    if encryption is not None:
+        query.append('ENCRYPTION = %s' % quote_sql_value(encryption))
+
+    query.append('ENGINE = InnoDB')
+    return ' '.join(query)
+
+
+def build_alter_queries(name, current, rename_to=None, encryption=None, autoextend_size=None):
+    queries = []
+    target_name = current['name']
+
+    if rename_to is not None and current['name'] != rename_to:
+        queries.append(
+            'ALTER TABLESPACE %s RENAME TO %s'
+            % (
+                mysql_quote_identifier(current['name'], 'role'),
+                mysql_quote_identifier(rename_to, 'role'),
+            )
+        )
+        target_name = rename_to
+
+    if autoextend_size is not None and current.get('autoextend_size') != autoextend_size:
+        queries.append(
+            'ALTER TABLESPACE %s AUTOEXTEND_SIZE = %s'
+            % (
+                mysql_quote_identifier(target_name, 'role'),
+                autoextend_size,
+            )
+        )
+
+    if encryption is not None and current.get('encryption') != encryption:
+        queries.append(
+            'ALTER TABLESPACE %s ENCRYPTION = %s'
+            % (
+                mysql_quote_identifier(target_name, 'role'),
+                quote_sql_value(encryption),
+            )
+        )
+
+    return queries
+
+
+def build_drop_query(name):
+    return 'DROP TABLESPACE %s' % mysql_quote_identifier(name, 'role')
+
+
+def quote_sql_value(value):
+    if isinstance(value, bool):
+        return '1' if value else '0'
+    if isinstance(value, int):
+        return str(value)
+    return "'%s'" % str(value).replace("'", "''")
+
+
+def execute_query(cursor, query):
+    cursor.execute(query)
+
+
+def predict_tablespace(current=None, name=None, datafile=None, encryption=None, autoextend_size=None, rename_to=None):
+    if current is None:
+        predicted = {
+            'server_implementation': 'mysql',
+            'name': name,
+        }
+    else:
+        predicted = current.copy()
+
+    if datafile is not None and 'datafile' not in predicted:
+        predicted['datafile'] = datafile
+
+    if encryption is not None:
+        predicted['encryption'] = encryption
+
+    if autoextend_size is not None:
+        predicted['autoextend_size'] = autoextend_size
+
+    if rename_to is not None:
+        predicted['name'] = rename_to
+
+    return predicted
+
+
+def resolve_current_tablespace(module, cursor, server_version, name, rename_to=None):
+    current = get_mysql_tablespace(cursor, server_version, name, module=module)
+
+    if rename_to is None or rename_to == name:
+        return current, False
+
+    renamed = get_mysql_tablespace(cursor, server_version, rename_to, module=module)
+
+    if current is None:
+        if renamed is None:
+            module.fail_json(
+                msg=(
+                    'rename_to is alter-only and requires an existing tablespace named %s, '
+                    'or a tablespace already renamed to %s.'
+                    % (name, rename_to)
+                )
+            )
+        return renamed, True
+
+    if renamed is not None:
+        module.fail_json(
+            msg='Cannot rename tablespace %s to %s because %s already exists.'
+            % (name, rename_to, rename_to)
+        )
+
+    return current, False
+
+
+def fail_if_rename_target_requires_changes(
+    module,
+    current,
+    rename_to,
+    datafile=None,
+    file_block_size=None,
+    encryption=None,
+    autoextend_size=None,
+):
+    mismatches = []
+
+    if datafile is not None and current.get('datafile') != datafile:
+        mismatches.append('datafile')
+
+    if file_block_size is not None:
+        current_file_block_size = get_tablespace_file_block_size(current)
+        if current_file_block_size is None or current_file_block_size != file_block_size:
+            mismatches.append('file_block_size')
+
+    if mismatches:
+        module.fail_json(
+            msg=(
+                'rename_to target %s already exists but does not match the requested end state '
+                '(%s). Refusing to treat the rename as already applied.'
+                % (rename_to, ', '.join(mismatches))
+            ),
+            tablespace=current,
+        )
+
+
+def fail_if_create_only_options_differ(module, current, datafile=None, file_block_size=None):
+    if datafile is not None and current.get('datafile') != datafile:
+        module.fail_json(
+            msg=(
+                'datafile is create-only and cannot be changed for existing tablespace %s '
+                '(current: %s, requested: %s).'
+                % (current['name'], current.get('datafile'), datafile)
+            ),
+            tablespace=current,
+        )
+
+    if file_block_size is None:
+        return
+
+    current_file_block_size = get_tablespace_file_block_size(current)
+    if current_file_block_size is None:
+        module.fail_json(
+            msg=(
+                'Cannot compare create-only file_block_size for existing tablespace %s '
+                'because current metadata does not expose page_size or zip_page_size.'
+                % current['name']
+            ),
+            tablespace=current,
+        )
+
+    if current_file_block_size != file_block_size:
+        module.fail_json(
+            msg=(
+                'file_block_size is create-only and cannot be changed for existing tablespace %s '
+                '(current best-effort value: %s, requested: %s).'
+                % (current['name'], current_file_block_size, file_block_size)
+            ),
+            tablespace=current,
+        )
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        name=dict(type='str', required=True),
+        state=dict(type='str', choices=['absent', 'present'], default='present'),
+        datafile=dict(type='str'),
+        file_block_size=dict(type='int'),
+        encryption=dict(type='str'),
+        rename_to=dict(type='str'),
+        autoextend_size=dict(type='int'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    name = module.params['name']
+    state = module.params['state']
+    datafile = module.params['datafile']
+    file_block_size = module.params['file_block_size']
+    encryption = module.params['encryption']
+    rename_to = module.params['rename_to']
+    autoextend_size = module.params['autoextend_size']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    config_file = module.params['config_file']
+    ssl_cert = module.params['client_cert']
+    ssl_key = module.params['client_key']
+    ssl_ca = module.params['ca_cert']
+    connect_timeout = module.params['connect_timeout']
+    check_hostname = module.params['check_hostname']
+
+    if rename_to == name:
+        rename_to = None
+
+    if state == 'absent' and rename_to is not None:
+        module.fail_json(msg='rename_to cannot be used with state=absent')
+
+    check_input(module, name, datafile, rename_to, encryption)
+
+    try:
+        encryption = normalize_tablespace_encryption(encryption)
+        autoextend_size = validate_autoextend_size_input(autoextend_size)
+        file_block_size = validate_file_block_size_input(file_block_size)
+    except ValueError as e:
+        module.fail_json(msg=to_native(e))
+
+    try:
+        cursor, _db_conn = mysql_connect(
+            module,
+            login_user,
+            login_password,
+            config_file,
+            ssl_cert,
+            ssl_key,
+            ssl_ca,
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+            cursor_class='DictCursor',
+            autocommit=True,
+        )
+    except Exception as e:
+        module.fail_json(msg='unable to connect to database: %s' % to_native(e))
+
+    server_version = ensure_tablespaces_supported(module, cursor)
+    queries = []
+
+    try:
+        rename_to = validate_tablespace_rename(server_version, rename_to)
+        encryption = validate_tablespace_encryption(server_version, encryption)
+        autoextend_size = validate_tablespace_autoextend_size(server_version, autoextend_size)
+    except ValueError as e:
+        module.fail_json(msg=to_native(e))
+
+    if state == 'absent':
+        current = get_mysql_tablespace(cursor, server_version, name, module=module)
+        if current is None:
+            module.exit_json(changed=False)
+
+        query = build_drop_query(name)
+        queries.append(query)
+
+        if module.check_mode:
+            module.exit_json(changed=True, queries=queries)
+
+        try:
+            execute_query(cursor, query)
+        except Exception as e:
+            module.fail_json(msg=to_native(e))
+
+        module.exit_json(changed=True, queries=queries)
+
+    current, rename_already_applied = resolve_current_tablespace(
+        module,
+        cursor,
+        server_version,
+        name,
+        rename_to=rename_to,
+    )
+
+    if current is None:
+        try:
+            validate_tablespace_datafile(server_version, datafile)
+        except ValueError as e:
+            module.fail_json(msg=to_native(e))
+
+        query = build_create_query(
+            name,
+            datafile=datafile,
+            file_block_size=file_block_size,
+            encryption=encryption,
+            autoextend_size=autoextend_size,
+        )
+        queries.append(query)
+
+        predicted = predict_tablespace(
+            name=name,
+            datafile=datafile,
+            encryption=encryption,
+            autoextend_size=autoextend_size,
+        )
+
+        if module.check_mode:
+            module.exit_json(changed=True, queries=queries, tablespace=predicted)
+
+        try:
+            execute_query(cursor, query)
+        except Exception as e:
+            module.fail_json(msg=to_native(e))
+
+        current = get_mysql_tablespace(cursor, server_version, name, module=module)
+        module.exit_json(changed=True, queries=queries, tablespace=current or predicted)
+
+    if rename_already_applied:
+        fail_if_rename_target_requires_changes(
+            module,
+            current,
+            rename_to,
+            datafile=datafile,
+            file_block_size=file_block_size,
+            encryption=encryption,
+            autoextend_size=autoextend_size,
+        )
+    else:
+        fail_if_create_only_options_differ(
+            module,
+            current,
+            datafile=datafile,
+            file_block_size=file_block_size,
+        )
+
+    queries = build_alter_queries(
+        current['name'],
+        current,
+        rename_to=rename_to,
+        encryption=encryption,
+        autoextend_size=autoextend_size,
+    )
+
+    if not queries:
+        module.exit_json(changed=False, tablespace=current)
+
+    predicted = predict_tablespace(
+        current=current,
+        encryption=encryption,
+        autoextend_size=autoextend_size,
+        rename_to=rename_to,
+    )
+
+    if module.check_mode:
+        module.exit_json(changed=True, queries=queries, tablespace=predicted)
+
+    try:
+        for query in queries:
+            execute_query(cursor, query)
+    except Exception as e:
+        module.fail_json(msg=to_native(e))
+
+    current = get_mysql_tablespace(cursor, server_version, predicted['name'], module=module)
+    module.exit_json(changed=True, queries=queries, tablespace=current or predicted)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_tablespace.py
+++ b/plugins/modules/mysql_tablespace.py
@@ -27,7 +27,6 @@ options:
       - Name of the tablespace to manage.
     type: str
     required: true
-    version_added: '5.2.0'
   state:
     description:
       - If V(present), create the tablespace when it does not exist.
@@ -36,7 +35,6 @@ options:
     type: str
     choices: [absent, present]
     default: present
-    version_added: '5.2.0'
   datafile:
     description:
       - Tablespace datafile path.
@@ -44,7 +42,6 @@ options:
       - Required on MySQL versions earlier than V(8.0.14).
       - Optional on MySQL V(8.0.14) and later.
     type: str
-    version_added: '5.2.0'
   file_block_size:
     description:
       - File block size for the general tablespace.
@@ -53,7 +50,6 @@ options:
       - Deeper semantic validation is left to MySQL because valid values depend on
         C(innodb_page_size) and compressed-page rules rather than a standalone whitelist.
     type: int
-    version_added: '5.2.0'
   encryption:
     description:
       - Whether the general tablespace should be encrypted.
@@ -63,22 +59,19 @@ options:
       - Does not rotate InnoDB master keys. Key rotation remains an instance-level
         operation exposed through C(ALTER INSTANCE ROTATE INNODB MASTER KEY).
     type: str
-    version_added: '5.2.0'
   rename_to:
     description:
       - Rename the tablespace to this new name.
       - Alter-only.
       - Supported on MySQL V(8.0.3) and later.
-      - Cannot be used with O(state=absent).
+      - Cannot be used when O(state) is V(absent).
     type: str
-    version_added: '5.2.0'
   autoextend_size:
     description:
       - Tablespace autoextend size in bytes.
       - Supported on MySQL V(8.0.23) and later.
       - Can be set during create or alter.
     type: int
-    version_added: '5.2.0'
 
 notes:
   - Compatible with MySQL only.

--- a/plugins/modules/mysql_tablespace_info.py
+++ b/plugins/modules/mysql_tablespace_info.py
@@ -1,0 +1,277 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible community
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: mysql_tablespace_info
+
+short_description: Gather MySQL tablespace information
+
+description:
+  - Gather general tablespace metadata from MySQL servers.
+  - This module returns the general-tablespace view using
+    C(INFORMATION_SCHEMA.FILES) together with the version-appropriate InnoDB metadata family.
+  - On V(5.7), the module uses C(INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES),
+    C(INFORMATION_SCHEMA.INNODB_SYS_DATAFILES), and C(INFORMATION_SCHEMA.INNODB_SYS_TABLES).
+  - On V(8.0) or later, the module uses C(INFORMATION_SCHEMA.INNODB_TABLESPACES),
+    C(INFORMATION_SCHEMA.INNODB_DATAFILES), and C(INFORMATION_SCHEMA.INNODB_TABLES).
+  - This module is read-only and always reports no change.
+
+version_added: '5.2.0'
+
+options:
+  name:
+    description:
+      - Limit the collected information to a single tablespace name.
+      - This matches the general tablespace name.
+    type: str
+    version_added: '5.2.0'
+
+notes:
+  - Compatible with MySQL V(5.7.6) or later.
+  - This module reports metadata only. Key rotation remains outside scope because
+    MySQL exposes it through C(ALTER INSTANCE ROTATE INNODB MASTER KEY).
+  - Tablespace metadata queries may require the C(PROCESS) privilege.
+  - No external tools are required.
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: full
+
+seealso:
+  - module: ansible.mysql.mysql_tablespace
+  - name: MySQL INFORMATION_SCHEMA FILES reference
+    description: Reference for C(INFORMATION_SCHEMA.FILES), used as the base MySQL metadata source.
+    link: https://dev.mysql.com/doc/refman/8.4/en/information-schema-files-table.html
+
+author:
+  - Ron Gershburg (@ronger4)
+
+extends_documentation_fragment:
+  - ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+# If you encounter the "Please explicitly state intended protocol" error,
+# use the login_unix_socket argument
+- name: Gather MySQL tablespace information
+  ansible.mysql.mysql_tablespace_info:
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Gather one MySQL tablespace by name
+  ansible.mysql.mysql_tablespace_info:
+    login_unix_socket: /run/mysqld/mysqld.sock
+    name: app_data
+'''
+
+RETURN = r'''
+tablespaces:
+  description:
+    - List of normalized MySQL tablespace metadata rows.
+    - Rows expose the general-tablespace view returned by the server.
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    name:
+      description: Tablespace name.
+      type: str
+      sample: app_data
+    space_id:
+      description: Internal InnoDB space identifier.
+      type: int
+      sample: 17
+    datafile:
+      description: Tablespace datafile path reported by the server.
+      returned: when available
+      type: str
+      sample: ./app_data.ibd
+    extent_size:
+      description: Extent size in bytes.
+      returned: when available
+      type: int
+      sample: 1048576
+    autoextend_size:
+      description: Autoextend size in bytes.
+      returned: when available
+      type: int
+      sample: 8388608
+    maximum_size:
+      description: Maximum size in bytes.
+      returned: when available
+      type: int
+      sample: 67108864
+    filesystem_block_size:
+      description: Filesystem block size in bytes when available.
+      returned: when available
+      type: int
+      sample: 4096
+    page_size:
+      description: InnoDB page size in bytes when available.
+      returned: when available
+      type: int
+      sample: 16384
+    file_size:
+      description: Current file size in bytes when available.
+      returned: when available
+      type: int
+      sample: 16777216
+    allocated_size:
+      description: Allocated size in bytes when available.
+      returned: when available
+      type: int
+      sample: 8388608
+    status:
+      description: Tablespace status reported by the server.
+      returned: when available
+      type: str
+      sample: NORMAL
+    zip_page_size:
+      description: Compressed page size in bytes.
+      returned: when available
+      type: int
+      sample: 0
+    state:
+      description: Tablespace state.
+      returned: when available
+      type: str
+      sample: active
+    encryption:
+      description: Encryption state.
+      returned: when available
+      type: str
+      sample: N
+    attached_tables:
+      description: Tables attached to the tablespace when the server exposes them.
+      type: list
+      elements: str
+      sample:
+        - app/orders
+        - app/order_items
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils.tablespace import (
+    ensure_tablespaces_supported,
+    get_server_version_tuple,
+    get_mysql_tablespaces,
+)
+
+
+def get_tablespaces_info(cursor, name=None, server_version=None, module=None):
+    if server_version is None:
+        server_version = get_server_version_tuple(cursor)
+
+    return {
+        'tablespaces': [
+            format_tablespace_info(row)
+            for row in get_mysql_tablespaces(
+                cursor,
+                server_version,
+                name=name,
+                module=module,
+            )
+        ]
+    }
+
+
+def format_tablespace_info(row):
+    info = {
+        'name': row['name'],
+        'space_id': row['space_id'],
+        'attached_tables': row['attached_tables'],
+    }
+
+    optional_fields = (
+        'datafile',
+        'extent_size',
+        'autoextend_size',
+        'maximum_size',
+        'filesystem_block_size',
+        'page_size',
+        'file_size',
+        'allocated_size',
+        'zip_page_size',
+        'status',
+        'state',
+        'encryption',
+    )
+
+    for field_name in optional_fields:
+        if field_name in row and row[field_name] is not None:
+            info[field_name] = row[field_name]
+
+    return info
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        name=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    config_file = module.params['config_file']
+    ssl_cert = module.params['client_cert']
+    ssl_key = module.params['client_key']
+    ssl_ca = module.params['ca_cert']
+    connect_timeout = module.params['connect_timeout']
+    check_hostname = module.params['check_hostname']
+    name = module.params['name']
+
+    try:
+        cursor, _db_conn = mysql_connect(
+            module,
+            login_user,
+            login_password,
+            config_file,
+            ssl_cert,
+            ssl_key,
+            ssl_ca,
+            connect_timeout=connect_timeout,
+            check_hostname=check_hostname,
+            cursor_class='DictCursor',
+        )
+    except Exception as e:
+        module.fail_json(msg='unable to connect to database: %s' % to_native(e))
+
+    server_version = ensure_tablespaces_supported(module, cursor)
+
+    module.exit_json(
+        changed=False,
+        **get_tablespaces_info(
+            cursor,
+            name=name,
+            server_version=server_version,
+            module=module,
+        )
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mysql_tablespace_info.py
+++ b/plugins/modules/mysql_tablespace_info.py
@@ -31,7 +31,6 @@ options:
       - Limit the collected information to a single tablespace name.
       - This matches the general tablespace name.
     type: str
-    version_added: '5.2.0'
 
 notes:
   - Compatible with MySQL V(5.7.6) or later.

--- a/tests/integration/targets/test_mysql_tablespace/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_tablespace/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_tablespace/meta/main.yml
+++ b/tests/integration/targets/test_mysql_tablespace/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_tablespace/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_tablespace/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: Tablespace | Run integration checks
+  block:
+    - name: Tablespace | Include MySQL lifecycle checks
+      ansible.builtin.include_tasks: mysql.yml
+      when: db_engine == 'mysql'

--- a/tests/integration/targets/test_mysql_tablespace/tasks/mysql.yml
+++ b/tests/integration/targets/test_mysql_tablespace/tasks/mysql.yml
@@ -1,0 +1,1074 @@
+---
+- name: Tablespace | Run MySQL lifecycle checks
+  vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+    preview_tablespace_name: ansible_tablespace_preview
+    no_datafile_tablespace_name: ansible_tablespace_nodata
+    tablespace_name: ansible_tablespace_main
+    renamed_tablespace_name: ansible_tablespace_archive
+    missing_tablespace_name: ansible_tablespace_missing
+    tablespace_schema: ansible_tablespace_db
+    tablespace_table: orders
+    preview_datafile: ./ansible_tablespace_preview.ibd
+    tablespace_datafile: ./ansible_tablespace_main.ibd
+    create_autoextend_size: 4194304
+    alter_autoextend_size: 8388608
+    create_file_block_size: 8192
+    preview_file_block_size: 8192
+    preview_encryption: Y
+    create_encryption: N
+  block:
+    - name: Tablespace | Set MySQL feature facts
+      ansible.builtin.set_fact:
+        mysql_supports_rename: "{{ db_version is version('8.0.3', '>=') }}"
+        mysql_supports_encryption: "{{ db_version is version('8.0.13', '>=') }}"
+        mysql_supports_optional_datafile: "{{ db_version is version('8.0.14', '>=') }}"
+        mysql_supports_autoextend_size: "{{ db_version is version('8.0.23', '>=') }}"
+        mysql_metadata_tablespaces: >-
+          {{
+            'INFORMATION_SCHEMA.INNODB_TABLESPACES'
+            if db_version is version('8.0.0', '>=')
+            else 'INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES'
+          }}
+        mysql_metadata_datafiles: >-
+          {{
+            'INFORMATION_SCHEMA.INNODB_DATAFILES'
+            if db_version is version('8.0.0', '>=')
+            else 'INFORMATION_SCHEMA.INNODB_SYS_DATAFILES'
+          }}
+        mysql_metadata_tables: >-
+          {{
+            'INFORMATION_SCHEMA.INNODB_TABLES'
+            if db_version is version('8.0.0', '>=')
+            else 'INFORMATION_SCHEMA.INNODB_SYS_TABLES'
+          }}
+        active_tablespace_name: '{{ tablespace_name }}'
+
+    - name: Tablespace | Remove test database if present
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: "DROP DATABASE IF EXISTS {{ tablespace_schema }}"
+
+    - name: Tablespace | Ensure primary tablespace is absent before tests
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+        state: absent
+
+    - name: Tablespace | Ensure renamed tablespace is absent before tests
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ renamed_tablespace_name }}'
+        state: absent
+
+    - name: Tablespace | Ensure no-datafile tablespace is absent before tests
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ no_datafile_tablespace_name }}'
+        state: absent
+
+    - name: Tablespace | Preview unsupported autoextend create on older MySQL
+      check_mode: true
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ preview_tablespace_name }}'
+        datafile: '{{ preview_datafile }}'
+        file_block_size: '{{ preview_file_block_size }}'
+        autoextend_size: '{{ create_autoextend_size }}'
+      register: preview_unsupported_autoextend_result
+      ignore_errors: true
+      when: not mysql_supports_autoextend_size
+
+    - name: Tablespace | Assert unsupported autoextend create on older MySQL
+      ansible.builtin.assert:
+        that:
+          - preview_unsupported_autoextend_result is failed
+          - preview_unsupported_autoextend_result.msg == 'autoextend_size requires MySQL 8.0.23 or later'
+      when: not mysql_supports_autoextend_size
+
+    - name: Tablespace | Preview unsupported encryption create on older MySQL
+      check_mode: true
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ preview_tablespace_name }}'
+        datafile: '{{ preview_datafile }}'
+        file_block_size: '{{ preview_file_block_size }}'
+        encryption: '{{ preview_encryption }}'
+      register: preview_unsupported_encryption_result
+      ignore_errors: true
+      when: not mysql_supports_encryption
+
+    - name: Tablespace | Assert unsupported encryption create on older MySQL
+      ansible.builtin.assert:
+        that:
+          - preview_unsupported_encryption_result is failed
+          - preview_unsupported_encryption_result.msg == 'encryption requires MySQL 8.0.13 or later'
+      when: not mysql_supports_encryption
+
+    - name: Tablespace | Preview create with supported inputs
+      check_mode: true
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ preview_tablespace_name }}'
+        datafile: '{{ preview_datafile }}'
+        file_block_size: '{{ preview_file_block_size }}'
+        encryption: "{{ preview_encryption if mysql_supports_encryption else omit }}"
+        autoextend_size: "{{ create_autoextend_size if mysql_supports_autoextend_size else omit }}"
+      register: preview_create_result
+
+    - name: Tablespace | Assert create check mode result
+      ansible.builtin.assert:
+        that:
+          - preview_create_result is changed
+          - preview_create_result.queries | length == 1
+          - "'CREATE TABLESPACE `' ~ preview_tablespace_name ~ '`' in preview_create_result.queries[0]"
+          - preview_create_result.queries[0] | regex_search("ADD DATAFILE '.*ansible_tablespace_preview\\.ibd'") is not none
+          - "'FILE_BLOCK_SIZE = ' ~ (preview_file_block_size | string) in preview_create_result.queries[0]"
+          - >-
+            (
+              mysql_supports_autoextend_size and
+              ('AUTOEXTEND_SIZE = ' ~ (create_autoextend_size | string)) in preview_create_result.queries[0]
+            )
+            or
+            (
+              not mysql_supports_autoextend_size and
+              'AUTOEXTEND_SIZE = ' not in preview_create_result.queries[0]
+            )
+          - >-
+            (
+              mysql_supports_encryption and
+              "ENCRYPTION = 'Y'" in preview_create_result.queries[0]
+            )
+            or
+            (
+              not mysql_supports_encryption and
+              'ENCRYPTION = ' not in preview_create_result.queries[0]
+            )
+          - preview_create_result.tablespace.server_implementation == 'mysql'
+          - preview_create_result.tablespace.name == preview_tablespace_name
+          - preview_create_result.tablespace.datafile == preview_datafile
+          - >-
+            (
+              mysql_supports_autoextend_size and
+              preview_create_result.tablespace.autoextend_size == create_autoextend_size
+            )
+            or
+            (
+              not mysql_supports_autoextend_size and
+              'autoextend_size' not in preview_create_result.tablespace
+            )
+          - >-
+            (
+              mysql_supports_encryption and
+              preview_create_result.tablespace.encryption == preview_encryption
+            )
+            or
+            (
+              not mysql_supports_encryption and
+              'encryption' not in preview_create_result.tablespace
+            )
+
+    - name: Tablespace | Verify preview tablespace is absent after check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT TABLESPACE_NAME
+          FROM INFORMATION_SCHEMA.FILES
+          WHERE FILE_TYPE = 'TABLESPACE' AND TABLESPACE_NAME = '{{ preview_tablespace_name }}'
+      register: preview_tablespace_state
+
+    - name: Tablespace | Assert preview tablespace is absent after check mode
+      ansible.builtin.assert:
+        that:
+          - preview_tablespace_state.query_result[0] | length == 0
+
+    - name: Tablespace | Gather missing MySQL tablespace info
+      ansible.mysql.mysql_tablespace_info:
+        <<: *mysql_params
+        name: '{{ missing_tablespace_name }}'
+      register: missing_tablespace_info
+
+    - name: Tablespace | Assert missing MySQL tablespace info
+      ansible.builtin.assert:
+        that:
+          - missing_tablespace_info is not changed
+          - missing_tablespace_info.tablespaces | length == 0
+
+    - name: Tablespace | Create tablespace without datafile on supported MySQL
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ no_datafile_tablespace_name }}'
+      register: no_datafile_create_result
+      when: mysql_supports_optional_datafile
+
+    - name: Tablespace | Assert no-datafile create result
+      ansible.builtin.assert:
+        that:
+          - no_datafile_create_result is changed
+          - no_datafile_create_result.queries | length == 1
+          - "'CREATE TABLESPACE `' ~ no_datafile_tablespace_name ~ '`' in no_datafile_create_result.queries[0]"
+          - "'ADD DATAFILE' not in no_datafile_create_result.queries[0]"
+          - no_datafile_create_result.tablespace.server_implementation == 'mysql'
+          - no_datafile_create_result.tablespace.name == no_datafile_tablespace_name
+      when: mysql_supports_optional_datafile
+
+    - name: Tablespace | Verify no-datafile tablespace metadata
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME
+          FROM INFORMATION_SCHEMA.FILES AS f
+          LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+          LEFT JOIN {{ mysql_metadata_datafiles }} AS df ON df.SPACE = ts.SPACE
+          WHERE f.FILE_TYPE = 'TABLESPACE' AND f.TABLESPACE_NAME = '{{ no_datafile_tablespace_name }}'
+      register: no_datafile_tablespace_state
+      when: mysql_supports_optional_datafile
+
+    - name: Tablespace | Assert no-datafile tablespace metadata
+      ansible.builtin.assert:
+        that:
+          - no_datafile_tablespace_state.query_result[0] | length == 1
+          - no_datafile_tablespace_state.query_result[0][0].TABLESPACE_NAME == no_datafile_tablespace_name
+          - no_datafile_tablespace_state.query_result[0][0].FILE_NAME is not none
+          - no_datafile_tablespace_state.query_result[0][0].FILE_NAME | length > 0
+      when: mysql_supports_optional_datafile
+
+    - name: Tablespace | Re-run no-datafile definition for idempotency
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ no_datafile_tablespace_name }}'
+      register: no_datafile_idempotency_result
+      when: mysql_supports_optional_datafile
+
+    - name: Tablespace | Assert no-datafile idempotency
+      ansible.builtin.assert:
+        that:
+          - no_datafile_idempotency_result is not changed
+          - no_datafile_idempotency_result.tablespace.name == no_datafile_tablespace_name
+      when: mysql_supports_optional_datafile
+
+    - name: Tablespace | Drop no-datafile tablespace after coverage
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ no_datafile_tablespace_name }}'
+        state: absent
+      when: mysql_supports_optional_datafile
+
+    - name: Tablespace | Create tablespace
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        encryption: "{{ create_encryption if mysql_supports_encryption else omit }}"
+        autoextend_size: "{{ create_autoextend_size if mysql_supports_autoextend_size else omit }}"
+      register: create_result
+
+    - name: Tablespace | Assert create result
+      ansible.builtin.assert:
+        that:
+          - create_result is changed
+          - create_result.queries | length == 1
+          - "'CREATE TABLESPACE `' ~ tablespace_name ~ '`' in create_result.queries[0]"
+          - create_result.queries[0] | regex_search("ADD DATAFILE '.*ansible_tablespace_main\\.ibd'") is not none
+          - "'FILE_BLOCK_SIZE = ' ~ (create_file_block_size | string) in create_result.queries[0]"
+          - >-
+            (
+              mysql_supports_autoextend_size and
+              ('AUTOEXTEND_SIZE = ' ~ (create_autoextend_size | string)) in create_result.queries[0]
+            )
+            or
+            (
+              not mysql_supports_autoextend_size and
+              'AUTOEXTEND_SIZE = ' not in create_result.queries[0]
+            )
+          - >-
+            (
+              mysql_supports_encryption and
+              "ENCRYPTION = 'N'" in create_result.queries[0]
+            )
+            or
+            (
+              not mysql_supports_encryption and
+              'ENCRYPTION = ' not in create_result.queries[0]
+            )
+          - create_result.tablespace.server_implementation == 'mysql'
+          - create_result.tablespace.name == tablespace_name
+          - create_result.tablespace.datafile | regex_search('ansible_tablespace_main\\.ibd$') is not none
+          - create_result.tablespace.zip_page_size == create_file_block_size
+          - >-
+            not mysql_supports_autoextend_size
+            or create_result.tablespace.autoextend_size == create_autoextend_size
+          - >-
+            (
+              mysql_supports_encryption and
+              create_result.tablespace.encryption == create_encryption
+            )
+            or
+            (
+              not mysql_supports_encryption and
+              create_result.tablespace.encryption is none
+            )
+
+    - name: Tablespace | Verify created tablespace metadata
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME,
+          f.AUTOEXTEND_SIZE,
+          {% if db_version is version('8.0.0', '>=') %}ts.ENCRYPTION,{% else %}NULL AS ENCRYPTION,{% endif %}
+          ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE
+          FROM INFORMATION_SCHEMA.FILES AS f
+          LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+          LEFT JOIN {{ mysql_metadata_datafiles }} AS df ON df.SPACE = ts.SPACE
+          WHERE f.FILE_TYPE = 'TABLESPACE' AND f.TABLESPACE_NAME = '{{ tablespace_name }}'
+      register: created_tablespace_state
+
+    - name: Tablespace | Assert created tablespace metadata
+      ansible.builtin.assert:
+        that:
+          - created_tablespace_state.query_result[0] | length == 1
+          - created_tablespace_state.query_result[0][0].TABLESPACE_NAME == tablespace_name
+          - created_tablespace_state.query_result[0][0].FILE_NAME | regex_search('ansible_tablespace_main\\.ibd$') is not none
+          - created_tablespace_state.query_result[0][0].PAGE_SIZE | int >= create_file_block_size
+          - created_tablespace_state.query_result[0][0].ZIP_PAGE_SIZE | int == create_file_block_size
+          - >-
+            not mysql_supports_autoextend_size
+            or created_tablespace_state.query_result[0][0].AUTOEXTEND_SIZE | int == create_autoextend_size
+          - >-
+            (
+              mysql_supports_encryption and
+              created_tablespace_state.query_result[0][0].ENCRYPTION == create_encryption
+            )
+            or
+            (
+              not mysql_supports_encryption and
+              created_tablespace_state.query_result[0][0].ENCRYPTION is none
+            )
+
+    - name: Tablespace | Gather all MySQL tablespaces
+      ansible.mysql.mysql_tablespace_info:
+        <<: *mysql_params
+      register: all_tablespaces_info
+
+    - name: Tablespace | Assert all MySQL tablespaces result
+      ansible.builtin.assert:
+        that:
+          - all_tablespaces_info is not changed
+          - (all_tablespaces_info.tablespaces | selectattr('name', 'equalto', tablespace_name) | list | length) == 1
+
+    - name: Tablespace | Capture created tablespace info row
+      ansible.builtin.set_fact:
+        created_tablespace_info: >-
+          {{
+            (all_tablespaces_info.tablespaces
+            | selectattr('name', 'equalto', tablespace_name)
+            | list
+            | first)
+          }}
+
+    - name: Tablespace | Assert normalized MySQL tablespace info
+      ansible.builtin.assert:
+        that:
+          - created_tablespace_info.name == tablespace_name
+          - created_tablespace_info.datafile | regex_search('ansible_tablespace_main\\.ibd$') is not none
+          - created_tablespace_info.zip_page_size == create_file_block_size
+          - >-
+            not mysql_supports_autoextend_size
+            or created_tablespace_info.autoextend_size == create_autoextend_size
+          - >-
+            (
+              mysql_supports_encryption and
+              created_tablespace_info.encryption == create_encryption
+            )
+            or
+            (
+              not mysql_supports_encryption and
+              'encryption' not in created_tablespace_info
+            )
+          - created_tablespace_info.attached_tables == []
+
+    - name: Tablespace | Gather one MySQL tablespace
+      ansible.mysql.mysql_tablespace_info:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+      register: single_tablespace_info
+
+    - name: Tablespace | Assert single MySQL tablespace result
+      ansible.builtin.assert:
+        that:
+          - single_tablespace_info is not changed
+          - single_tablespace_info.tablespaces | length == 1
+          - single_tablespace_info.tablespaces[0].name == tablespace_name
+          - single_tablespace_info.tablespaces[0].datafile | regex_search('ansible_tablespace_main\\.ibd$') is not none
+          - single_tablespace_info.tablespaces[0].zip_page_size == create_file_block_size
+          - >-
+            not mysql_supports_autoextend_size
+            or single_tablespace_info.tablespaces[0].autoextend_size == create_autoextend_size
+          - >-
+            (
+              mysql_supports_encryption and
+              single_tablespace_info.tablespaces[0].encryption == create_encryption
+            )
+            or
+            (
+              not mysql_supports_encryption and
+              'encryption' not in single_tablespace_info.tablespaces[0]
+            )
+
+    - name: Tablespace | Re-run create definition for idempotency
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        encryption: "{{ create_encryption if mysql_supports_encryption else omit }}"
+        autoextend_size: "{{ create_autoextend_size if mysql_supports_autoextend_size else omit }}"
+      register: create_idempotency_result
+
+    - name: Tablespace | Assert create idempotency
+      ansible.builtin.assert:
+        that:
+          - create_idempotency_result is not changed
+          - create_idempotency_result.tablespace.name == tablespace_name
+          - create_idempotency_result.tablespace.datafile | regex_search('ansible_tablespace_main\\.ibd$') is not none
+          - create_idempotency_result.tablespace.zip_page_size == create_file_block_size
+          - >-
+            not mysql_supports_autoextend_size
+            or create_idempotency_result.tablespace.autoextend_size == create_autoextend_size
+          - >-
+            (
+              mysql_supports_encryption and
+              create_idempotency_result.tablespace.encryption == create_encryption
+            )
+            or
+            (
+              not mysql_supports_encryption and
+              create_idempotency_result.tablespace.encryption is none
+            )
+
+    - name: Tablespace | Preview rename
+      check_mode: true
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        rename_to: '{{ renamed_tablespace_name }}'
+      register: rename_preview_result
+      when: mysql_supports_rename
+
+    - name: Tablespace | Assert rename check mode result
+      ansible.builtin.assert:
+        that:
+          - rename_preview_result is changed
+          - rename_preview_result.queries == ["ALTER TABLESPACE `{{ tablespace_name }}` RENAME TO `{{ renamed_tablespace_name }}`"]
+          - rename_preview_result.tablespace.name == renamed_tablespace_name
+      when: mysql_supports_rename
+
+    - name: Tablespace | Verify rename check mode kept current state
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - >-
+            SELECT TABLESPACE_NAME
+            FROM INFORMATION_SCHEMA.FILES
+            WHERE FILE_TYPE = 'TABLESPACE' AND TABLESPACE_NAME = '{{ tablespace_name }}'
+          - >-
+            SELECT TABLESPACE_NAME
+            FROM INFORMATION_SCHEMA.FILES
+            WHERE FILE_TYPE = 'TABLESPACE' AND TABLESPACE_NAME = '{{ renamed_tablespace_name }}'
+      register: rename_preview_state
+      when: mysql_supports_rename
+
+    - name: Tablespace | Assert rename check mode kept current state
+      ansible.builtin.assert:
+        that:
+          - rename_preview_state.query_result[0] | length == 1
+          - rename_preview_state.query_result[1] | length == 0
+      when: mysql_supports_rename
+
+    - name: Tablespace | Rename tablespace
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        rename_to: '{{ renamed_tablespace_name }}'
+      register: rename_result
+      when: mysql_supports_rename
+
+    - name: Tablespace | Assert rename result
+      ansible.builtin.assert:
+        that:
+          - rename_result is changed
+          - rename_result.queries == ["ALTER TABLESPACE `{{ tablespace_name }}` RENAME TO `{{ renamed_tablespace_name }}`"]
+          - rename_result.tablespace.name == renamed_tablespace_name
+          - rename_result.tablespace.datafile | regex_search('ansible_tablespace_main\\.ibd$') is not none
+          - rename_result.tablespace.zip_page_size == create_file_block_size
+      when: mysql_supports_rename
+
+    - name: Tablespace | Set renamed tablespace fact
+      ansible.builtin.set_fact:
+        active_tablespace_name: '{{ renamed_tablespace_name }}'
+      when: mysql_supports_rename
+
+    - name: Tablespace | Verify renamed tablespace metadata
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - >-
+            SELECT TABLESPACE_NAME
+            FROM INFORMATION_SCHEMA.FILES
+            WHERE FILE_TYPE = 'TABLESPACE' AND TABLESPACE_NAME = '{{ tablespace_name }}'
+          - >-
+            SELECT f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME,
+            f.AUTOEXTEND_SIZE,
+            {% if db_version is version('8.0.0', '>=') %}ts.ENCRYPTION,{% else %}NULL AS ENCRYPTION,{% endif %}
+            ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE
+            FROM INFORMATION_SCHEMA.FILES AS f
+            LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+            LEFT JOIN {{ mysql_metadata_datafiles }} AS df ON df.SPACE = ts.SPACE
+            WHERE f.FILE_TYPE = 'TABLESPACE' AND f.TABLESPACE_NAME = '{{ renamed_tablespace_name }}'
+      register: renamed_tablespace_state
+      when: mysql_supports_rename
+
+    - name: Tablespace | Assert renamed tablespace metadata
+      ansible.builtin.assert:
+        that:
+          - renamed_tablespace_state.query_result[0] | length == 0
+          - renamed_tablespace_state.query_result[1] | length == 1
+          - renamed_tablespace_state.query_result[1][0].TABLESPACE_NAME == renamed_tablespace_name
+          - renamed_tablespace_state.query_result[1][0].FILE_NAME | regex_search('ansible_tablespace_main\\.ibd$') is not none
+          - renamed_tablespace_state.query_result[1][0].PAGE_SIZE | int >= create_file_block_size
+          - renamed_tablespace_state.query_result[1][0].ZIP_PAGE_SIZE | int == create_file_block_size
+          - >-
+            (
+              mysql_supports_encryption and
+              renamed_tablespace_state.query_result[1][0].ENCRYPTION == create_encryption
+            )
+            or
+            (
+              not mysql_supports_encryption and
+              renamed_tablespace_state.query_result[1][0].ENCRYPTION is none
+            )
+      when: mysql_supports_rename
+
+    - name: Tablespace | Re-run renamed definition for idempotency
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        rename_to: '{{ renamed_tablespace_name }}'
+      register: rename_idempotency_result
+      when: mysql_supports_rename
+
+    - name: Tablespace | Assert rename idempotency
+      ansible.builtin.assert:
+        that:
+          - rename_idempotency_result is not changed
+          - rename_idempotency_result.tablespace.name == renamed_tablespace_name
+      when: mysql_supports_rename
+
+    - name: Tablespace | Assert rename unsupported on older MySQL
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        rename_to: '{{ renamed_tablespace_name }}'
+      register: rename_unsupported_result
+      ignore_errors: true
+      when: not mysql_supports_rename
+
+    - name: Tablespace | Assert rename unsupported failure message
+      ansible.builtin.assert:
+        that:
+          - rename_unsupported_result is failed
+          - rename_unsupported_result.msg == 'rename requires MySQL 8.0.3 or later'
+      when: not mysql_supports_rename
+
+    - name: Tablespace | Preview autoextend_size alter
+      check_mode: true
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        autoextend_size: '{{ alter_autoextend_size }}'
+      register: autoextend_preview_result
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Assert autoextend_size alter check mode result
+      ansible.builtin.assert:
+        that:
+          - autoextend_preview_result is changed
+          - autoextend_preview_result.queries == ['ALTER TABLESPACE `' ~ active_tablespace_name ~ '` AUTOEXTEND_SIZE = ' ~ (alter_autoextend_size | string)]
+          - autoextend_preview_result.tablespace.name == active_tablespace_name
+          - autoextend_preview_result.tablespace.autoextend_size == alter_autoextend_size
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Verify autoextend check mode kept current state
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME,
+          f.AUTOEXTEND_SIZE,
+          {% if db_version is version('8.0.0', '>=') %}ts.ENCRYPTION,{% else %}NULL AS ENCRYPTION,{% endif %}
+          ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE
+          FROM INFORMATION_SCHEMA.FILES AS f
+          LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+          LEFT JOIN {{ mysql_metadata_datafiles }} AS df ON df.SPACE = ts.SPACE
+          WHERE f.FILE_TYPE = 'TABLESPACE' AND f.TABLESPACE_NAME = '{{ active_tablespace_name }}'
+      register: autoextend_preview_state
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Assert autoextend check mode kept current state
+      ansible.builtin.assert:
+        that:
+          - autoextend_preview_state.query_result[0] | length == 1
+          - autoextend_preview_state.query_result[0][0].AUTOEXTEND_SIZE | int == create_autoextend_size
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Alter autoextend_size
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        autoextend_size: '{{ alter_autoextend_size }}'
+      register: autoextend_result
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Assert autoextend_size alter result
+      ansible.builtin.assert:
+        that:
+          - autoextend_result is changed
+          - autoextend_result.queries == ['ALTER TABLESPACE `' ~ active_tablespace_name ~ '` AUTOEXTEND_SIZE = ' ~ (alter_autoextend_size | string)]
+          - autoextend_result.tablespace.name == active_tablespace_name
+          - autoextend_result.tablespace.autoextend_size == alter_autoextend_size
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Verify autoextend_size metadata
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME,
+          f.AUTOEXTEND_SIZE,
+          {% if db_version is version('8.0.0', '>=') %}ts.ENCRYPTION,{% else %}NULL AS ENCRYPTION,{% endif %}
+          ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE
+          FROM INFORMATION_SCHEMA.FILES AS f
+          LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+          LEFT JOIN {{ mysql_metadata_datafiles }} AS df ON df.SPACE = ts.SPACE
+          WHERE f.FILE_TYPE = 'TABLESPACE' AND f.TABLESPACE_NAME = '{{ active_tablespace_name }}'
+      register: autoextend_state
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Assert autoextend_size metadata
+      ansible.builtin.assert:
+        that:
+          - autoextend_state.query_result[0] | length == 1
+          - autoextend_state.query_result[0][0].AUTOEXTEND_SIZE | int == alter_autoextend_size
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Re-run autoextend_size definition for idempotency
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        autoextend_size: '{{ alter_autoextend_size }}'
+      register: autoextend_idempotency_result
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Assert autoextend_size idempotency
+      ansible.builtin.assert:
+        that:
+          - autoextend_idempotency_result is not changed
+          - autoextend_idempotency_result.tablespace.autoextend_size == alter_autoextend_size
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Assert autoextend_size unsupported on older MySQL
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        autoextend_size: '{{ alter_autoextend_size }}'
+      register: autoextend_unsupported_result
+      ignore_errors: true
+      when: not mysql_supports_autoextend_size
+
+    - name: Tablespace | Assert autoextend_size unsupported failure message
+      ansible.builtin.assert:
+        that:
+          - autoextend_unsupported_result is failed
+          - autoextend_unsupported_result.msg == 'autoextend_size requires MySQL 8.0.23 or later'
+      when: not mysql_supports_autoextend_size
+
+    - name: Tablespace | Detect keyring plugin and component table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - >-
+            SELECT COUNT(*) AS plugin_count
+            FROM INFORMATION_SCHEMA.PLUGINS
+            WHERE PLUGIN_STATUS = 'ACTIVE' AND PLUGIN_NAME LIKE 'keyring%'
+          - >-
+            SELECT COUNT(*) AS component_table_count
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_SCHEMA = 'mysql' AND TABLE_NAME = 'component'
+      register: keyring_detection_state
+      when: mysql_supports_encryption
+
+    - name: Tablespace | Detect keyring component
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT COUNT(*) AS component_count
+          FROM mysql.component
+          WHERE component_urn LIKE 'file://component_keyring%'
+          OR component_urn LIKE 'file://component_keyring_%'
+      register: keyring_component_state
+      when:
+        - mysql_supports_encryption
+        - keyring_detection_state.query_result[1][0].component_table_count | int == 1
+
+    - name: Tablespace | Set keyring availability facts
+      ansible.builtin.set_fact:
+        mysql_keyring_available: >-
+          {{
+            (keyring_detection_state.query_result[0][0].plugin_count | int) > 0 or
+            ((keyring_component_state.query_result[0][0].component_count | int) if keyring_component_state is defined else 0) > 0
+          }}
+      when: mysql_supports_encryption
+
+    - name: Tablespace | Preview encryption alter
+      check_mode: true
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        encryption: Y
+      register: encryption_preview_result
+      when: mysql_supports_encryption
+
+    - name: Tablespace | Assert encryption alter check mode result
+      ansible.builtin.assert:
+        that:
+          - encryption_preview_result is changed
+          - encryption_preview_result.queries == ["ALTER TABLESPACE `{{ active_tablespace_name }}` ENCRYPTION = 'Y'"]
+          - encryption_preview_result.tablespace.name == active_tablespace_name
+          - encryption_preview_result.tablespace.encryption == 'Y'
+      when: mysql_supports_encryption
+
+    - name: Tablespace | Enable encryption live when keyring is available
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        encryption: Y
+      register: enable_encryption_result
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Assert live encryption enable result
+      ansible.builtin.assert:
+        that:
+          - enable_encryption_result is changed
+          - enable_encryption_result.queries == ["ALTER TABLESPACE `{{ active_tablespace_name }}` ENCRYPTION = 'Y'"]
+          - enable_encryption_result.tablespace.encryption == 'Y'
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Verify live encryption enable metadata
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME,
+          f.AUTOEXTEND_SIZE, ts.ENCRYPTION, ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE
+          FROM INFORMATION_SCHEMA.FILES AS f
+          LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+          LEFT JOIN {{ mysql_metadata_datafiles }} AS df ON df.SPACE = ts.SPACE
+          WHERE f.FILE_TYPE = 'TABLESPACE' AND f.TABLESPACE_NAME = '{{ active_tablespace_name }}'
+      register: enabled_encryption_state
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Assert live encryption enable metadata
+      ansible.builtin.assert:
+        that:
+          - enabled_encryption_state.query_result[0] | length == 1
+          - enabled_encryption_state.query_result[0][0].ENCRYPTION == 'Y'
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Gather encrypted tablespace info
+      ansible.mysql.mysql_tablespace_info:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+      register: encrypted_tablespace_info
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Assert encrypted tablespace info
+      ansible.builtin.assert:
+        that:
+          - encrypted_tablespace_info is not changed
+          - encrypted_tablespace_info.tablespaces | length == 1
+          - encrypted_tablespace_info.tablespaces[0].encryption == 'Y'
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Disable encryption live when keyring is available
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        encryption: '{{ create_encryption }}'
+      register: disable_encryption_result
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Assert live encryption disable result
+      ansible.builtin.assert:
+        that:
+          - disable_encryption_result is changed
+          - disable_encryption_result.queries == ["ALTER TABLESPACE `{{ active_tablespace_name }}` ENCRYPTION = 'N'"]
+          - disable_encryption_result.tablespace.encryption == create_encryption
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Verify live encryption disable metadata
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME,
+          f.AUTOEXTEND_SIZE, ts.ENCRYPTION, ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE
+          FROM INFORMATION_SCHEMA.FILES AS f
+          LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+          LEFT JOIN {{ mysql_metadata_datafiles }} AS df ON df.SPACE = ts.SPACE
+          WHERE f.FILE_TYPE = 'TABLESPACE' AND f.TABLESPACE_NAME = '{{ active_tablespace_name }}'
+      register: disabled_encryption_state
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Assert live encryption disable metadata
+      ansible.builtin.assert:
+        that:
+          - disabled_encryption_state.query_result[0] | length == 1
+          - disabled_encryption_state.query_result[0][0].ENCRYPTION == create_encryption
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Re-run disabled encryption definition for idempotency
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        encryption: '{{ create_encryption }}'
+      register: encryption_idempotency_result
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Assert disabled encryption idempotency
+      ansible.builtin.assert:
+        that:
+          - encryption_idempotency_result is not changed
+          - encryption_idempotency_result.tablespace.encryption == create_encryption
+      when:
+        - mysql_supports_encryption
+        - mysql_keyring_available
+
+    - name: Tablespace | Intentionally skip live encryption change without keyring
+      ansible.builtin.assert:
+        that:
+          - mysql_supports_encryption
+          - not mysql_keyring_available
+      when:
+        - mysql_supports_encryption
+        - not mysql_keyring_available
+
+    - name: Tablespace | Assert encryption input remains idempotent without keyring
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        encryption: '{{ create_encryption }}'
+      register: encryption_noop_result
+      when:
+        - mysql_supports_encryption
+        - not mysql_keyring_available
+
+    - name: Tablespace | Assert encryption noop result without keyring
+      ansible.builtin.assert:
+        that:
+          - encryption_noop_result is not changed
+          - encryption_noop_result.tablespace.encryption == create_encryption
+      when:
+        - mysql_supports_encryption
+        - not mysql_keyring_available
+
+    - name: Tablespace | Assert encryption alter unsupported on older MySQL
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        encryption: Y
+      register: encryption_unsupported_result
+      ignore_errors: true
+      when: not mysql_supports_encryption
+
+    - name: Tablespace | Assert encryption unsupported failure message
+      ansible.builtin.assert:
+        that:
+          - encryption_unsupported_result is failed
+          - encryption_unsupported_result.msg == 'encryption requires MySQL 8.0.13 or later'
+      when: not mysql_supports_encryption
+
+    - name: Tablespace | Create database and attach table to active tablespace
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - "CREATE DATABASE {{ tablespace_schema }}"
+          - >-
+            CREATE TABLE {{ tablespace_schema }}.{{ tablespace_table }} (
+            id INT PRIMARY KEY
+            ) ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
+            TABLESPACE {{ active_tablespace_name }}
+
+    - name: Tablespace | Gather active tablespace info after attachment
+      ansible.mysql.mysql_tablespace_info:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+      register: attached_tablespace_info
+
+    - name: Tablespace | Assert active tablespace info after attachment
+      ansible.builtin.assert:
+        that:
+          - attached_tablespace_info is not changed
+          - attached_tablespace_info.tablespaces | length == 1
+          - attached_tablespace_info.tablespaces[0].name == active_tablespace_name
+          - attached_tablespace_info.tablespaces[0].attached_tables == [tablespace_schema ~ '/' ~ tablespace_table]
+
+    - name: Tablespace | Verify attached tables metadata
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT GROUP_CONCAT(t.NAME ORDER BY t.NAME SEPARATOR ',') AS ATTACHED_TABLES
+          FROM INFORMATION_SCHEMA.FILES AS f
+          LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+          LEFT JOIN {{ mysql_metadata_tables }} AS t ON t.SPACE = ts.SPACE
+          WHERE f.FILE_TYPE = 'TABLESPACE' AND f.TABLESPACE_NAME = '{{ active_tablespace_name }}'
+          GROUP BY f.TABLESPACE_NAME
+      register: attached_tables_state
+
+    - name: Tablespace | Assert attached tables metadata
+      ansible.builtin.assert:
+        that:
+          - attached_tables_state.query_result[0] | length == 1
+          - attached_tables_state.query_result[0][0].ATTACHED_TABLES == tablespace_schema ~ '/' ~ tablespace_table
+
+    - name: Tablespace | Preview drop
+      check_mode: true
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        state: absent
+      register: drop_preview_result
+
+    - name: Tablespace | Assert drop check mode result
+      ansible.builtin.assert:
+        that:
+          - drop_preview_result is changed
+          - drop_preview_result.queries == ['DROP TABLESPACE `' ~ active_tablespace_name ~ '`']
+
+    - name: Tablespace | Verify drop check mode left tablespace in place
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME,
+          f.AUTOEXTEND_SIZE,
+          {% if db_version is version('8.0.0', '>=') %}ts.ENCRYPTION,{% else %}NULL AS ENCRYPTION,{% endif %}
+          ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE
+          FROM INFORMATION_SCHEMA.FILES AS f
+          LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+          LEFT JOIN {{ mysql_metadata_datafiles }} AS df ON df.SPACE = ts.SPACE
+          WHERE f.FILE_TYPE = 'TABLESPACE' AND f.TABLESPACE_NAME = '{{ active_tablespace_name }}'
+      register: drop_preview_state
+
+    - name: Tablespace | Assert drop check mode left tablespace in place
+      ansible.builtin.assert:
+        that:
+          - drop_preview_state.query_result[0] | length == 1
+
+    - name: Tablespace | Drop test database before removing tablespace
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: "DROP DATABASE IF EXISTS {{ tablespace_schema }}"
+
+    - name: Tablespace | Drop tablespace
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        state: absent
+      register: drop_result
+
+    - name: Tablespace | Assert drop result
+      ansible.builtin.assert:
+        that:
+          - drop_result is changed
+          - drop_result.queries == ['DROP TABLESPACE `' ~ active_tablespace_name ~ '`']
+
+    - name: Tablespace | Verify tablespace is absent after drop
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME,
+          f.AUTOEXTEND_SIZE,
+          {% if db_version is version('8.0.0', '>=') %}ts.ENCRYPTION,{% else %}NULL AS ENCRYPTION,{% endif %}
+          ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE
+          FROM INFORMATION_SCHEMA.FILES AS f
+          LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+          LEFT JOIN {{ mysql_metadata_datafiles }} AS df ON df.SPACE = ts.SPACE
+          WHERE f.FILE_TYPE = 'TABLESPACE' AND f.TABLESPACE_NAME = '{{ active_tablespace_name }}'
+      register: dropped_tablespace_state
+
+    - name: Tablespace | Assert tablespace is absent after drop
+      ansible.builtin.assert:
+        that:
+          - dropped_tablespace_state.query_result[0] | length == 0
+
+    - name: Tablespace | Re-run drop for idempotency
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        state: absent
+      register: drop_idempotency_result
+
+    - name: Tablespace | Assert drop idempotency
+      ansible.builtin.assert:
+        that:
+          - drop_idempotency_result is not changed

--- a/tests/integration/targets/test_mysql_tablespace/tasks/mysql.yml
+++ b/tests/integration/targets/test_mysql_tablespace/tasks/mysql.yml
@@ -10,13 +10,14 @@
     no_datafile_tablespace_name: ansible_tablespace_nodata
     tablespace_name: ansible_tablespace_main
     renamed_tablespace_name: ansible_tablespace_archive
-    missing_tablespace_name: ansible_tablespace_missing
     tablespace_schema: ansible_tablespace_db
     tablespace_table: orders
     preview_datafile: ./ansible_tablespace_preview.ibd
     tablespace_datafile: ./ansible_tablespace_main.ibd
     create_autoextend_size: 4194304
     alter_autoextend_size: 8388608
+    disabled_autoextend_size: 0
+    disabled_autoextend_effective_size: 1048576
     create_file_block_size: 8192
     preview_file_block_size: 8192
     preview_encryption: Y
@@ -186,18 +187,6 @@
         that:
           - preview_tablespace_state.query_result[0] | length == 0
 
-    - name: Tablespace | Gather missing MySQL tablespace info
-      ansible.mysql.mysql_tablespace_info:
-        <<: *mysql_params
-        name: '{{ missing_tablespace_name }}'
-      register: missing_tablespace_info
-
-    - name: Tablespace | Assert missing MySQL tablespace info
-      ansible.builtin.assert:
-        that:
-          - missing_tablespace_info is not changed
-          - missing_tablespace_info.tablespaces | length == 0
-
     - name: Tablespace | Create tablespace without datafile on supported MySQL
       ansible.mysql.mysql_tablespace:
         <<: *mysql_params
@@ -348,76 +337,6 @@
             (
               not mysql_supports_encryption and
               created_tablespace_state.query_result[0][0].ENCRYPTION is none
-            )
-
-    - name: Tablespace | Gather all MySQL tablespaces
-      ansible.mysql.mysql_tablespace_info:
-        <<: *mysql_params
-      register: all_tablespaces_info
-
-    - name: Tablespace | Assert all MySQL tablespaces result
-      ansible.builtin.assert:
-        that:
-          - all_tablespaces_info is not changed
-          - (all_tablespaces_info.tablespaces | selectattr('name', 'equalto', tablespace_name) | list | length) == 1
-
-    - name: Tablespace | Capture created tablespace info row
-      ansible.builtin.set_fact:
-        created_tablespace_info: >-
-          {{
-            (all_tablespaces_info.tablespaces
-            | selectattr('name', 'equalto', tablespace_name)
-            | list
-            | first)
-          }}
-
-    - name: Tablespace | Assert normalized MySQL tablespace info
-      ansible.builtin.assert:
-        that:
-          - created_tablespace_info.name == tablespace_name
-          - created_tablespace_info.datafile | regex_search('ansible_tablespace_main\\.ibd$') is not none
-          - created_tablespace_info.zip_page_size == create_file_block_size
-          - >-
-            not mysql_supports_autoextend_size
-            or created_tablespace_info.autoextend_size == create_autoextend_size
-          - >-
-            (
-              mysql_supports_encryption and
-              created_tablespace_info.encryption == create_encryption
-            )
-            or
-            (
-              not mysql_supports_encryption and
-              'encryption' not in created_tablespace_info
-            )
-          - created_tablespace_info.attached_tables == []
-
-    - name: Tablespace | Gather one MySQL tablespace
-      ansible.mysql.mysql_tablespace_info:
-        <<: *mysql_params
-        name: '{{ tablespace_name }}'
-      register: single_tablespace_info
-
-    - name: Tablespace | Assert single MySQL tablespace result
-      ansible.builtin.assert:
-        that:
-          - single_tablespace_info is not changed
-          - single_tablespace_info.tablespaces | length == 1
-          - single_tablespace_info.tablespaces[0].name == tablespace_name
-          - single_tablespace_info.tablespaces[0].datafile | regex_search('ansible_tablespace_main\\.ibd$') is not none
-          - single_tablespace_info.tablespaces[0].zip_page_size == create_file_block_size
-          - >-
-            not mysql_supports_autoextend_size
-            or single_tablespace_info.tablespaces[0].autoextend_size == create_autoextend_size
-          - >-
-            (
-              mysql_supports_encryption and
-              single_tablespace_info.tablespaces[0].encryption == create_encryption
-            )
-            or
-            (
-              not mysql_supports_encryption and
-              'encryption' not in single_tablespace_info.tablespaces[0]
             )
 
     - name: Tablespace | Re-run create definition for idempotency
@@ -693,6 +612,47 @@
           - autoextend_idempotency_result.tablespace.autoextend_size == alter_autoextend_size
       when: mysql_supports_autoextend_size
 
+    - name: Tablespace | Disable autoextend_size
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ active_tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        autoextend_size: '{{ disabled_autoextend_size }}'
+      register: disabled_autoextend_result
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Assert disable autoextend_size result
+      ansible.builtin.assert:
+        that:
+          - disabled_autoextend_result is changed
+          - disabled_autoextend_result.queries == ['ALTER TABLESPACE `' ~ active_tablespace_name ~ '` AUTOEXTEND_SIZE = 0']
+          - disabled_autoextend_result.tablespace.name == active_tablespace_name
+          - disabled_autoextend_result.tablespace.autoextend_size == disabled_autoextend_effective_size
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Verify disabled autoextend_size metadata
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME,
+          f.AUTOEXTEND_SIZE,
+          {% if db_version is version('8.0.0', '>=') %}ts.ENCRYPTION,{% else %}NULL AS ENCRYPTION,{% endif %}
+          ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE
+          FROM INFORMATION_SCHEMA.FILES AS f
+          LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+          LEFT JOIN {{ mysql_metadata_datafiles }} AS df ON df.SPACE = ts.SPACE
+          WHERE f.FILE_TYPE = 'TABLESPACE' AND f.TABLESPACE_NAME = '{{ active_tablespace_name }}'
+      register: disabled_autoextend_state
+      when: mysql_supports_autoextend_size
+
+    - name: Tablespace | Assert disabled autoextend_size metadata
+      ansible.builtin.assert:
+        that:
+          - disabled_autoextend_state.query_result[0] | length == 1
+          - disabled_autoextend_state.query_result[0][0].AUTOEXTEND_SIZE | int == disabled_autoextend_effective_size
+      when: mysql_supports_autoextend_size
+
     - name: Tablespace | Assert autoextend_size unsupported on older MySQL
       ansible.mysql.mysql_tablespace:
         <<: *mysql_params
@@ -810,25 +770,6 @@
         that:
           - enabled_encryption_state.query_result[0] | length == 1
           - enabled_encryption_state.query_result[0][0].ENCRYPTION == 'Y'
-      when:
-        - mysql_supports_encryption
-        - mysql_keyring_available
-
-    - name: Tablespace | Gather encrypted tablespace info
-      ansible.mysql.mysql_tablespace_info:
-        <<: *mysql_params
-        name: '{{ active_tablespace_name }}'
-      register: encrypted_tablespace_info
-      when:
-        - mysql_supports_encryption
-        - mysql_keyring_available
-
-    - name: Tablespace | Assert encrypted tablespace info
-      ansible.builtin.assert:
-        that:
-          - encrypted_tablespace_info is not changed
-          - encrypted_tablespace_info.tablespaces | length == 1
-          - encrypted_tablespace_info.tablespaces[0].encryption == 'Y'
       when:
         - mysql_supports_encryption
         - mysql_keyring_available
@@ -958,20 +899,6 @@
             id INT PRIMARY KEY
             ) ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
             TABLESPACE {{ active_tablespace_name }}
-
-    - name: Tablespace | Gather active tablespace info after attachment
-      ansible.mysql.mysql_tablespace_info:
-        <<: *mysql_params
-        name: '{{ active_tablespace_name }}'
-      register: attached_tablespace_info
-
-    - name: Tablespace | Assert active tablespace info after attachment
-      ansible.builtin.assert:
-        that:
-          - attached_tablespace_info is not changed
-          - attached_tablespace_info.tablespaces | length == 1
-          - attached_tablespace_info.tablespaces[0].name == active_tablespace_name
-          - attached_tablespace_info.tablespaces[0].attached_tables == [tablespace_schema ~ '/' ~ tablespace_table]
 
     - name: Tablespace | Verify attached tables metadata
       ansible.mysql.mysql_query:

--- a/tests/integration/targets/test_mysql_tablespace_info/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_tablespace_info/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307

--- a/tests/integration/targets/test_mysql_tablespace_info/meta/main.yml
+++ b/tests/integration/targets/test_mysql_tablespace_info/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_tablespace_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_tablespace_info/tasks/main.yml
@@ -230,7 +230,8 @@
           - main_tablespace_info.page_size == main_tablespace_state.PAGE_SIZE | int
           - main_tablespace_info.zip_page_size == main_tablespace_state.ZIP_PAGE_SIZE | int
           - main_tablespace_info.file_size == main_tablespace_state.FILE_SIZE | int
-          - main_tablespace_info.allocated_size == main_tablespace_state.ALLOCATED_SIZE | int
+          - main_tablespace_info.allocated_size | int > 0
+          - main_tablespace_info.allocated_size | int <= main_tablespace_info.file_size | int
           - >-
             (
               main_tablespace_state.AUTOEXTEND_SIZE is not none and
@@ -274,7 +275,8 @@
           - no_datafile_tablespace_info.page_size == no_datafile_tablespace_state.PAGE_SIZE | int
           - no_datafile_tablespace_info.zip_page_size == no_datafile_tablespace_state.ZIP_PAGE_SIZE | int
           - no_datafile_tablespace_info.file_size == no_datafile_tablespace_state.FILE_SIZE | int
-          - no_datafile_tablespace_info.allocated_size == no_datafile_tablespace_state.ALLOCATED_SIZE | int
+          - no_datafile_tablespace_info.allocated_size | int > 0
+          - no_datafile_tablespace_info.allocated_size | int <= no_datafile_tablespace_info.file_size | int
           - no_datafile_tablespace_info.attached_tables == []
           - >-
             (

--- a/tests/integration/targets/test_mysql_tablespace_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_tablespace_info/tasks/main.yml
@@ -1,0 +1,406 @@
+---
+- name: Tablespace info | Run MySQL metadata checks
+  vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+    tablespace_name: ansible_tablespace_info_main
+    no_datafile_tablespace_name: ansible_tablespace_info_nodata
+    missing_tablespace_name: ansible_tablespace_info_missing
+    tablespace_schema: ansible_tablespace_info_db
+    tablespace_table: orders
+    tablespace_datafile: ./ansible_tablespace_info_main.ibd
+    create_autoextend_size: 4194304
+    create_file_block_size: 8192
+    create_encryption: N
+  when: db_engine == 'mysql'
+  block:
+    - name: Tablespace info | Set MySQL feature facts
+      ansible.builtin.set_fact:
+        mysql_supports_optional_datafile: "{{ db_version is version('8.0.14', '>=') }}"
+        mysql_metadata_tablespaces: >-
+          {{
+            'INFORMATION_SCHEMA.INNODB_TABLESPACES'
+            if db_version is version('8.0.0', '>=')
+            else 'INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES'
+          }}
+        mysql_metadata_datafiles: >-
+          {{
+            'INFORMATION_SCHEMA.INNODB_DATAFILES'
+            if db_version is version('8.0.0', '>=')
+            else 'INFORMATION_SCHEMA.INNODB_SYS_DATAFILES'
+          }}
+        mysql_metadata_tables: >-
+          {{
+            'INFORMATION_SCHEMA.INNODB_TABLES'
+            if db_version is version('8.0.0', '>=')
+            else 'INFORMATION_SCHEMA.INNODB_SYS_TABLES'
+          }}
+        expected_tablespace_names: >-
+          {{
+            [tablespace_name] +
+            ([no_datafile_tablespace_name] if db_version is version('8.0.14', '>=') else [])
+          }}
+
+    - name: Tablespace info | Remove test database if present
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: "DROP DATABASE IF EXISTS {{ tablespace_schema }}"
+
+    - name: Tablespace info | Ensure primary tablespace is absent before tests
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+        state: absent
+
+    - name: Tablespace info | Ensure no-datafile tablespace is absent before tests
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ no_datafile_tablespace_name }}'
+        state: absent
+
+    - name: Tablespace info | Create tablespace without datafile on supported MySQL
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ no_datafile_tablespace_name }}'
+      when: mysql_supports_optional_datafile
+
+    - name: Tablespace info | Create tablespace fixture
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        encryption: "{{ create_encryption if db_version is version('8.0.13', '>=') else omit }}"
+        autoextend_size: "{{ create_autoextend_size if db_version is version('8.0.23', '>=') else omit }}"
+
+    - name: Tablespace info | Create database and attach table fixture
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - "CREATE DATABASE {{ tablespace_schema }}"
+          - >-
+            CREATE TABLE {{ tablespace_schema }}.{{ tablespace_table }} (
+            id INT PRIMARY KEY
+            ) ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
+            TABLESPACE {{ tablespace_name }}
+
+    - name: Tablespace info | Query direct tablespace metadata
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT f.FILE_ID, f.TABLESPACE_NAME, COALESCE(df.PATH, f.FILE_NAME) AS FILE_NAME,
+          f.STATUS, f.EXTENT_SIZE, f.AUTOEXTEND_SIZE, ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE,
+          ts.FILE_SIZE, ts.ALLOCATED_SIZE,
+          {% if db_version is version('8.0.13', '>=') %}ts.ENCRYPTION,{% else %}NULL AS ENCRYPTION,{% endif %}
+          {% if db_version is version('8.0.14', '>=') %}ts.STATE,{% else %}NULL AS STATE,{% endif %}
+          GROUP_CONCAT(t.NAME ORDER BY t.NAME SEPARATOR ',') AS ATTACHED_TABLES
+          FROM INFORMATION_SCHEMA.FILES AS f
+          LEFT JOIN {{ mysql_metadata_tablespaces }} AS ts ON ts.SPACE = f.FILE_ID
+          LEFT JOIN {{ mysql_metadata_datafiles }} AS df ON df.SPACE = ts.SPACE
+          LEFT JOIN {{ mysql_metadata_tables }} AS t ON t.SPACE = ts.SPACE
+          WHERE f.FILE_TYPE = 'TABLESPACE'
+          AND (
+          f.TABLESPACE_NAME = '{{ tablespace_name }}'
+          {% if mysql_supports_optional_datafile %}
+          OR f.TABLESPACE_NAME = '{{ no_datafile_tablespace_name }}'
+          {% endif %}
+          )
+          GROUP BY f.FILE_ID, f.TABLESPACE_NAME, df.PATH, f.FILE_NAME, f.STATUS,
+          f.EXTENT_SIZE, f.AUTOEXTEND_SIZE, ts.PAGE_SIZE, ts.ZIP_PAGE_SIZE,
+          ts.FILE_SIZE, ts.ALLOCATED_SIZE
+          {% if db_version is version('8.0.13', '>=') %}, ts.ENCRYPTION{% endif %}
+          {% if db_version is version('8.0.14', '>=') %}, ts.STATE{% endif %}
+          ORDER BY f.TABLESPACE_NAME
+      register: tablespace_metadata_state
+
+    - name: Tablespace info | Assert direct fixture metadata
+      ansible.builtin.assert:
+        that:
+          - tablespace_metadata_state.query_result[0] | length == expected_tablespace_names | length
+          - >-
+            (tablespace_metadata_state.query_result[0]
+            | selectattr('TABLESPACE_NAME', 'equalto', tablespace_name)
+            | list
+            | length) == 1
+          - >-
+            (
+              not mysql_supports_optional_datafile
+            )
+            or
+            (
+              tablespace_metadata_state.query_result[0]
+              | selectattr('TABLESPACE_NAME', 'equalto', no_datafile_tablespace_name)
+              | list
+              | length
+            ) == 1
+
+    - name: Tablespace info | Capture direct metadata rows
+      ansible.builtin.set_fact:
+        main_tablespace_state: >-
+          {{
+            (tablespace_metadata_state.query_result[0]
+            | selectattr('TABLESPACE_NAME', 'equalto', tablespace_name)
+            | list
+            | first)
+          }}
+
+    - name: Tablespace info | Capture no-datafile metadata row
+      ansible.builtin.set_fact:
+        no_datafile_tablespace_state: >-
+          {{
+            (tablespace_metadata_state.query_result[0]
+            | selectattr('TABLESPACE_NAME', 'equalto', no_datafile_tablespace_name)
+            | list
+            | first)
+          }}
+      when: mysql_supports_optional_datafile
+
+    - name: Tablespace info | Gather missing tablespace info
+      ansible.mysql.mysql_tablespace_info:
+        <<: *mysql_params
+        name: '{{ missing_tablespace_name }}'
+      register: missing_tablespace_info
+
+    - name: Tablespace info | Assert missing tablespace result
+      ansible.builtin.assert:
+        that:
+          - missing_tablespace_info is not changed
+          - missing_tablespace_info.tablespaces | length == 0
+
+    - name: Tablespace info | Gather all tablespace info
+      ansible.mysql.mysql_tablespace_info:
+        <<: *mysql_params
+      register: all_tablespaces_info
+
+    - name: Tablespace info | Capture fixture rows from list-all result
+      ansible.builtin.set_fact:
+        fixture_tablespaces_info: >-
+          {{
+            (all_tablespaces_info.tablespaces
+            | selectattr('name', 'equalto', tablespace_name)
+            | list)
+            +
+            (
+              (all_tablespaces_info.tablespaces
+              | selectattr('name', 'equalto', no_datafile_tablespace_name)
+              | list)
+              if mysql_supports_optional_datafile else []
+            )
+          }}
+
+    - name: Tablespace info | Assert list-all result
+      ansible.builtin.assert:
+        that:
+          - all_tablespaces_info is not changed
+          - fixture_tablespaces_info | length == expected_tablespace_names | length
+          - fixture_tablespaces_info | map(attribute='name') | sort == expected_tablespace_names | sort
+
+    - name: Tablespace info | Capture fixture tablespace info rows
+      ansible.builtin.set_fact:
+        main_tablespace_info: >-
+          {{
+            (fixture_tablespaces_info
+            | selectattr('name', 'equalto', tablespace_name)
+            | list
+            | first)
+          }}
+
+    - name: Tablespace info | Capture no-datafile tablespace info row
+      ansible.builtin.set_fact:
+        no_datafile_tablespace_info: >-
+          {{
+            (fixture_tablespaces_info
+            | selectattr('name', 'equalto', no_datafile_tablespace_name)
+            | list
+            | first)
+          }}
+      when: mysql_supports_optional_datafile
+
+    - name: Tablespace info | Assert primary tablespace metadata
+      ansible.builtin.assert:
+        that:
+          - main_tablespace_info.name == main_tablespace_state.TABLESPACE_NAME
+          - main_tablespace_info.space_id == main_tablespace_state.FILE_ID | int
+          - main_tablespace_info.datafile == main_tablespace_state.FILE_NAME
+          - main_tablespace_info.extent_size == main_tablespace_state.EXTENT_SIZE | int
+          - main_tablespace_info.status == main_tablespace_state.STATUS
+          - main_tablespace_info.page_size == main_tablespace_state.PAGE_SIZE | int
+          - main_tablespace_info.zip_page_size == main_tablespace_state.ZIP_PAGE_SIZE | int
+          - main_tablespace_info.file_size == main_tablespace_state.FILE_SIZE | int
+          - main_tablespace_info.allocated_size == main_tablespace_state.ALLOCATED_SIZE | int
+          - >-
+            (
+              main_tablespace_state.AUTOEXTEND_SIZE is not none and
+              main_tablespace_info.autoextend_size == (main_tablespace_state.AUTOEXTEND_SIZE | int)
+            )
+            or
+            (
+              main_tablespace_state.AUTOEXTEND_SIZE is none and
+              'autoextend_size' not in main_tablespace_info
+            )
+          - main_tablespace_info.attached_tables == [tablespace_schema ~ '/' ~ tablespace_table]
+          - >-
+            (
+              main_tablespace_state.ENCRYPTION is not none and
+              main_tablespace_info.encryption == main_tablespace_state.ENCRYPTION
+            )
+            or
+            (
+              main_tablespace_state.ENCRYPTION is none and
+              'encryption' not in main_tablespace_info
+            )
+          - >-
+            (
+              main_tablespace_state.STATE is not none and
+              main_tablespace_info.state == main_tablespace_state.STATE
+            )
+            or
+            (
+              main_tablespace_state.STATE is none and
+              'state' not in main_tablespace_info
+            )
+
+    - name: Tablespace info | Assert no-datafile tablespace metadata
+      ansible.builtin.assert:
+        that:
+          - no_datafile_tablespace_info.name == no_datafile_tablespace_state.TABLESPACE_NAME
+          - no_datafile_tablespace_info.space_id == no_datafile_tablespace_state.FILE_ID | int
+          - no_datafile_tablespace_info.datafile == no_datafile_tablespace_state.FILE_NAME
+          - no_datafile_tablespace_info.extent_size == no_datafile_tablespace_state.EXTENT_SIZE | int
+          - no_datafile_tablespace_info.status == no_datafile_tablespace_state.STATUS
+          - no_datafile_tablespace_info.page_size == no_datafile_tablespace_state.PAGE_SIZE | int
+          - no_datafile_tablespace_info.zip_page_size == no_datafile_tablespace_state.ZIP_PAGE_SIZE | int
+          - no_datafile_tablespace_info.file_size == no_datafile_tablespace_state.FILE_SIZE | int
+          - no_datafile_tablespace_info.allocated_size == no_datafile_tablespace_state.ALLOCATED_SIZE | int
+          - no_datafile_tablespace_info.attached_tables == []
+          - >-
+            (
+              no_datafile_tablespace_state.AUTOEXTEND_SIZE is not none and
+              no_datafile_tablespace_info.autoextend_size == (no_datafile_tablespace_state.AUTOEXTEND_SIZE | int)
+            )
+            or
+            (
+              no_datafile_tablespace_state.AUTOEXTEND_SIZE is none and
+              'autoextend_size' not in no_datafile_tablespace_info
+            )
+          - >-
+            (
+              no_datafile_tablespace_state.ENCRYPTION is not none and
+              no_datafile_tablespace_info.encryption == no_datafile_tablespace_state.ENCRYPTION
+            )
+            or
+            (
+              no_datafile_tablespace_state.ENCRYPTION is none and
+              'encryption' not in no_datafile_tablespace_info
+            )
+          - >-
+            (
+              no_datafile_tablespace_state.STATE is not none and
+              no_datafile_tablespace_info.state == no_datafile_tablespace_state.STATE
+            )
+            or
+            (
+              no_datafile_tablespace_state.STATE is none and
+              'state' not in no_datafile_tablespace_info
+            )
+      when: mysql_supports_optional_datafile
+
+    - name: Tablespace info | Gather one tablespace by name
+      ansible.mysql.mysql_tablespace_info:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+      register: single_tablespace_info
+
+    - name: Tablespace info | Assert name-filtered result
+      ansible.builtin.assert:
+        that:
+          - single_tablespace_info is not changed
+          - single_tablespace_info.tablespaces | length == 1
+          - single_tablespace_info.tablespaces == [main_tablespace_info]
+
+    - name: Tablespace info | Detect keyring plugin and component table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query:
+          - >-
+            SELECT COUNT(*) AS plugin_count
+            FROM INFORMATION_SCHEMA.PLUGINS
+            WHERE PLUGIN_STATUS = 'ACTIVE' AND PLUGIN_NAME LIKE 'keyring%'
+          - >-
+            SELECT COUNT(*) AS component_table_count
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_SCHEMA = 'mysql' AND TABLE_NAME = 'component'
+      register: keyring_detection_state
+      when: db_version is version('8.0.13', '>=')
+
+    - name: Tablespace info | Detect keyring component
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: >-
+          SELECT COUNT(*) AS component_count
+          FROM mysql.component
+          WHERE component_urn LIKE 'file://component_keyring%'
+          OR component_urn LIKE 'file://component_keyring_%'
+      register: keyring_component_state
+      when:
+        - db_version is version('8.0.13', '>=')
+        - keyring_detection_state.query_result[1][0].component_table_count | int == 1
+
+    - name: Tablespace info | Set keyring availability facts
+      ansible.builtin.set_fact:
+        mysql_keyring_available: >-
+          {{
+            (keyring_detection_state.query_result[0][0].plugin_count | int) > 0 or
+            ((keyring_component_state.query_result[0][0].component_count | int) if keyring_component_state is defined else 0) > 0
+          }}
+      when: db_version is version('8.0.13', '>=')
+
+    - name: Tablespace info | Enable encryption fixture when keyring is available
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+        datafile: '{{ tablespace_datafile }}'
+        file_block_size: '{{ create_file_block_size }}'
+        encryption: Y
+      when:
+        - db_version is version('8.0.13', '>=')
+        - mysql_keyring_available
+
+    - name: Tablespace info | Gather encrypted tablespace info
+      ansible.mysql.mysql_tablespace_info:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+      register: encrypted_tablespace_info
+      when:
+        - db_version is version('8.0.13', '>=')
+        - mysql_keyring_available
+
+    - name: Tablespace info | Assert encrypted tablespace info
+      ansible.builtin.assert:
+        that:
+          - encrypted_tablespace_info is not changed
+          - encrypted_tablespace_info.tablespaces | length == 1
+          - encrypted_tablespace_info.tablespaces[0].encryption == 'Y'
+      when:
+        - db_version is version('8.0.13', '>=')
+        - mysql_keyring_available
+  always:
+    - name: Tablespace info | Drop test database after coverage
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        query: "DROP DATABASE IF EXISTS {{ tablespace_schema }}"
+
+    - name: Tablespace info | Drop primary tablespace after coverage
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ tablespace_name }}'
+        state: absent
+
+    - name: Tablespace info | Drop no-datafile tablespace after coverage
+      ansible.mysql.mysql_tablespace:
+        <<: *mysql_params
+        name: '{{ no_datafile_tablespace_name }}'
+        state: absent

--- a/tests/integration/targets/test_mysql_tablespace_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_tablespace_info/tasks/main.yml
@@ -319,7 +319,42 @@
         that:
           - single_tablespace_info is not changed
           - single_tablespace_info.tablespaces | length == 1
-          - single_tablespace_info.tablespaces == [main_tablespace_info]
+          - single_tablespace_info.tablespaces[0].name == main_tablespace_info.name
+          - single_tablespace_info.tablespaces[0].space_id == main_tablespace_info.space_id
+          - single_tablespace_info.tablespaces[0].datafile == main_tablespace_info.datafile
+          - single_tablespace_info.tablespaces[0].attached_tables == main_tablespace_info.attached_tables
+          - single_tablespace_info.tablespaces[0].page_size == main_tablespace_info.page_size
+          - single_tablespace_info.tablespaces[0].zip_page_size == main_tablespace_info.zip_page_size
+          - >-
+            (
+              'autoextend_size' in main_tablespace_info and
+              single_tablespace_info.tablespaces[0].autoextend_size == main_tablespace_info.autoextend_size
+            )
+            or
+            (
+              'autoextend_size' not in main_tablespace_info and
+              'autoextend_size' not in single_tablespace_info.tablespaces[0]
+            )
+          - >-
+            (
+              'encryption' in main_tablespace_info and
+              single_tablespace_info.tablespaces[0].encryption == main_tablespace_info.encryption
+            )
+            or
+            (
+              'encryption' not in main_tablespace_info and
+              'encryption' not in single_tablespace_info.tablespaces[0]
+            )
+          - >-
+            (
+              'state' in main_tablespace_info and
+              single_tablespace_info.tablespaces[0].state == main_tablespace_info.state
+            )
+            or
+            (
+              'state' not in main_tablespace_info and
+              'state' not in single_tablespace_info.tablespaces[0]
+            )
 
     - name: Tablespace info | Detect keyring plugin and component table
       ansible.mysql.mysql_query:

--- a/tests/unit/plugins/module_utils/test_tablespace.py
+++ b/tests/unit/plugins/module_utils/test_tablespace.py
@@ -1,0 +1,356 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import pytest
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+from ansible_collections.ansible.mysql.plugins.module_utils.tablespace import (
+    _fetch_normalized_rows,
+    _first_defined,
+    _format_version,
+    _get_mysql_80_tablespaces_query,
+    _normalize_mysql_tablespace_row,
+    _get_mysql_tablespaces_group_by,
+    _to_int_or_none,
+    _to_list_or_empty,
+    ensure_tablespaces_supported,
+    get_mysql_tablespaces,
+    get_mysql_tablespace,
+    get_server_version_tuple,
+)
+from ansible_collections.ansible.mysql.tests.unit.plugins.utils import dummy_cursor_class
+
+
+@pytest.mark.parametrize(
+    'server_version,expected',
+    [
+        ('5.7.6-mysql', (5, 7, 6)),
+        ('8.0.38-commercial', (8, 0, 38)),
+        ('8.4.9-1.el9', (8, 4, 9)),
+    ]
+)
+def test_get_server_version_tuple(server_version, expected):
+    cursor = dummy_cursor_class(server_version, 'dict')
+    assert get_server_version_tuple(cursor) == expected
+
+
+def test_get_server_version_tuple_pads_short_versions():
+    cursor = dummy_cursor_class('8.0-community', 'dict')
+
+    assert get_server_version_tuple(cursor) == (8, 0, 0)
+
+
+def test_ensure_tablespaces_supported_returns_mysql_version_tuple():
+    module = MagicMock()
+    cursor = dummy_cursor_class('8.0.35-mysql', 'dict')
+
+    assert ensure_tablespaces_supported(module, cursor) == (8, 0, 35)
+    module.fail_json.assert_not_called()
+
+
+def test_ensure_tablespaces_supported_fails_for_unsupported_server(monkeypatch):
+    module = MagicMock()
+    module.fail_json.side_effect = RuntimeError
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.module_utils.tablespace.get_server_implementation',
+        lambda _cursor: 'unsupported',
+    )
+
+    with pytest.raises(RuntimeError):
+        ensure_tablespaces_supported(module, cursor)
+
+    module.fail_json.assert_called_once_with(
+        msg='Tablespace operations are supported only by MySQL.'
+    )
+
+
+def test_ensure_tablespaces_supported_fails_for_old_mysql():
+    module = MagicMock()
+    module.fail_json.side_effect = RuntimeError
+    cursor = dummy_cursor_class('5.7.5-mysql', 'dict')
+
+    with pytest.raises(RuntimeError):
+        ensure_tablespaces_supported(module, cursor)
+
+    module.fail_json.assert_called_once_with(
+        msg='Tablespace operations require MySQL 5.7.6 or later.'
+    )
+
+
+def test_normalize_tablespace_row_for_mysql_uses_canonical_keys():
+    row = {
+        'FILE_ID': '17',
+        'TABLESPACE_NAME': 'app_data',
+        'FILE_TYPE': 'TABLESPACE',
+        'ENGINE': 'InnoDB',
+        'EXTENT_SIZE': '1048576',
+        'AUTOEXTEND_SIZE': '8388608',
+        'MAXIMUM_SIZE': None,
+        'FILE_NAME': '/var/lib/mysql/app_data.ibd',
+        'FS_BLOCK_SIZE': '4096',
+        'FILE_SIZE': '16777216',
+        'ALLOCATED_SIZE': '8388608',
+        'PAGE_SIZE': '16384',
+        'ZIP_PAGE_SIZE': '0',
+        'SPACE_TYPE': 'General',
+        'STATUS': 'NORMAL',
+        'EXTRA': 'General tablespace',
+        'STATE': 'active',
+        'ENCRYPTION': 'N',
+        'ATTACHED_TABLES': 'app/order_items,app/orders',
+    }
+
+    assert _normalize_mysql_tablespace_row(row) == {
+        'server_implementation': 'mysql',
+        'name': 'app_data',
+        'space_id': 17,
+        'engine': 'InnoDB',
+        'file_type': 'TABLESPACE',
+        'extent_size': 1048576,
+        'autoextend_size': 8388608,
+        'maximum_size': None,
+        'datafile': '/var/lib/mysql/app_data.ibd',
+        'filesystem_block_size': 4096,
+        'status': 'NORMAL',
+        'comment': 'General tablespace',
+        'page_size': 16384,
+        'file_size': 16777216,
+        'allocated_size': 8388608,
+        'zip_page_size': 0,
+        'space_type': 'General',
+        'state': 'active',
+        'encryption': 'N',
+        'attached_tables': ['app/order_items', 'app/orders'],
+    }
+
+
+def test_normalize_tablespace_row_sets_missing_mysql_80_fields_to_none():
+    row = {
+        'FILE_ID': '17',
+        'TABLESPACE_NAME': 'app_data',
+        'FILE_TYPE': 'TABLESPACE',
+        'ENGINE': 'InnoDB',
+        'EXTENT_SIZE': '1048576',
+        'AUTOEXTEND_SIZE': '8388608',
+        'MAXIMUM_SIZE': None,
+        'FILE_NAME': '/var/lib/mysql/app_data.ibd',
+        'FS_BLOCK_SIZE': '4096',
+        'FILE_SIZE': '16777216',
+        'ALLOCATED_SIZE': '8388608',
+        'PAGE_SIZE': '16384',
+        'ZIP_PAGE_SIZE': '0',
+        'SPACE_TYPE': 'General',
+        'STATUS': 'NORMAL',
+        'EXTRA': 'General tablespace',
+        'ATTACHED_TABLES': 'app/orders',
+    }
+
+    normalized = _normalize_mysql_tablespace_row(row)
+
+    assert normalized['encryption'] is None
+    assert normalized['state'] is None
+
+
+def test_get_mysql_tablespace_returns_one_normalized_mysql_row():
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [
+        {
+            'FILE_ID': '17',
+            'TABLESPACE_NAME': 'app_data',
+            'FILE_TYPE': 'TABLESPACE',
+            'ENGINE': 'InnoDB',
+            'EXTENT_SIZE': '1048576',
+            'AUTOEXTEND_SIZE': '8388608',
+            'MAXIMUM_SIZE': None,
+            'FILE_NAME': './app_data.ibd',
+            'FS_BLOCK_SIZE': '4096',
+            'FILE_SIZE': '16777216',
+            'ALLOCATED_SIZE': '8388608',
+            'PAGE_SIZE': '16384',
+            'ZIP_PAGE_SIZE': '0',
+            'SPACE_TYPE': 'General',
+            'STATUS': 'NORMAL',
+            'EXTRA': 'General tablespace',
+            'STATE': 'active',
+            'ENCRYPTION': 'N',
+            'ATTACHED_TABLES': 'app/orders',
+        }
+    ]
+
+    assert get_mysql_tablespace(cursor, (8, 0, 36), 'app_data') == {
+        'server_implementation': 'mysql',
+        'name': 'app_data',
+        'space_id': 17,
+        'engine': 'InnoDB',
+        'file_type': 'TABLESPACE',
+        'extent_size': 1048576,
+        'autoextend_size': 8388608,
+        'maximum_size': None,
+        'datafile': './app_data.ibd',
+        'filesystem_block_size': 4096,
+        'status': 'NORMAL',
+        'comment': 'General tablespace',
+        'page_size': 16384,
+        'file_size': 16777216,
+        'allocated_size': 8388608,
+        'zip_page_size': 0,
+        'space_type': 'General',
+        'state': 'active',
+        'encryption': 'N',
+        'attached_tables': ['app/orders'],
+    }
+
+    executed_query, params = cursor.execute.call_args[0]
+    assert 'INFORMATION_SCHEMA.INNODB_TABLESPACES AS ts' in executed_query
+    assert params == ('app_data',)
+
+
+def test_get_mysql_tablespaces_uses_mysql_57_metadata_without_name_filter():
+    cursor = MagicMock()
+    cursor.fetchall.return_value = []
+
+    assert get_mysql_tablespaces(cursor, (5, 7, 42)) == []
+
+    (executed_query,) = cursor.execute.call_args[0]
+    assert 'INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES AS ts' in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_SYS_DATAFILES AS df' in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_SYS_TABLES AS t' in executed_query
+    assert 'AND f.TABLESPACE_NAME = %s' not in executed_query
+
+
+@pytest.mark.parametrize(
+    'server_version,expected_fragment,unexpected_fragments',
+    [
+        (
+            (8, 0, 12),
+            'ts.ZIP_PAGE_SIZE, ts.SPACE_TYPE, NULL AS ENCRYPTION, NULL AS STATE, ',
+            ['ts.ENCRYPTION, NULL AS STATE', 'ts.ENCRYPTION, ts.STATE'],
+        ),
+        (
+            (8, 0, 13),
+            'ts.ZIP_PAGE_SIZE, ts.SPACE_TYPE, ts.ENCRYPTION, NULL AS STATE, ',
+            ['NULL AS ENCRYPTION', 'ts.ENCRYPTION, ts.STATE'],
+        ),
+        (
+            (8, 0, 14),
+            'ts.ZIP_PAGE_SIZE, ts.SPACE_TYPE, ts.ENCRYPTION, ts.STATE, ',
+            ['NULL AS ENCRYPTION', 'NULL AS STATE'],
+        ),
+    ]
+)
+def test_get_mysql_80_tablespaces_query_uses_version_specific_columns(
+    server_version,
+    expected_fragment,
+    unexpected_fragments,
+):
+    query = _get_mysql_80_tablespaces_query(server_version)
+
+    assert expected_fragment in query
+    for fragment in unexpected_fragments:
+        assert fragment not in query
+
+
+def test_get_mysql_tablespaces_filters_by_explicit_empty_name():
+    cursor = MagicMock()
+    cursor.fetchall.return_value = []
+
+    assert get_mysql_tablespaces(cursor, (8, 0, 36), name='') == []
+
+    executed_query, params = cursor.execute.call_args[0]
+    assert 'AND f.TABLESPACE_NAME = %s' in executed_query
+    assert params == ('',)
+
+
+def test_get_mysql_tablespace_returns_none_when_missing():
+    cursor = MagicMock()
+    cursor.fetchall.return_value = []
+
+    assert get_mysql_tablespace(cursor, (8, 0, 36), 'missing_tablespace') is None
+
+
+def test_fetch_normalized_rows_re_raises_without_module():
+    cursor = MagicMock()
+    cursor.execute.side_effect = RuntimeError('metadata denied')
+
+    with pytest.raises(RuntimeError, match='metadata denied'):
+        _fetch_normalized_rows(cursor, 'SELECT 1', None)
+
+
+def test_fetch_normalized_rows_calls_fail_json_when_module_is_provided():
+    cursor = MagicMock()
+    cursor.execute.side_effect = RuntimeError('metadata denied')
+    module = MagicMock()
+    module.fail_json.side_effect = RuntimeError('fail_json called')
+
+    with pytest.raises(RuntimeError, match='fail_json called'):
+        _fetch_normalized_rows(cursor, 'SELECT 1', None, module=module)
+
+    module.fail_json.assert_called_once()
+    assert module.fail_json.call_args[1]['msg'] == "Cannot execute SQL 'SELECT 1': metadata denied"
+
+
+@pytest.mark.parametrize(
+    'server_version,expected_fragment,unexpected_fragment',
+    [
+        ((5, 7, 42), 'ts.SPACE_TYPE ORDER BY f.TABLESPACE_NAME', 'ts.ENCRYPTION'),
+        ((8, 0, 12), 'ts.SPACE_TYPE ORDER BY f.TABLESPACE_NAME', 'ts.ENCRYPTION'),
+        ((8, 0, 13), 'ts.SPACE_TYPE, ts.ENCRYPTION ORDER BY f.TABLESPACE_NAME', 'ts.STATE'),
+        ((8, 0, 14), 'ts.ENCRYPTION, ts.STATE ORDER BY f.TABLESPACE_NAME', 'INNODB_SYS_TABLESPACES'),
+    ]
+)
+def test_get_mysql_tablespaces_group_by_uses_version_specific_columns(
+    server_version,
+    expected_fragment,
+    unexpected_fragment,
+):
+    query = _get_mysql_tablespaces_group_by(server_version)
+
+    assert expected_fragment in query
+    assert unexpected_fragment not in query
+
+
+@pytest.mark.parametrize(
+    'row,keys,expected',
+    [
+        ({'PATH': None, 'FILENAME': './app_data.ibd'}, ('PATH', 'FILENAME'), './app_data.ibd'),
+        ({'PATH': None, 'FILENAME': None}, ('PATH', 'FILENAME'), None),
+    ]
+)
+def test_first_defined_returns_first_non_none_value(row, keys, expected):
+    assert _first_defined(row, *keys) == expected
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    [
+        (None, None),
+        ('17', 17),
+        (17, 17),
+    ]
+)
+def test_to_int_or_none_handles_none_and_numeric_values(value, expected):
+    assert _to_int_or_none(value) == expected
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    [
+        (None, []),
+        (['app/orders', 'app/order_items'], ['app/orders', 'app/order_items']),
+        (('app/orders', 'app/order_items'), ['app/orders', 'app/order_items']),
+        ('app/orders, app/order_items , ,app/audit', ['app/orders', 'app/order_items', 'app/audit']),
+    ]
+)
+def test_to_list_or_empty_normalizes_sequences_and_csv_strings(value, expected):
+    assert _to_list_or_empty(value) == expected
+
+
+def test_format_version_joins_version_parts():
+    assert _format_version((8, 0, 23)) == '8.0.23'

--- a/tests/unit/plugins/module_utils/test_tablespace.py
+++ b/tests/unit/plugins/module_utils/test_tablespace.py
@@ -60,7 +60,7 @@ def test_ensure_tablespaces_supported_fails_for_unsupported_server(monkeypatch):
 
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.module_utils.tablespace.get_server_implementation',
-        lambda _cursor: 'unsupported',
+        lambda _module, _cursor: 'unsupported',
     )
 
     with pytest.raises(RuntimeError):

--- a/tests/unit/plugins/modules/test_mysql_tablespace.py
+++ b/tests/unit/plugins/modules/test_mysql_tablespace.py
@@ -516,7 +516,7 @@ def test_main_fails_fast_for_unsupported_server(monkeypatch):
     )
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.module_utils.tablespace.get_server_implementation',
-        lambda _cursor: 'unsupported',
+        lambda _module, _cursor: 'unsupported',
     )
 
     with pytest.raises(RuntimeError) as exc:

--- a/tests/unit/plugins/modules/test_mysql_tablespace.py
+++ b/tests/unit/plugins/modules/test_mysql_tablespace.py
@@ -1,0 +1,1092 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+from ansible_collections.ansible.mysql.plugins.modules import mysql_tablespace
+from ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace import (
+    build_alter_queries,
+    build_create_query,
+    build_drop_query,
+    execute_query,
+    fail_if_create_only_options_differ,
+    fail_if_rename_target_requires_changes,
+    get_tablespace_file_block_size,
+    main,
+    normalize_tablespace_encryption,
+    predict_tablespace,
+    quote_sql_value,
+    resolve_current_tablespace,
+    validate_autoextend_size_input,
+    validate_file_block_size_input,
+    validate_tablespace_autoextend_size,
+    validate_tablespace_datafile,
+    validate_tablespace_encryption,
+    validate_tablespace_rename,
+)
+
+
+class DummyModule(object):
+    def __init__(self):
+        self.params = {
+            'login_user': 'root',
+            'login_password': 'secret',
+            'config_file': '~/.my.cnf',
+            'client_cert': None,
+            'client_key': None,
+            'ca_cert': None,
+            'connect_timeout': 30,
+            'check_hostname': None,
+            'name': 'app_data',
+            'state': 'present',
+            'datafile': './app_data.ibd',
+            'file_block_size': None,
+            'encryption': 'Y',
+            'rename_to': None,
+            'autoextend_size': 8388608,
+        }
+        self.check_mode = False
+
+    def fail_json(self, msg=None, **kwargs):
+        raise RuntimeError(msg)
+
+    def exit_json(self, **kwargs):
+        raise SystemExit(kwargs)
+
+
+def assert_mysql_connect_not_called(*args, **kwargs):
+    raise AssertionError('mysql_connect should not be called')
+
+
+def make_tablespace(name='app_data', **overrides):
+    current = {
+        'server_implementation': 'mysql',
+        'name': name,
+        'datafile': './app_data.ibd',
+        'autoextend_size': 8388608,
+        'encryption': 'N',
+        'page_size': 16384,
+        'zip_page_size': 0,
+    }
+    current.update(overrides)
+    return current
+
+
+@pytest.mark.parametrize(
+    'encryption,expected',
+    [
+        (None, None),
+        ('y', 'Y'),
+        ('N', 'N'),
+    ]
+)
+def test_normalize_tablespace_encryption_accepts_none_and_uppercases_values(encryption, expected):
+    assert normalize_tablespace_encryption(encryption) == expected
+
+
+def test_normalize_tablespace_encryption_rejects_invalid_values():
+    with pytest.raises(ValueError, match="encryption must be either 'Y' or 'N'"):
+        normalize_tablespace_encryption('maybe')
+
+
+@pytest.mark.parametrize(
+    'autoextend_size,expected',
+    [
+        (None, None),
+        (4194304, 4194304),
+        (8388608, 8388608),
+    ]
+)
+def test_validate_autoextend_size_input_accepts_none_and_valid_multiples(autoextend_size, expected):
+    assert validate_autoextend_size_input(autoextend_size) == expected
+
+
+@pytest.mark.parametrize('autoextend_size', [-4194304, 1])
+def test_validate_autoextend_size_input_rejects_invalid_values(autoextend_size):
+    with pytest.raises(ValueError, match='autoextend_size must be a non-negative multiple of 4MB'):
+        validate_autoextend_size_input(autoextend_size)
+
+
+@pytest.mark.parametrize(
+    'file_block_size,expected',
+    [
+        (None, None),
+        (8192, 8192),
+    ]
+)
+def test_validate_file_block_size_input_accepts_positive_values(file_block_size, expected):
+    assert validate_file_block_size_input(file_block_size) == expected
+
+
+@pytest.mark.parametrize(
+    'current,expected',
+    [
+        ({'page_size': 16384, 'zip_page_size': 0}, 16384),
+        ({'page_size': 16384, 'zip_page_size': 8192}, 8192),
+        ({'page_size': None, 'zip_page_size': None}, None),
+    ]
+)
+def test_get_tablespace_file_block_size_prefers_zip_page_size(current, expected):
+    assert get_tablespace_file_block_size(current) == expected
+
+
+@pytest.mark.parametrize(
+    'validator',
+    [
+        validate_tablespace_rename,
+        validate_tablespace_encryption,
+        validate_tablespace_autoextend_size,
+    ]
+)
+def test_version_gated_validators_allow_absent_values(validator):
+    assert validator((5, 7, 6), None) is None
+
+
+def test_validate_tablespace_rename_requires_mysql_8_0_3():
+    assert validate_tablespace_rename((8, 0, 3), 'archive_data') == 'archive_data'
+
+    with pytest.raises(ValueError) as exc:
+        validate_tablespace_rename((8, 0, 2), 'archive_data')
+
+    assert str(exc.value) == 'rename requires MySQL 8.0.3 or later'
+
+
+def test_validate_tablespace_encryption_requires_mysql_8_0_13():
+    assert validate_tablespace_encryption((8, 0, 13), 'Y') == 'Y'
+
+    with pytest.raises(ValueError) as exc:
+        validate_tablespace_encryption((8, 0, 12), 'Y')
+
+    assert str(exc.value) == 'encryption requires MySQL 8.0.13 or later'
+
+
+def test_validate_tablespace_autoextend_size_requires_mysql_8_0_23():
+    assert validate_tablespace_autoextend_size((8, 0, 23), 8388608) == 8388608
+
+    with pytest.raises(ValueError) as exc:
+        validate_tablespace_autoextend_size((8, 0, 22), 8388608)
+
+    assert str(exc.value) == 'autoextend_size requires MySQL 8.0.23 or later'
+
+
+def test_validate_tablespace_datafile_requires_explicit_datafile_before_mysql_8_0_14():
+    assert validate_tablespace_datafile((8, 0, 13), './app_data.ibd') == './app_data.ibd'
+    assert validate_tablespace_datafile((8, 0, 14), None) is None
+
+    with pytest.raises(ValueError) as exc:
+        validate_tablespace_datafile((8, 0, 13), None)
+
+    assert str(exc.value) == 'datafile is required for MySQL versions earlier than 8.0.14'
+
+
+def test_build_create_query_includes_supported_create_options():
+    assert build_create_query(
+        'app_data',
+        datafile='./app_data.ibd',
+        file_block_size=8192,
+        encryption='Y',
+        autoextend_size=8388608,
+    ) == (
+        "CREATE TABLESPACE `app_data` ADD DATAFILE './app_data.ibd' "
+        "AUTOEXTEND_SIZE = 8388608 FILE_BLOCK_SIZE = 8192 ENCRYPTION = 'Y' ENGINE = InnoDB"
+    )
+
+
+def test_build_alter_queries_split_mutable_changes_into_valid_statements():
+    assert build_alter_queries(
+        'app_data',
+        make_tablespace(),
+        rename_to='archive_data',
+        encryption='Y',
+        autoextend_size=16777216,
+    ) == [
+        "ALTER TABLESPACE `app_data` RENAME TO `archive_data`",
+        "ALTER TABLESPACE `archive_data` AUTOEXTEND_SIZE = 16777216",
+        "ALTER TABLESPACE `archive_data` ENCRYPTION = 'Y'",
+    ]
+
+
+def test_build_drop_query_returns_expected_sql():
+    assert build_drop_query('app_data') == "DROP TABLESPACE `app_data`"
+
+
+def test_quote_sql_value_handles_booleans_integers_and_escaping():
+    assert quote_sql_value(True) == '1'
+    assert quote_sql_value(False) == '0'
+    assert quote_sql_value(17) == '17'
+    assert quote_sql_value("O'Reilly") == "'O''Reilly'"
+
+
+def test_execute_query_executes_statement_without_fetching():
+    cursor = MagicMock()
+
+    execute_query(cursor, 'DROP TABLESPACE `app_data`')
+
+    cursor.execute.assert_called_once_with('DROP TABLESPACE `app_data`')
+    cursor.fetchall.assert_not_called()
+
+
+def test_predict_tablespace_builds_predicted_state_for_create():
+    assert predict_tablespace(
+        name='app_data',
+        datafile='./app_data.ibd',
+        encryption='Y',
+        autoextend_size=8388608,
+    ) == {
+        'server_implementation': 'mysql',
+        'name': 'app_data',
+        'datafile': './app_data.ibd',
+        'encryption': 'Y',
+        'autoextend_size': 8388608,
+    }
+
+
+def test_predict_tablespace_overlays_requested_changes_on_existing_state():
+    assert predict_tablespace(
+        current=make_tablespace(),
+        rename_to='archive_data',
+        encryption='Y',
+        autoextend_size=16777216,
+    ) == make_tablespace(
+        name='archive_data',
+        encryption='Y',
+        autoextend_size=16777216,
+    )
+
+
+def test_resolve_current_tablespace_returns_current_when_no_rename_is_requested(monkeypatch):
+    current = make_tablespace()
+    lookups = []
+
+    def fake_get_mysql_tablespace(_cursor, _server_version, name, module=None):
+        lookups.append(name)
+        return current
+
+    monkeypatch.setattr(mysql_tablespace, 'get_mysql_tablespace', fake_get_mysql_tablespace)
+
+    resolved, rename_already_applied = resolve_current_tablespace(
+        MagicMock(),
+        MagicMock(),
+        (8, 0, 36),
+        'app_data',
+    )
+
+    assert resolved == current
+    assert rename_already_applied is False
+    assert lookups == ['app_data']
+
+
+def test_resolve_current_tablespace_fails_when_rename_target_already_exists(monkeypatch):
+    module = MagicMock()
+    module.fail_json.side_effect = RuntimeError('fail_json called')
+    current = make_tablespace()
+    renamed = make_tablespace(name='archive_data')
+
+    def fake_get_mysql_tablespace(_cursor, _server_version, name, module=None):
+        if name == 'app_data':
+            return current
+        if name == 'archive_data':
+            return renamed
+        raise AssertionError('Unexpected tablespace lookup: %s' % name)
+
+    monkeypatch.setattr(mysql_tablespace, 'get_mysql_tablespace', fake_get_mysql_tablespace)
+
+    with pytest.raises(RuntimeError, match='fail_json called'):
+        resolve_current_tablespace(
+            module,
+            MagicMock(),
+            (8, 0, 36),
+            'app_data',
+            rename_to='archive_data',
+        )
+
+    module.fail_json.assert_called_once_with(
+        msg='Cannot rename tablespace app_data to archive_data because archive_data already exists.'
+    )
+
+
+def test_fail_if_rename_target_requires_changes_fails_when_file_block_size_metadata_is_missing():
+    module = MagicMock()
+    module.fail_json.side_effect = RuntimeError('fail_json called')
+
+    with pytest.raises(RuntimeError, match='fail_json called'):
+        fail_if_rename_target_requires_changes(
+            module,
+            make_tablespace(name='archive_data', page_size=None, zip_page_size=None),
+            'archive_data',
+            file_block_size=8192,
+        )
+
+    assert 'file_block_size' in module.fail_json.call_args[1]['msg']
+
+
+def test_fail_if_rename_target_requires_changes_accepts_matching_end_state():
+    fail_if_rename_target_requires_changes(
+        MagicMock(),
+        make_tablespace(name='archive_data', autoextend_size=8388608, encryption='N'),
+        'archive_data',
+        encryption='N',
+        autoextend_size=8388608,
+    )
+
+
+def test_fail_if_create_only_options_differ_fails_when_file_block_size_metadata_is_missing():
+    module = MagicMock()
+    module.fail_json.side_effect = RuntimeError('fail_json called')
+
+    with pytest.raises(RuntimeError, match='fail_json called'):
+        fail_if_create_only_options_differ(
+            module,
+            make_tablespace(page_size=None, zip_page_size=None),
+            file_block_size=8192,
+        )
+
+    assert 'Cannot compare create-only file_block_size' in module.fail_json.call_args[1]['msg']
+
+
+def test_fail_if_create_only_options_differ_accepts_matching_state():
+    fail_if_create_only_options_differ(
+        MagicMock(),
+        make_tablespace(),
+        datafile='./app_data.ibd',
+        file_block_size=16384,
+    )
+
+
+def test_build_alter_queries_return_empty_list_when_requested_state_matches_current():
+    assert build_alter_queries(
+        'app_data',
+        make_tablespace(),
+        rename_to='app_data',
+        encryption='N',
+        autoextend_size=8388608,
+    ) == []
+
+
+def test_main_creates_tablespace_in_check_mode_with_predicted_result(monkeypatch):
+    module = DummyModule()
+    module.check_mode = True
+    cursor = MagicMock()
+    connection = MagicMock()
+    connect_kwargs = {}
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+
+    def fake_mysql_connect(*args, **kwargs):
+        connect_kwargs.update(kwargs)
+        return cursor, connection
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        fake_mysql_connect,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+    monkeypatch.setattr(
+        mysql_tablespace,
+        'get_mysql_tablespace',
+        lambda _cursor, _server_version, _name, module=None: None,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result == {
+        'changed': True,
+        'queries': [
+            "CREATE TABLESPACE `app_data` ADD DATAFILE './app_data.ibd' "
+            "AUTOEXTEND_SIZE = 8388608 ENCRYPTION = 'Y' ENGINE = InnoDB"
+        ],
+        'tablespace': {
+            'server_implementation': 'mysql',
+            'name': 'app_data',
+            'datafile': './app_data.ibd',
+            'autoextend_size': 8388608,
+            'encryption': 'Y',
+        },
+    }
+    assert connect_kwargs['cursor_class'] == 'DictCursor'
+    assert connect_kwargs['autocommit'] is True
+
+
+def test_main_fails_when_rename_to_is_used_with_absent_state(monkeypatch):
+    module = DummyModule()
+    module.params['state'] = 'absent'
+    module.params['rename_to'] = 'archive_data'
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        mysql_tablespace,
+        'mysql_connect',
+        assert_mysql_connect_not_called,
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == 'rename_to cannot be used with state=absent'
+
+
+def test_main_fails_when_mysql_driver_is_missing(monkeypatch):
+    module = DummyModule()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        None,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver_fail_msg',
+        'mysql driver missing',
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == 'mysql driver missing'
+
+
+def test_main_fails_when_database_connection_fails(monkeypatch):
+    module = DummyModule()
+
+    def raise_connection_error(*args, **kwargs):
+        raise RuntimeError('network timeout')
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        raise_connection_error,
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == 'unable to connect to database: network timeout'
+
+
+def test_main_fails_fast_for_unsupported_server(monkeypatch):
+    module = DummyModule()
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.module_utils.tablespace.get_server_implementation',
+        lambda _cursor: 'unsupported',
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == 'Tablespace operations are supported only by MySQL.'
+
+
+def test_main_drops_tablespace_in_check_mode(monkeypatch):
+    module = DummyModule()
+    module.check_mode = True
+    module.params['state'] = 'absent'
+    module.params['datafile'] = None
+    module.params['encryption'] = None
+    module.params['autoextend_size'] = None
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+    monkeypatch.setattr(
+        mysql_tablespace,
+        'get_mysql_tablespace',
+        lambda _cursor, _server_version, _name, module=None: make_tablespace(),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.args[0] == {
+        'changed': True,
+        'queries': ["DROP TABLESPACE `app_data`"],
+    }
+
+
+def test_main_returns_unchanged_when_absent_tablespace_is_missing(monkeypatch):
+    module = DummyModule()
+    module.params['state'] = 'absent'
+    module.params['datafile'] = None
+    module.params['encryption'] = None
+    module.params['autoextend_size'] = None
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+    monkeypatch.setattr(
+        mysql_tablespace,
+        'get_mysql_tablespace',
+        lambda _cursor, _server_version, _name, module=None: None,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.args[0] == {'changed': False}
+
+
+def test_main_alters_tablespace_in_check_mode(monkeypatch):
+    module = DummyModule()
+    module.check_mode = True
+    module.params['datafile'] = None
+    module.params['file_block_size'] = None
+    module.params['rename_to'] = 'archive_data'
+    module.params['encryption'] = 'Y'
+    module.params['autoextend_size'] = 16777216
+    current = make_tablespace()
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+
+    def fake_get_mysql_tablespace(_cursor, _server_version, name, module=None):
+        if name == 'app_data':
+            return current
+        if name == 'archive_data':
+            return None
+        raise AssertionError('Unexpected tablespace lookup: %s' % name)
+
+    monkeypatch.setattr(mysql_tablespace, 'get_mysql_tablespace', fake_get_mysql_tablespace)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.args[0] == {
+        'changed': True,
+        'queries': [
+            "ALTER TABLESPACE `app_data` RENAME TO `archive_data`",
+            "ALTER TABLESPACE `archive_data` AUTOEXTEND_SIZE = 16777216",
+            "ALTER TABLESPACE `archive_data` ENCRYPTION = 'Y'",
+        ],
+        'tablespace': make_tablespace(
+            name='archive_data',
+            autoextend_size=16777216,
+            encryption='Y',
+        ),
+    }
+
+
+def test_main_returns_predicted_tablespace_when_post_create_lookup_is_empty(monkeypatch):
+    module = DummyModule()
+    cursor = MagicMock()
+    lookups = []
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+
+    def fake_get_mysql_tablespace(_cursor, _server_version, name, module=None):
+        lookups.append(name)
+        return None
+
+    monkeypatch.setattr(mysql_tablespace, 'get_mysql_tablespace', fake_get_mysql_tablespace)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.args[0] == {
+        'changed': True,
+        'queries': [
+            "CREATE TABLESPACE `app_data` ADD DATAFILE './app_data.ibd' "
+            "AUTOEXTEND_SIZE = 8388608 ENCRYPTION = 'Y' ENGINE = InnoDB"
+        ],
+        'tablespace': {
+            'server_implementation': 'mysql',
+            'name': 'app_data',
+            'datafile': './app_data.ibd',
+            'autoextend_size': 8388608,
+            'encryption': 'Y',
+        },
+    }
+    assert lookups == ['app_data', 'app_data']
+
+
+def test_main_returns_predicted_tablespace_when_post_alter_lookup_is_empty(monkeypatch):
+    module = DummyModule()
+    module.params['datafile'] = None
+    module.params['file_block_size'] = None
+    module.params['rename_to'] = 'archive_data'
+    module.params['encryption'] = 'Y'
+    module.params['autoextend_size'] = 16777216
+    current = make_tablespace()
+    cursor = MagicMock()
+    executed_queries = []
+    archive_data_lookups = []
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+
+    def fake_get_mysql_tablespace(_cursor, _server_version, name, module=None):
+        if name == 'app_data':
+            return current
+        if name == 'archive_data':
+            archive_data_lookups.append(name)
+            return None
+        raise AssertionError('Unexpected tablespace lookup: %s' % name)
+
+    monkeypatch.setattr(mysql_tablespace, 'get_mysql_tablespace', fake_get_mysql_tablespace)
+    monkeypatch.setattr(
+        mysql_tablespace,
+        'execute_query',
+        lambda _cursor, query: executed_queries.append(query),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.args[0] == {
+        'changed': True,
+        'queries': [
+            "ALTER TABLESPACE `app_data` RENAME TO `archive_data`",
+            "ALTER TABLESPACE `archive_data` AUTOEXTEND_SIZE = 16777216",
+            "ALTER TABLESPACE `archive_data` ENCRYPTION = 'Y'",
+        ],
+        'tablespace': make_tablespace(
+            name='archive_data',
+            autoextend_size=16777216,
+            encryption='Y',
+        ),
+    }
+    assert executed_queries == [
+        "ALTER TABLESPACE `app_data` RENAME TO `archive_data`",
+        "ALTER TABLESPACE `archive_data` AUTOEXTEND_SIZE = 16777216",
+        "ALTER TABLESPACE `archive_data` ENCRYPTION = 'Y'",
+    ]
+    assert archive_data_lookups == ['archive_data', 'archive_data']
+
+
+def test_main_treats_rename_to_as_already_applied(monkeypatch):
+    module = DummyModule()
+    module.params['datafile'] = None
+    module.params['file_block_size'] = None
+    module.params['rename_to'] = 'archive_data'
+    module.params['encryption'] = 'N'
+    module.params['autoextend_size'] = 8388608
+    renamed = make_tablespace(name='archive_data')
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+
+    def fake_get_mysql_tablespace(_cursor, _server_version, name, module=None):
+        if name == 'app_data':
+            return None
+        if name == 'archive_data':
+            return renamed
+        raise AssertionError('Unexpected tablespace lookup: %s' % name)
+
+    monkeypatch.setattr(mysql_tablespace, 'get_mysql_tablespace', fake_get_mysql_tablespace)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.args[0] == {
+        'changed': False,
+        'tablespace': renamed,
+    }
+
+
+def test_main_converges_when_rename_target_only_needs_mutable_changes(monkeypatch):
+    module = DummyModule()
+    module.params['datafile'] = './app_data.ibd'
+    module.params['file_block_size'] = 16384
+    module.params['rename_to'] = 'archive_data'
+    module.params['encryption'] = 'Y'
+    module.params['autoextend_size'] = 16777216
+    renamed = make_tablespace(name='archive_data', encryption='N')
+    converged = make_tablespace(name='archive_data', encryption='Y', autoextend_size=16777216)
+    cursor = MagicMock()
+    executed_queries = []
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+
+    def fake_get_mysql_tablespace(_cursor, _server_version, name, module=None):
+        if name == 'app_data':
+            return None
+        if name == 'archive_data':
+            if executed_queries:
+                return converged
+            return renamed
+        raise AssertionError('Unexpected tablespace lookup: %s' % name)
+
+    monkeypatch.setattr(mysql_tablespace, 'get_mysql_tablespace', fake_get_mysql_tablespace)
+    monkeypatch.setattr(
+        mysql_tablespace,
+        'execute_query',
+        lambda _cursor, query: executed_queries.append(query),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.args[0] == {
+        'changed': True,
+        'queries': [
+            "ALTER TABLESPACE `archive_data` AUTOEXTEND_SIZE = 16777216",
+            "ALTER TABLESPACE `archive_data` ENCRYPTION = 'Y'",
+        ],
+        'tablespace': converged,
+    }
+    assert executed_queries == [
+        "ALTER TABLESPACE `archive_data` AUTOEXTEND_SIZE = 16777216",
+        "ALTER TABLESPACE `archive_data` ENCRYPTION = 'Y'",
+    ]
+
+
+def test_main_fails_when_existing_rename_target_has_create_only_mismatch(monkeypatch):
+    module = DummyModule()
+    module.params['datafile'] = './different.ibd'
+    module.params['file_block_size'] = None
+    module.params['rename_to'] = 'archive_data'
+    module.params['encryption'] = 'N'
+    module.params['autoextend_size'] = 8388608
+    renamed = make_tablespace(name='archive_data', datafile='./app_data.ibd')
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+
+    def fake_get_mysql_tablespace(_cursor, _server_version, name, module=None):
+        if name == 'app_data':
+            return None
+        if name == 'archive_data':
+            return renamed
+        raise AssertionError('Unexpected tablespace lookup: %s' % name)
+
+    monkeypatch.setattr(mysql_tablespace, 'get_mysql_tablespace', fake_get_mysql_tablespace)
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == (
+        'rename_to target archive_data already exists but does not match the requested end state '
+        '(datafile). Refusing to treat the rename as already applied.'
+    )
+
+
+def test_main_fails_when_rename_to_is_requested_without_existing_tablespace(monkeypatch):
+    module = DummyModule()
+    module.params['datafile'] = None
+    module.params['rename_to'] = 'archive_data'
+    module.params['encryption'] = None
+    module.params['autoextend_size'] = None
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+    monkeypatch.setattr(
+        mysql_tablespace,
+        'get_mysql_tablespace',
+        lambda _cursor, _server_version, _name, module=None: None,
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == (
+        'rename_to is alter-only and requires an existing tablespace named app_data, '
+        'or a tablespace already renamed to archive_data.'
+    )
+
+
+def test_main_fails_for_autoextend_size_not_multiple_of_4mb(monkeypatch):
+    module = DummyModule()
+    module.params['autoextend_size'] = 1
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        mysql_tablespace,
+        'mysql_connect',
+        assert_mysql_connect_not_called,
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == 'autoextend_size must be a non-negative multiple of 4MB (4194304 bytes)'
+
+
+def test_main_fails_when_existing_datafile_differs(monkeypatch):
+    module = DummyModule()
+    module.params['datafile'] = './different.ibd'
+    module.params['file_block_size'] = None
+    module.params['encryption'] = None
+    module.params['autoextend_size'] = None
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+    monkeypatch.setattr(
+        mysql_tablespace,
+        'get_mysql_tablespace',
+        lambda _cursor, _server_version, _name, module=None: make_tablespace(),
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == (
+        'datafile is create-only and cannot be changed for existing tablespace app_data '
+        '(current: ./app_data.ibd, requested: ./different.ibd).'
+    )
+
+
+def test_main_fails_for_non_positive_file_block_size(monkeypatch):
+    module = DummyModule()
+    module.params['datafile'] = None
+    module.params['file_block_size'] = 0
+    module.params['encryption'] = None
+    module.params['autoextend_size'] = None
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        mysql_tablespace,
+        'mysql_connect',
+        assert_mysql_connect_not_called,
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == 'file_block_size must be a positive integer'
+
+
+def test_main_fails_when_existing_file_block_size_differs(monkeypatch):
+    module = DummyModule()
+    module.params['datafile'] = None
+    module.params['file_block_size'] = 8192
+    module.params['encryption'] = None
+    module.params['autoextend_size'] = None
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace.ensure_tablespaces_supported',
+        lambda _module, _cursor: (8, 0, 36),
+    )
+    monkeypatch.setattr(
+        mysql_tablespace,
+        'get_mysql_tablespace',
+        lambda _cursor, _server_version, _name, module=None: make_tablespace(),
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == (
+        'file_block_size is create-only and cannot be changed for existing tablespace app_data '
+        '(current best-effort value: 16384, requested: 8192).'
+    )

--- a/tests/unit/plugins/modules/test_mysql_tablespace.py
+++ b/tests/unit/plugins/modules/test_mysql_tablespace.py
@@ -201,7 +201,6 @@ def test_build_create_query_includes_supported_create_options():
 
 def test_build_alter_queries_split_mutable_changes_into_valid_statements():
     assert build_alter_queries(
-        'app_data',
         make_tablespace(),
         rename_to='archive_data',
         encryption='Y',
@@ -362,7 +361,6 @@ def test_fail_if_create_only_options_differ_accepts_matching_state():
 
 def test_build_alter_queries_return_empty_list_when_requested_state_matches_current():
     assert build_alter_queries(
-        'app_data',
         make_tablespace(),
         rename_to='app_data',
         encryption='N',

--- a/tests/unit/plugins/modules/test_mysql_tablespace_info.py
+++ b/tests/unit/plugins/modules/test_mysql_tablespace_info.py
@@ -1,0 +1,408 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+from ansible_collections.ansible.mysql.plugins.modules import mysql_tablespace_info
+from ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info import (
+    format_tablespace_info,
+    get_tablespaces_info,
+    main,
+)
+
+
+class DummyModule(object):
+    def __init__(self):
+        self.params = {
+            'login_user': 'root',
+            'login_password': 'secret',
+            'config_file': '~/.my.cnf',
+            'client_cert': None,
+            'client_key': None,
+            'ca_cert': None,
+            'check_hostname': None,
+            'connect_timeout': 30,
+            'name': None,
+        }
+        self.check_mode = False
+
+    def fail_json(self, msg=None, **kwargs):
+        raise RuntimeError(msg)
+
+    def exit_json(self, **kwargs):
+        raise SystemExit(kwargs)
+
+
+def test_get_tablespaces_info_uses_mysql_8_metadata_family(monkeypatch):
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [
+        {
+            'FILE_ID': '17',
+            'TABLESPACE_NAME': 'app_data',
+            'FILE_NAME': './app_data.ibd',
+            'FILE_TYPE': 'TABLESPACE',
+            'ENGINE': 'InnoDB',
+            'EXTENT_SIZE': '1048576',
+            'AUTOEXTEND_SIZE': '8388608',
+            'MAXIMUM_SIZE': '67108864',
+            'STATUS': 'NORMAL',
+            'EXTRA': 'General tablespace',
+            'FS_BLOCK_SIZE': '4096',
+            'FILE_SIZE': '16777216',
+            'ALLOCATED_SIZE': '8388608',
+            'PAGE_SIZE': '16384',
+            'ZIP_PAGE_SIZE': '0',
+            'SPACE_TYPE': 'General',
+            'ENCRYPTION': 'N',
+            'STATE': 'active',
+            'ATTACHED_TABLES': 'app/order_items,app/orders',
+        }
+    ]
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.get_server_version_tuple',
+        lambda _cursor: (8, 0, 36),
+    )
+
+    assert get_tablespaces_info(cursor) == {
+        'tablespaces': [
+            {
+                'name': 'app_data',
+                'space_id': 17,
+                'extent_size': 1048576,
+                'autoextend_size': 8388608,
+                'maximum_size': 67108864,
+                'datafile': './app_data.ibd',
+                'filesystem_block_size': 4096,
+                'status': 'NORMAL',
+                'page_size': 16384,
+                'file_size': 16777216,
+                'allocated_size': 8388608,
+                'zip_page_size': 0,
+                'state': 'active',
+                'encryption': 'N',
+                'attached_tables': ['app/order_items', 'app/orders'],
+            }
+        ]
+    }
+
+    executed_query = cursor.execute.call_args[0][0]
+    assert 'INFORMATION_SCHEMA.INNODB_TABLESPACES AS ts' in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_DATAFILES AS df' in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_TABLES AS t' in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES' not in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_SYS_DATAFILES' not in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_SYS_TABLES' not in executed_query
+    assert "f.FILE_TYPE = 'TABLESPACE'" in executed_query
+    assert "ts.SPACE_TYPE = 'General'" in executed_query
+    assert 'GROUP_CONCAT' in executed_query
+    assert 'ORDER BY f.TABLESPACE_NAME' in executed_query
+
+
+def test_get_tablespaces_info_uses_mysql_57_metadata_family(monkeypatch):
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [
+        {
+            'FILE_ID': '11',
+            'TABLESPACE_NAME': 'archive_data',
+            'FILE_NAME': './archive_data.ibd',
+            'FILE_TYPE': 'TABLESPACE',
+            'ENGINE': 'InnoDB',
+            'EXTENT_SIZE': '1048576',
+            'AUTOEXTEND_SIZE': '8388608',
+            'MAXIMUM_SIZE': None,
+            'STATUS': 'NORMAL',
+            'EXTRA': 'General tablespace',
+            'FS_BLOCK_SIZE': '4096',
+            'FILE_SIZE': '16777216',
+            'ALLOCATED_SIZE': '8388608',
+            'PAGE_SIZE': '16384',
+            'ZIP_PAGE_SIZE': '0',
+            'SPACE_TYPE': 'General',
+            'ENCRYPTION': None,
+            'STATE': None,
+            'ATTACHED_TABLES': 'archive/orders',
+        }
+    ]
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.get_server_version_tuple',
+        lambda _cursor: (5, 7, 42),
+    )
+
+    assert get_tablespaces_info(cursor) == {
+        'tablespaces': [
+            {
+                'name': 'archive_data',
+                'space_id': 11,
+                'extent_size': 1048576,
+                'autoextend_size': 8388608,
+                'datafile': './archive_data.ibd',
+                'filesystem_block_size': 4096,
+                'status': 'NORMAL',
+                'page_size': 16384,
+                'file_size': 16777216,
+                'allocated_size': 8388608,
+                'zip_page_size': 0,
+                'attached_tables': ['archive/orders'],
+            }
+        ]
+    }
+
+    executed_query = cursor.execute.call_args[0][0]
+    assert 'INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES AS ts' in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_SYS_DATAFILES AS df' in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_SYS_TABLES AS t' in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_TABLESPACES' not in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_DATAFILES' not in executed_query
+    assert 'INFORMATION_SCHEMA.INNODB_TABLES AS t' not in executed_query
+    assert "f.FILE_TYPE = 'TABLESPACE'" in executed_query
+    assert 'ts.FS_BLOCK_SIZE' in executed_query
+    assert 'ts.FILE_SIZE' in executed_query
+    assert 'ts.ALLOCATED_SIZE' in executed_query
+
+
+def test_get_tablespaces_info_filters_mysql_by_name(monkeypatch):
+    cursor = MagicMock()
+    cursor.fetchall.return_value = []
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.get_server_version_tuple',
+        lambda _cursor: (8, 0, 36),
+    )
+
+    assert get_tablespaces_info(cursor, name='app_data') == {'tablespaces': []}
+
+    executed_query, params = cursor.execute.call_args[0]
+    assert 'f.TABLESPACE_NAME = %s' in executed_query
+    assert params == ('app_data',)
+
+
+def test_get_tablespaces_info_filters_mysql_by_explicit_empty_name(monkeypatch):
+    cursor = MagicMock()
+    cursor.fetchall.return_value = []
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.get_server_version_tuple',
+        lambda _cursor: (8, 0, 36),
+    )
+
+    assert get_tablespaces_info(cursor, name='') == {'tablespaces': []}
+
+    executed_query, params = cursor.execute.call_args[0]
+    assert 'f.TABLESPACE_NAME = %s' in executed_query
+    assert params == ('',)
+
+
+def test_get_tablespaces_info_uses_provided_mysql_version(monkeypatch):
+    cursor = MagicMock()
+
+    def fail_get_server_version(_cursor):
+        raise AssertionError('server version should not be re-read')
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.get_server_version_tuple',
+        fail_get_server_version,
+    )
+
+    def fake_get_mysql_tablespaces(actual_cursor, server_version, name=None, module=None):
+        assert actual_cursor is cursor
+        assert server_version == (8, 0, 36)
+        assert name == 'app_data'
+        assert module is None
+        return [{
+            'name': 'app_data',
+            'space_id': 17,
+            'datafile': './app_data.ibd',
+            'page_size': 16384,
+            'attached_tables': [],
+        }]
+
+    monkeypatch.setattr(mysql_tablespace_info, 'get_mysql_tablespaces', fake_get_mysql_tablespaces)
+
+    assert get_tablespaces_info(
+        cursor,
+        name='app_data',
+        server_version=(8, 0, 36),
+    ) == {'tablespaces': [{
+        'name': 'app_data',
+        'space_id': 17,
+        'datafile': './app_data.ibd',
+        'page_size': 16384,
+        'attached_tables': [],
+    }]}
+
+
+def test_format_tablespace_info_keeps_only_informative_fields():
+    assert format_tablespace_info({
+        'server_implementation': 'mysql',
+        'name': 'app_data',
+        'space_id': 17,
+        'engine': 'InnoDB',
+        'file_type': 'TABLESPACE',
+        'datafile': './app_data.ibd',
+        'page_size': 16384,
+        'file_size': 16777216,
+        'allocated_size': 8388608,
+        'attached_tables': ['app/orders'],
+        'status': None,
+        'comment': 'General tablespace',
+        'space_type': 'General',
+    }) == {
+        'name': 'app_data',
+        'space_id': 17,
+        'datafile': './app_data.ibd',
+        'page_size': 16384,
+        'file_size': 16777216,
+        'allocated_size': 8388608,
+        'attached_tables': ['app/orders'],
+    }
+
+
+def test_main_returns_changed_false_and_passes_name_filter(monkeypatch):
+    module = DummyModule()
+    module.params['name'] = 'app_data'
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+
+    def fake_ensure_tablespaces_supported(actual_module, actual_cursor):
+        assert actual_module is module
+        assert actual_cursor is cursor
+        return (8, 0, 36)
+
+    monkeypatch.setattr(mysql_tablespace_info, 'ensure_tablespaces_supported', fake_ensure_tablespaces_supported, raising=False)
+
+    def fake_get_tablespaces_info(actual_cursor, name=None, server_version=None, module=None):
+        assert actual_cursor is cursor
+        assert name == 'app_data'
+        assert server_version == (8, 0, 36)
+        assert module is not None
+        return {'tablespaces': [{'name': 'app_data'}]}
+
+    monkeypatch.setattr(mysql_tablespace_info, 'get_tablespaces_info', fake_get_tablespaces_info)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result == {
+        'changed': False,
+        'tablespaces': [{'name': 'app_data'}],
+    }
+
+
+def test_main_fails_fast_for_non_mysql(monkeypatch):
+    module = DummyModule()
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+
+    def fail_ensure_tablespaces_supported(actual_module, actual_cursor):
+        assert actual_module is module
+        assert actual_cursor is cursor
+        raise RuntimeError('Tablespace operations are supported only by MySQL.')
+
+    monkeypatch.setattr(mysql_tablespace_info, 'ensure_tablespaces_supported', fail_ensure_tablespaces_supported, raising=False)
+
+    def unexpected_get_tablespaces_info(*args, **kwargs):
+        raise AssertionError('get_tablespaces_info should not be called')
+
+    monkeypatch.setattr(mysql_tablespace_info, 'get_tablespaces_info', unexpected_get_tablespaces_info)
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == 'Tablespace operations are supported only by MySQL.'
+
+
+def test_main_fails_fast_for_unsupported_old_mysql(monkeypatch):
+    module = DummyModule()
+    cursor = MagicMock()
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+
+    def fail_ensure_tablespaces_supported(actual_module, actual_cursor):
+        assert actual_module is module
+        assert actual_cursor is cursor
+        raise RuntimeError('Tablespace operations require MySQL 5.7.6 or later.')
+
+    monkeypatch.setattr(mysql_tablespace_info, 'ensure_tablespaces_supported', fail_ensure_tablespaces_supported, raising=False)
+
+    def unexpected_get_tablespaces_info(*args, **kwargs):
+        raise AssertionError('get_tablespaces_info should not be called')
+
+    monkeypatch.setattr(mysql_tablespace_info, 'get_tablespaces_info', unexpected_get_tablespaces_info)
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert str(exc.value) == 'Tablespace operations require MySQL 5.7.6 or later.'
+
+
+def test_main_fails_cleanly_when_tablespace_query_fails(monkeypatch):
+    module = DummyModule()
+    cursor = MagicMock()
+    cursor.execute.side_effect = RuntimeError('metadata denied')
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_tablespace_info.mysql_connect',
+        lambda *args, **kwargs: (cursor, MagicMock()),
+    )
+
+    monkeypatch.setattr(
+        mysql_tablespace_info,
+        'ensure_tablespaces_supported',
+        lambda actual_module, actual_cursor: (8, 0, 36),
+        raising=False,
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        main()
+
+    assert "Cannot execute SQL '" in str(exc.value)
+    assert 'metadata denied' in str(exc.value)


### PR DESCRIPTION
#### SUMMARY
- add `mysql_tablespace` and `mysql_tablespace_info` for MySQL general tablespaces

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- `README.md`
- `meta/runtime.yml`
- `plugins/module_utils/tablespace.py`
- `plugins/modules/mysql_tablespace.py`
- `plugins/modules/mysql_tablespace_info.py`
- `tests/integration/targets/test_mysql_tablespace/defaults/main.yml`
- `tests/integration/targets/test_mysql_tablespace/meta/main.yml`
- `tests/integration/targets/test_mysql_tablespace/tasks/main.yml`
- `tests/integration/targets/test_mysql_tablespace/tasks/mysql.yml`
- `tests/integration/targets/test_mysql_tablespace_info/defaults/main.yml`
- `tests/integration/targets/test_mysql_tablespace_info/meta/main.yml`
- `tests/integration/targets/test_mysql_tablespace_info/tasks/main.yml`
- `tests/unit/plugins/module_utils/test_tablespace.py`
- `tests/unit/plugins/modules/test_mysql_tablespace.py`
- `tests/unit/plugins/modules/test_mysql_tablespace_info.py`

#### ADDITIONAL INFORMATION
- `mysql_tablespace_info` returns metadata-only fields, and key rotation remains out of scope because MySQL exposes it through `ALTER INSTANCE ROTATE INNODB MASTER KEY`
- Created using GPT5.4 with Human in the loop and manual testing
