### PR TITLE
mysql_info: handle SHOW REPLICAS server ID column spelling

### DIFF
--- a/changelogs/fragments/848-mysql-info-server-id.yml
+++ b/changelogs/fragments/848-mysql-info-server-id.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql_info - handled the server ID column spelling returned by MySQL's ``SHOW REPLICAS`` statement (https://github.com/ansible-collections/ansible.mysql/issues/848).

--- a/plugins/modules/mysql_info.py
+++ b/plugins/modules/mysql_info.py
@@ -555,12 +555,13 @@ class MySQL_Info(object):
         res = self.__exec_sql(query)
         if res:
             for line in res:
-                srv_id = line['Server_id']
+                server_id_key = 'Server_Id' if 'Server_Id' in line else 'Server_id'
+                srv_id = line[server_id_key]
                 if srv_id not in self.info['slave_hosts']:
                     self.info['slave_hosts'][srv_id] = {}
 
                 for vname, val in line.items():
-                    if vname != 'Server_id':
+                    if vname != server_id_key:
                         self.info['slave_hosts'][srv_id][vname] = self.__convert(val)
 
     def __get_users(self):

--- a/tests/integration/targets/test_mysql_info/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_info/tasks/main.yml
@@ -96,6 +96,17 @@
           - result is not changed
           - result.version != {}
 
+    - name: mysql_info - collect replica hosts
+      mysql_info:
+        <<: *mysql_params
+        filter: slave_hosts
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.slave_hosts is mapping
+
     # Test excluding
     - name: Collect all info except settings and users
       mysql_info:

--- a/tests/unit/plugins/modules/test_mysql_info.py
+++ b/tests/unit/plugins/modules/test_mysql_info.py
@@ -35,3 +35,29 @@ def test_get_info_suffix(suffix, cursor_output, server_implementation, server_ve
     info = MySQL_Info(MagicMock(), cursor, server_implementation, server_version, user_implementation)
 
     assert info.get_info([], [], False)['version']['suffix'] == suffix
+
+
+@pytest.mark.parametrize('server_id_column', ['Server_id', 'Server_Id'])
+def test_get_info_slave_hosts_server_id_column(server_id_column):
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [
+        {
+            server_id_column: 2,
+            'Host': 'replica1',
+            'Port': 3306,
+            'Source_Id': 1,
+        },
+    ]
+
+    info = MySQL_Info(MagicMock(), cursor, 'mysql', '8.4.9', 'mysql')
+
+    assert info.get_info(['slave_hosts'], [], False) == {
+        'slave_hosts': {
+            2: {
+                'Host': 'replica1',
+                'Port': 3306,
+                'Source_Id': 1,
+            },
+        },
+    }
+    cursor.execute.assert_called_once_with('SHOW REPLICAS')


### PR DESCRIPTION
##### SUMMARY

Fixes #848.

`mysql_info` assumed that the server ID column returned by `SHOW REPLICAS` was named `Server_id`. MySQL emits `Server_Id`, and PyMySQL preserves that server-provided casing, so collecting information failed with a `KeyError` when the result contained a registered replica.

This change accepts both column spellings, excludes the selected server ID field from the replica details, and adds unit and integration regression coverage.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`mysql_info`

##### ADDITIONAL INFORMATION

Validation:

- `ansible-test units tests/unit/plugins/modules/test_mysql_info.py --python 3.12`: 6 passed
- `ansible-test sanity --base-branch main --changed --untracked --python 3.12`: passed
- The full container integration test was not run locally because Podman is unavailable.


