### PR TITLE
feat: add warning when MariaDB is detected

### DIFF
--- a/changelogs/fragments/0-mariadb_detection.yml
+++ b/changelogs/fragments/0-mariadb_detection.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - modules - add a warning to redirect users to use ansible.mariadb when a MariaDB server is detected (https://github.com/ansible-collections/ansible.mysql/issues/845).

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -214,8 +214,11 @@ def get_server_version(cursor):
     return version_str
 
 
-def get_server_implementation(cursor):
+def get_server_implementation(module, cursor):
     if 'mariadb' in get_server_version(cursor).lower():
+        module.warn("MariaDB has been detected: "
+                    "its support will be dropped in 6.0.0. "
+                    "For MariaDB automation, please use the ansible.mariadb collection instead.")
         return "mariadb"
     else:
         return "mysql"

--- a/plugins/module_utils/resource_group.py
+++ b/plugins/module_utils/resource_group.py
@@ -26,7 +26,7 @@ def get_server_version_tuple(cursor):
 
 
 def ensure_resource_groups_supported(module, cursor):
-    if get_server_implementation(cursor) != 'mysql':
+    if get_server_implementation(module, cursor) != 'mysql':
         module.fail_json(msg='Resource groups are supported only by MySQL 8.0 or later.')
 
     if get_server_version_tuple(cursor) < (8, 0, 0):

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -191,7 +191,7 @@ def user_add(cursor, user, host, host_all, password, encrypted,
         return {'changed': True, 'password_changed': None, 'attributes': attributes}
 
     # Determine what user management method server uses
-    impl = get_user_implementation(cursor)
+    impl = get_user_implementation(module, cursor)
     old_user_mgmt = impl.use_old_user_mgmt(cursor)
 
     mogrify = do_not_mogrify_requires if old_user_mgmt else mogrify_requires
@@ -265,9 +265,9 @@ def user_add(cursor, user, host, host_all, password, encrypted,
 
     if new_priv is not None:
         for db_table, priv in new_priv.items():
-            privileges_grant(cursor, user, host, db_table, priv, tls_requires)
+            privileges_grant(module, cursor, user, host, db_table, priv, tls_requires)
     if tls_requires is not None:
-        privileges_grant(cursor, user, host, "*.*", get_grants(cursor, user, host), tls_requires)
+        privileges_grant(module, cursor, user, host, "*.*", get_grants(cursor, user, host), tls_requires)
 
     final_attributes = None
 
@@ -298,7 +298,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
     grant_option = False
 
     # Determine what user management method server uses
-    impl = get_user_implementation(cursor)
+    impl = get_user_implementation(module, cursor)
     old_user_mgmt = impl.use_old_user_mgmt(cursor)
 
     if host_all and not role:
@@ -486,7 +486,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                     if db_table not in curr_priv:
                         msg = "New privileges granted"
                         if not module.check_mode:
-                            privileges_grant(cursor, user, host, db_table, priv, tls_requires, maria_role)
+                            privileges_grant(module, cursor, user, host, db_table, priv, tls_requires, maria_role)
                         changed = True
 
             # If the db.table specification exists in both the user's current privileges
@@ -529,7 +529,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted,
                         if len(revoke_privs) > 0:
                             privileges_revoke(cursor, user, host, db_table, revoke_privs, grant_option, maria_role)
                         if len(grant_privs) > 0:
-                            privileges_grant(cursor, user, host, db_table, grant_privs, tls_requires, maria_role)
+                            privileges_grant(module, cursor, user, host, db_table, grant_privs, tls_requires, maria_role)
                     else:
                         changed = True
 
@@ -920,7 +920,7 @@ def privileges_revoke(cursor, user, host, db_table, priv, grant_option, maria_ro
     cursor.execute("FLUSH PRIVILEGES")
 
 
-def privileges_grant(cursor, user, host, db_table, priv, tls_requires, maria_role=False):
+def privileges_grant(module, cursor, user, host, db_table, priv, tls_requires, maria_role=False):
     # Escape '%' since mysql db.execute uses a format string and the
     # specification of db and table often use a % (SQL wildcard)
     db_table = db_table.replace('%', '%%')
@@ -942,7 +942,7 @@ def privileges_grant(cursor, user, host, db_table, priv, tls_requires, maria_rol
         query.append("TO %s")
         params = (user)
 
-    impl = get_user_implementation(cursor)
+    impl = get_user_implementation(module, cursor)
     if tls_requires and impl.use_old_user_mgmt(cursor):
         query, params = mogrify_requires(" ".join(query), params, tls_requires)
         query = [query]
@@ -1079,7 +1079,7 @@ def limit_resources(module, cursor, user, host, resource_limits, check_mode):
 
     Returns: True, if changed, False otherwise.
     """
-    impl = get_user_implementation(cursor)
+    impl = get_user_implementation(module, cursor)
     if not impl.server_supports_alter_user(cursor):
         module.fail_json(msg="The server version does not match the requirements "
                              "for resource_limits parameter. See module's documentation.")
@@ -1215,8 +1215,8 @@ def attributes_get(cursor, user, host):
     return j if j else None
 
 
-def get_user_implementation(cursor):
-    db_engine = get_server_implementation(cursor)
+def get_user_implementation(module, cursor):
+    db_engine = get_server_implementation(module, cursor)
     if db_engine == 'mariadb':
         from ansible_collections.ansible.mysql.plugins.module_utils.implementations.mariadb import user as mariauser
         return mariauser

--- a/plugins/modules/mysql_binlog_info.py
+++ b/plugins/modules/mysql_binlog_info.py
@@ -327,7 +327,7 @@ def main():
                 "Exception message: %s" % (config_file, to_native(e))
         )
 
-    server_implementation = get_server_implementation(cursor)
+    server_implementation = get_server_implementation(module, cursor)
     server_version = get_server_version(cursor)
 
     mysql = MySQL_Binlog_Info(module, cursor, server_implementation, server_version)

--- a/plugins/modules/mysql_clone.py
+++ b/plugins/modules/mysql_clone.py
@@ -362,7 +362,7 @@ def main():
     connection = None
     try:
         cursor, connection = _connect(module)
-        server_implementation = get_server_implementation(cursor)
+        server_implementation = get_server_implementation(module, cursor)
         server_version = get_server_version(cursor)
         validate_clone_support(module, server_implementation, server_version)
         ensure_clone_plugin_active(module, cursor)

--- a/plugins/modules/mysql_db.py
+++ b/plugins/modules/mysql_db.py
@@ -737,7 +737,7 @@ def main():
     if state in ['absent', 'present'] and not sql_log_bin:
         cursor.execute("SET SQL_LOG_BIN=0;")
 
-    server_implementation = get_server_implementation(cursor)
+    server_implementation = get_server_implementation(module, cursor)
     server_version = get_server_version(cursor)
 
     changed = False

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -785,7 +785,7 @@ def main():
                'Exception message: %s' % (connector_name, connector_version, config_file, to_native(e)))
         module.fail_json(msg)
 
-    server_implementation = get_server_implementation(cursor)
+    server_implementation = get_server_implementation(module, cursor)
     server_version = get_server_version(cursor)
     user_implementation = get_user_implementation(cursor)
 

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -787,7 +787,7 @@ def main():
 
     server_implementation = get_server_implementation(module, cursor)
     server_version = get_server_version(cursor)
-    user_implementation = get_user_implementation(cursor)
+    user_implementation = get_user_implementation(module, cursor)
 
     ###############################
     # Create object and do main job

--- a/plugins/modules/mysql_password_policy.py
+++ b/plugins/modules/mysql_password_policy.py
@@ -390,7 +390,7 @@ def main():
                 "Exception message: %s" % (module.params['config_file'], to_native(exc))
         )
 
-    server_implementation = get_server_implementation(cursor)
+    server_implementation = get_server_implementation(module, cursor)
     if server_implementation == 'mysql':
         server_version = get_server_version(cursor).split('-', 1)[0]
         if module.params['mode'] == 'persist' and LooseVersion(server_version) < LooseVersion('8.0'):

--- a/plugins/modules/mysql_replication.py
+++ b/plugins/modules/mysql_replication.py
@@ -566,7 +566,7 @@ def main():
             module.fail_json(msg="unable to find %s. Exception message: %s" % (config_file, to_native(e)))
 
     server_version = get_server_version(cursor)
-    server_implementation = get_server_implementation(cursor)
+    server_implementation = get_server_implementation(module, cursor)
     command_resolver = CommandResolver(server_implementation, server_version)
     cursor.execute("SELECT VERSION()")
     if server_implementation == 'mariadb':

--- a/plugins/modules/mysql_replication_filter.py
+++ b/plugins/modules/mysql_replication_filter.py
@@ -589,7 +589,7 @@ def main():
     executor = MySQLReplicationFilter(
         module,
         cursor,
-        get_server_implementation(cursor),
+        get_server_implementation(module, cursor),
         get_server_version(cursor),
     )
 

--- a/plugins/modules/mysql_role.py
+++ b/plugins/modules/mysql_role.py
@@ -806,7 +806,7 @@ class Role():
 
         if privs:
             for db_table, priv in privs.items():
-                privileges_grant(self.cursor, self.name, self.host,
+                privileges_grant(self.module, self.cursor, self.name, self.host,
                                  db_table, priv, tls_requires=None,
                                  maria_role=self.is_mariadb)
 
@@ -1071,7 +1071,7 @@ def main():
     # Set defaults
     changed = False
 
-    impl = get_user_implementation(cursor)
+    impl = get_user_implementation(module, cursor)
 
     if priv is not None:
         try:

--- a/plugins/modules/mysql_slow_log.py
+++ b/plugins/modules/mysql_slow_log.py
@@ -381,7 +381,7 @@ def main():
         'min_examined_row_limit': module.params['min_examined_row_limit'],
     }
 
-    slow_log = MySQLSlowLog(module, cursor, get_server_implementation(cursor))
+    slow_log = MySQLSlowLog(module, cursor, get_server_implementation(module, cursor))
 
     module.exit_json(
         **slow_log.configure(

--- a/tests/unit/plugins/module_utils/test_mysql.py
+++ b/tests/unit/plugins/module_utils/test_mysql.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
+from unittest.mock import MagicMock
 
 from ansible_collections.ansible.mysql.plugins.module_utils.mysql import get_server_version, get_server_implementation
 from ..utils import dummy_cursor_class
@@ -34,10 +35,34 @@ def test_get_server_version(cursor_return_version, cursor_return_type):
         ('10.5.1-mariadb', 'list', 'mariadb'),
     ]
 )
-def test_get_server_implamentation(cursor_return_version, cursor_return_type, server_implementation):
+def test_get_server_implementation(cursor_return_version, cursor_return_type, server_implementation):
     """
     Test that server implementation are handled properly by get_server_implementation() whether the server version returned as a list or dict.
     """
+    module = MagicMock()
     cursor = dummy_cursor_class(cursor_return_version, cursor_return_type)
 
-    assert get_server_implementation(cursor) == server_implementation
+    assert get_server_implementation(module, cursor) == server_implementation
+
+
+def test_get_server_implementation_warns_on_mariadb():
+    """Test that a deprecation warning is emitted when MariaDB is detected."""
+    module = MagicMock()
+    cursor = dummy_cursor_class('10.5.0-mariadb', 'dict')
+
+    get_server_implementation(module, cursor)
+
+    module.warn.assert_called_once()
+    assert 'MariaDB has been detected' in module.warn.call_args[0][0]
+    assert '6.0.0' in module.warn.call_args[0][0]
+    assert 'ansible.mariadb' in module.warn.call_args[0][0]
+
+
+def test_get_server_implementation_no_warning_on_mysql():
+    """Test that no warning is emitted when MySQL is detected."""
+    module = MagicMock()
+    cursor = dummy_cursor_class('8.0.0-mysql', 'dict')
+
+    get_server_implementation(module, cursor)
+
+    module.warn.assert_not_called()

--- a/tests/unit/plugins/modules/test_mysql_clone.py
+++ b/tests/unit/plugins/modules/test_mysql_clone.py
@@ -307,7 +307,7 @@ def test_main_returns_predictive_result_in_check_mode(monkeypatch):
     )
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_implementation',
-        lambda _cursor: 'mysql',
+        lambda _module, _cursor: 'mysql',
     )
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_version',
@@ -412,7 +412,7 @@ def test_main_fails_immediately_for_fatal_execute_error(monkeypatch):
     )
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_implementation',
-        lambda _cursor: 'mysql',
+        lambda _module, _cursor: 'mysql',
     )
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_version',
@@ -477,7 +477,7 @@ def test_main_waits_after_expected_restart_error(monkeypatch):
     )
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_implementation',
-        lambda _cursor: 'mysql',
+        lambda _module, _cursor: 'mysql',
     )
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.modules.mysql_clone.get_server_version',

--- a/tests/unit/plugins/modules/test_mysql_password_policy.py
+++ b/tests/unit/plugins/modules/test_mysql_password_policy.py
@@ -384,7 +384,7 @@ def test_main_rejects_persist_mode_for_old_mysql(monkeypatch):
         monkeypatch.setattr(AnsibleModule, 'fail_json', fail_json)
         monkeypatch.setattr(mysql_password_policy, 'mysql_driver', object())
         monkeypatch.setattr(mysql_password_policy, 'mysql_connect', lambda *args, **kwargs: (MagicMock(), MagicMock()))
-        monkeypatch.setattr(mysql_password_policy, 'get_server_implementation', lambda cursor: 'mysql')
+        monkeypatch.setattr(mysql_password_policy, 'get_server_implementation', lambda module, cursor: 'mysql')
         monkeypatch.setattr(mysql_password_policy, 'get_server_version', lambda cursor: '5.7.44')
 
         with pytest.raises(AnsibleFailJson) as exc:
@@ -404,7 +404,7 @@ def test_main_returns_configure_result(monkeypatch):
         monkeypatch.setattr(AnsibleModule, 'fail_json', fail_json)
         monkeypatch.setattr(mysql_password_policy, 'mysql_driver', object())
         monkeypatch.setattr(mysql_password_policy, 'mysql_connect', lambda *args, **kwargs: (MagicMock(), MagicMock()))
-        monkeypatch.setattr(mysql_password_policy, 'get_server_implementation', lambda cursor: 'mariadb')
+        monkeypatch.setattr(mysql_password_policy, 'get_server_implementation', lambda module, cursor: 'mariadb')
 
         def fake_configure(self, desired_settings, mode='global', check_mode=False):
             assert desired_settings['length'] == 12


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/ansible.mysql/issues/845

feat: add warning when MariaDB is detected

Related to https://forum.ansible.com/t/resolved-should-ansible-mysql-be-split-into-separate-mysql-and-mariadb-collections/45866


##### ISSUE TYPE

- Feature Pull Request


