### PR TITLE
Add mysql_partition module

### DIFF
--- a/plugins/modules/mysql_partition.py
+++ b/plugins/modules/mysql_partition.py
@@ -36,13 +36,13 @@ options:
   action:
     description:
       - Partition operation to perform.
-      - C(add) adds a new partition. For RANGE and LIST types, O(partition_name) and O(value) are required.
+      - V(add) adds a new partition. For RANGE and LIST types, O(name) and O(value) are required.
         For HASH and KEY types, O(number) is required instead.
-      - C(drop) removes partitions. Only valid for RANGE and LIST types.
-      - C(reorganize) splits or merges partitions. Only valid for RANGE and LIST types.
-        Requires O(partitions) and O(into).
-      - C(truncate) removes all rows from specified partitions without dropping them.
-      - C(check), C(repair), C(analyze), and C(optimize) run maintenance operations on specified partitions.
+      - V(drop) removes partitions. Only valid for RANGE and LIST types.
+      - V(reorganize) splits or merges partitions. Only valid for RANGE and LIST types.
+        Requires O(name) and O(into).
+      - V(truncate) removes all rows from specified partitions without dropping them.
+      - V(check), V(repair), V(analyze), and V(optimize) run maintenance operations on specified partitions.
     type: str
     required: true
     choices:
@@ -54,17 +54,22 @@ options:
       - repair
       - analyze
       - optimize
-  partition_name:
+  name:
     description:
-      - Name of the partition to add.
-      - Required when O(action=add) for RANGE and LIST partition types.
-    type: str
+      - Partition name or names to operate on.
+      - For O(action=add) on RANGE and LIST partition types, provide exactly one partition name.
+      - For O(action=drop), O(action=truncate), O(action=check), O(action=repair),
+        O(action=analyze), and O(action=optimize), provide one or more partition names.
+      - For O(action=reorganize), specifies the source partitions to reorganize.
+      - For maintenance and truncate actions, a single-element list containing V(ALL) targets every partition.
+    type: list
+    elements: str
   value:
     description:
       - Partition boundary expression, written as raw SQL.
       - For RANGE partitions, this is the expression used in C(VALUES LESS THAN), for example
-        C(2024), C(MAXVALUE), or C('2024-07-01').
-      - For LIST partitions, this is the expression used in C(VALUES IN), for example C(7, 8, 9).
+        V(2024), V(MAXVALUE), or V('2024-07-01').
+      - For LIST partitions, this is the expression used in C(VALUES IN), for example V(7,8,9).
       - Required when O(action=add) for RANGE and LIST partition types.
     type: str
   number:
@@ -72,15 +77,6 @@ options:
       - Number of partitions to add.
       - Used only when O(action=add) for HASH and KEY partition types.
     type: int
-  partitions:
-    description:
-      - List of partition names to operate on.
-      - Required for O(action=drop), O(action=truncate), O(action=check), O(action=repair),
-        O(action=analyze), and O(action=optimize).
-      - For O(action=reorganize), specifies the source partitions to reorganize.
-      - For maintenance and truncate actions, a single-element list containing C(ALL) targets every partition.
-    type: list
-    elements: str
   into:
     description:
       - List of target partition definitions for reorganize.
@@ -109,6 +105,7 @@ notes:
     They are validated against common SQL injection patterns but are not parameterized.
   - Each invocation runs a single C(ALTER TABLE ... PARTITION) statement.
   - For O(action=add) on HASH or KEY partitions, each call increases the partition count and is not idempotent.
+  - Reducing HASH and KEY partition counts with C(COALESCE PARTITION) is not currently supported.
 
 attributes:
   check_mode:
@@ -118,6 +115,7 @@ attributes:
     details:
       - O(action=add) for RANGE and LIST types is idempotent when the partition already exists.
       - O(action=drop) is idempotent when the partition does not exist.
+      - O(action=reorganize) is idempotent when the target partition layout already matches O(into).
       - Maintenance operations and truncate always report C(changed=true).
       - O(action=add) for HASH and KEY types always reports C(changed=true).
 
@@ -141,7 +139,7 @@ EXAMPLES = r'''
     table: events
     schema: mydb
     action: add
-    partition_name: p2025
+    name: p2025
     value: "2026"
     login_unix_socket: /run/mysqld/mysqld.sock
 
@@ -150,7 +148,7 @@ EXAMPLES = r'''
     table: sales
     schema: mydb
     action: add
-    partition_name: p_south
+    name: p_south
     value: "10, 11, 12"
     login_unix_socket: /run/mysqld/mysqld.sock
 
@@ -167,7 +165,7 @@ EXAMPLES = r'''
     table: events
     schema: mydb
     action: drop
-    partitions:
+    name:
       - p2020
     login_unix_socket: /run/mysqld/mysqld.sock
 
@@ -176,7 +174,7 @@ EXAMPLES = r'''
     table: events
     schema: mydb
     action: reorganize
-    partitions:
+    name:
       - p2024
     into:
       - name: p2024h1
@@ -190,7 +188,7 @@ EXAMPLES = r'''
     table: events
     schema: mydb
     action: truncate
-    partitions:
+    name:
       - p2020
     login_unix_socket: /run/mysqld/mysqld.sock
 
@@ -199,7 +197,7 @@ EXAMPLES = r'''
     table: events
     schema: mydb
     action: analyze
-    partitions:
+    name:
       - ALL
     login_unix_socket: /run/mysqld/mysqld.sock
 
@@ -210,7 +208,7 @@ EXAMPLES = r'''
         table: events
         schema: mydb
         action: add
-        partition_name: p202502
+        name: p202502
         value: "'2025-03-01'"
         login_unix_socket: /run/mysqld/mysqld.sock
 
@@ -219,14 +217,14 @@ EXAMPLES = r'''
         table: events
         schema: mydb
         action: drop
-        partitions:
+        name:
           - p202401
         login_unix_socket: /run/mysqld/mysqld.sock
 '''
 
 RETURN = r'''
 queries:
-  description: List of SQL queries executed or predicted.
+  description: List of SQL queries executed (or that would be executed in check mode).
   returned: always
   type: list
   elements: str
@@ -236,6 +234,37 @@ partition_info:
   returned: success
   type: list
   elements: dict
+  contains:
+    PARTITION_NAME:
+      description: Name of the partition.
+      returned: success
+      type: str
+      sample: p2025
+    PARTITION_METHOD:
+      description: Partitioning method used by the table.
+      returned: success
+      type: str
+      sample: RANGE
+    PARTITION_EXPRESSION:
+      description: Expression used by the table partition definition.
+      returned: success
+      type: str
+      sample: created_year
+    PARTITION_DESCRIPTION:
+      description: Partition boundary or value list as reported by C(INFORMATION_SCHEMA.PARTITIONS).
+      returned: success
+      type: str
+      sample: '2026'
+    PARTITION_ORDINAL_POSITION:
+      description: Position of the partition within the table definition.
+      returned: success
+      type: int
+      sample: 4
+    TABLE_ROWS:
+      description: Estimated number of rows stored in the partition.
+      returned: success
+      type: int
+      sample: 0
 msg:
   description: Human-readable description of the result.
   returned: always
@@ -264,6 +293,7 @@ PARTITION_QUERY = (
     "FROM INFORMATION_SCHEMA.PARTITIONS "
     "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s "
     "AND PARTITION_NAME IS NOT NULL "
+    "AND SUBPARTITION_NAME IS NULL "
     "ORDER BY PARTITION_ORDINAL_POSITION"
 )
 
@@ -300,10 +330,35 @@ def partition_exists(partitions, name):
     return any(p['PARTITION_NAME'] == name for p in partitions)
 
 
+def get_partition(partitions, name):
+    for partition in partitions:
+        if partition['PARTITION_NAME'] == name:
+            return partition
+    return None
+
+
 def get_partition_method(partitions):
     if not partitions:
         return None
     return partitions[0]['PARTITION_METHOD']
+
+
+def normalize_partition_description(value):
+    return ','.join(str(value).strip().split(','))
+
+
+def reorganize_matches_current_state(current_partitions, source_names, into):
+    if any(partition_exists(current_partitions, source_name) for source_name in source_names):
+        return False
+
+    for target in into:
+        current_partition = get_partition(current_partitions, target['name'])
+        if current_partition is None:
+            return False
+        if normalize_partition_description(current_partition['PARTITION_DESCRIPTION']) != normalize_partition_description(target['value']):
+            return False
+
+    return True
 
 
 def build_add_query(table_ref, partition_method, partition_name, value, number):
@@ -354,7 +409,7 @@ def build_maintenance_query(table_ref, action, partitions):
     return 'ALTER TABLE %s %s PARTITION %s' % (table_ref, action.upper(), quoted)
 
 
-def validate_inputs(module, action, partition_method, partition_name, value, number, partitions, into):
+def validate_inputs(module, action, partition_method, names, value, number, into):
     if action == 'add':
         if partition_method in HASH_KEY_METHODS:
             if number is None:
@@ -362,40 +417,43 @@ def validate_inputs(module, action, partition_method, partition_name, value, num
             if number < 1:
                 module.fail_json(msg='number must be at least 1.')
         else:
-            if not partition_name:
-                module.fail_json(msg='partition_name is required when adding %s partitions.' % partition_method)
+            if not names:
+                module.fail_json(msg='name is required when adding %s partitions.' % partition_method)
+            if len(names) != 1:
+                module.fail_json(msg='exactly one name is required when adding %s partitions.' % partition_method)
             if value is None:
                 module.fail_json(msg='value is required when adding %s partitions.' % partition_method)
 
     elif action == 'drop':
-        if not partitions:
-            module.fail_json(msg='partitions is required for drop.')
+        if not names:
+            module.fail_json(msg='name is required for drop.')
         if partition_method in HASH_KEY_METHODS:
             module.fail_json(
                 msg='DROP PARTITION is not supported for %s partitions.' % partition_method)
 
     elif action == 'reorganize':
-        if not partitions:
-            module.fail_json(msg='partitions is required for reorganize (source partitions).')
+        if not names:
+            module.fail_json(msg='name is required for reorganize (source partitions).')
         if not into:
             module.fail_json(msg='into is required for reorganize (target partition definitions).')
         if partition_method in HASH_KEY_METHODS:
             module.fail_json(
                 msg='REORGANIZE PARTITION with value definitions is not supported for %s partitions.' % partition_method)
 
-    elif action in ('truncate',) or action in MAINTENANCE_ACTIONS:
-        if not partitions:
-            module.fail_json(msg='partitions is required for %s.' % action)
+    elif action == 'truncate' or action in MAINTENANCE_ACTIONS:
+        if not names:
+            module.fail_json(msg='name is required for %s.' % action)
 
 
 def handle_add(module, cursor, table_ref, schema, table, partition_method, current_partitions):
-    partition_name = module.params['partition_name']
+    names = module.params['name'] or []
     value = module.params['value']
     number = module.params['number']
 
     if partition_method in HASH_KEY_METHODS:
         query = build_add_query(table_ref, partition_method, None, None, number)
     else:
+        partition_name = names[0]
         if partition_exists(current_partitions, partition_name):
             module.exit_json(
                 changed=False, queries=[],
@@ -420,7 +478,7 @@ def handle_add(module, cursor, table_ref, schema, table, partition_method, curre
 
 
 def handle_drop(module, cursor, table_ref, schema, table, current_partitions):
-    partitions = module.params['partitions']
+    partitions = module.params['name']
 
     existing = [p for p in partitions if partition_exists(current_partitions, p)]
     if not existing:
@@ -447,8 +505,20 @@ def handle_drop(module, cursor, table_ref, schema, table, current_partitions):
 
 
 def handle_reorganize(module, cursor, table_ref, partition_method, current_partitions):
-    partitions = module.params['partitions']
+    partitions = module.params['name']
     into = module.params['into']
+
+    if reorganize_matches_current_state(current_partitions, partitions, into):
+        module.exit_json(
+            changed=False, queries=[],
+            partition_info=current_partitions,
+            msg='Partitions already match requested layout.')
+
+    missing = [partition for partition in partitions if not partition_exists(current_partitions, partition)]
+    if missing:
+        module.fail_json(
+            msg='Source partitions do not exist: %s.' % ', '.join(missing),
+            partition_info=current_partitions)
 
     query = build_reorganize_query(table_ref, partition_method, partitions, into)
     queries = [query]
@@ -468,7 +538,7 @@ def handle_reorganize(module, cursor, table_ref, partition_method, current_parti
 
 
 def handle_truncate(module, cursor, table_ref, current_partitions):
-    partitions = module.params['partitions']
+    partitions = module.params['name']
 
     query = build_truncate_query(table_ref, partitions)
     queries = [query]
@@ -488,7 +558,7 @@ def handle_truncate(module, cursor, table_ref, current_partitions):
 
 
 def handle_maintenance(module, cursor, table_ref, action, current_partitions):
-    partitions = module.params['partitions']
+    partitions = module.params['name']
 
     query = build_maintenance_query(table_ref, action, partitions)
     queries = [query]
@@ -516,10 +586,9 @@ def main():
             'add', 'drop', 'reorganize', 'truncate',
             'check', 'repair', 'analyze', 'optimize',
         ]),
-        partition_name=dict(type='str'),
+        name=dict(type='list', elements='str'),
         value=dict(type='str'),
         number=dict(type='int'),
-        partitions=dict(type='list', elements='str'),
         into=dict(type='list', elements='dict', options=dict(
             name=dict(type='str', required=True),
             value=dict(type='str', required=True),
@@ -538,9 +607,9 @@ def main():
     table = module.params['table']
     schema = module.params['schema']
 
-    check_input(module, table, schema, module.params['partition_name'], module.params['value'])
-    if module.params['partitions']:
-        check_input(module, module.params['partitions'])
+    check_input(module, table, schema, module.params['value'])
+    if module.params['name']:
+        check_input(module, module.params['name'])
     if module.params['into']:
         for item in module.params['into']:
             check_input(module, item['name'], item['value'])
@@ -579,9 +648,8 @@ def main():
 
     validate_inputs(
         module, action, partition_method,
-        module.params['partition_name'], module.params['value'],
-        module.params['number'], module.params['partitions'],
-        module.params['into'])
+        module.params['name'], module.params['value'],
+        module.params['number'], module.params['into'])
 
     if action == 'add':
         queries = handle_add(module, cursor, table_ref, schema, table, partition_method, current_partitions)

--- a/plugins/modules/mysql_partition.py
+++ b/plugins/modules/mysql_partition.py
@@ -562,7 +562,7 @@ def main():
     except Exception as e:
         module.fail_json(msg='unable to connect to database: %s' % to_native(e))
 
-    if get_server_implementation(cursor) != 'mysql':
+    if get_server_implementation(module, cursor) != 'mysql':
         module.fail_json(msg='mysql_partition is supported only by MySQL. MariaDB is not supported.')
 
     if not schema:

--- a/plugins/modules/mysql_partition.py
+++ b/plugins/modules/mysql_partition.py
@@ -1,0 +1,608 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: mysql_partition
+
+short_description: Manage MySQL table partitions
+
+description:
+  - Add, drop, reorganize, truncate, or run maintenance operations on MySQL table partitions.
+  - Supports RANGE, RANGE COLUMNS, LIST, LIST COLUMNS, HASH, and KEY partition types.
+  - The module auto-detects the partition method of the target table and generates the appropriate SQL syntax.
+  - The module is limited to MySQL and fails on MariaDB.
+
+version_added: '5.2.0'
+
+options:
+  table:
+    description:
+      - Name of the partitioned table to manage.
+    type: str
+    required: true
+  schema:
+    description:
+      - Database (schema) containing the table.
+      - If omitted, the current default database from the connection is used.
+    type: str
+  action:
+    description:
+      - Partition operation to perform.
+      - C(add) adds a new partition. For RANGE and LIST types, O(partition_name) and O(value) are required.
+        For HASH and KEY types, O(number) is required instead.
+      - C(drop) removes partitions. Only valid for RANGE and LIST types.
+      - C(reorganize) splits or merges partitions. Only valid for RANGE and LIST types.
+        Requires O(partitions) and O(into).
+      - C(truncate) removes all rows from specified partitions without dropping them.
+      - C(check), C(repair), C(analyze), and C(optimize) run maintenance operations on specified partitions.
+    type: str
+    required: true
+    choices:
+      - add
+      - drop
+      - reorganize
+      - truncate
+      - check
+      - repair
+      - analyze
+      - optimize
+  partition_name:
+    description:
+      - Name of the partition to add.
+      - Required when O(action=add) for RANGE and LIST partition types.
+    type: str
+  value:
+    description:
+      - Partition boundary expression, written as raw SQL.
+      - For RANGE partitions, this is the expression used in C(VALUES LESS THAN), for example
+        C(2024), C(MAXVALUE), or C('2024-07-01').
+      - For LIST partitions, this is the expression used in C(VALUES IN), for example C(7, 8, 9).
+      - Required when O(action=add) for RANGE and LIST partition types.
+    type: str
+  number:
+    description:
+      - Number of partitions to add.
+      - Used only when O(action=add) for HASH and KEY partition types.
+    type: int
+  partitions:
+    description:
+      - List of partition names to operate on.
+      - Required for O(action=drop), O(action=truncate), O(action=check), O(action=repair),
+        O(action=analyze), and O(action=optimize).
+      - For O(action=reorganize), specifies the source partitions to reorganize.
+      - For maintenance and truncate actions, a single-element list containing C(ALL) targets every partition.
+    type: list
+    elements: str
+  into:
+    description:
+      - List of target partition definitions for reorganize.
+      - Each element is a dictionary with O(into[].name) and O(into[].value) keys.
+      - Required when O(action=reorganize).
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - Name of the target partition.
+        type: str
+        required: true
+      value:
+        description:
+          - Partition boundary expression for the target partition, written as raw SQL.
+        type: str
+        required: true
+
+notes:
+  - MariaDB is not supported. The module fails with an error on MariaDB servers.
+  - C(DROP PARTITION) is only supported for RANGE and LIST partition types.
+    HASH and KEY partitions cannot be dropped individually.
+  - C(REORGANIZE PARTITION) with value definitions is only supported for RANGE and LIST types.
+  - The O(value) and O(into[].value) parameters accept raw SQL expressions.
+    They are validated against common SQL injection patterns but are not parameterized.
+  - Each invocation runs a single C(ALTER TABLE ... PARTITION) statement.
+  - For O(action=add) on HASH or KEY partitions, each call increases the partition count and is not idempotent.
+
+attributes:
+  check_mode:
+    support: full
+  idempotent:
+    support: partial
+    details:
+      - O(action=add) for RANGE and LIST types is idempotent when the partition already exists.
+      - O(action=drop) is idempotent when the partition does not exist.
+      - Maintenance operations and truncate always report C(changed=true).
+      - O(action=add) for HASH and KEY types always reports C(changed=true).
+
+seealso:
+  - module: ansible.mysql.mysql_db
+  - module: ansible.mysql.mysql_query
+  - name: MySQL ALTER TABLE Partition Operations
+    description: Complete reference of MySQL partition management statements.
+    link: https://dev.mysql.com/doc/refman/8.4/en/alter-table-partition-operations.html
+
+author:
+  - Ron Gershburg (@rgershbu)
+
+extends_documentation_fragment:
+  - ansible.mysql.mysql
+'''
+
+EXAMPLES = r'''
+- name: Add a RANGE partition for the next year
+  ansible.mysql.mysql_partition:
+    table: events
+    schema: mydb
+    action: add
+    partition_name: p2025
+    value: "2026"
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Add a LIST partition for new regions
+  ansible.mysql.mysql_partition:
+    table: sales
+    schema: mydb
+    action: add
+    partition_name: p_south
+    value: "10, 11, 12"
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Add partitions to a HASH-partitioned table
+  ansible.mysql.mysql_partition:
+    table: sessions
+    schema: mydb
+    action: add
+    number: 4
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Drop an old partition
+  ansible.mysql.mysql_partition:
+    table: events
+    schema: mydb
+    action: drop
+    partitions:
+      - p2020
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Reorganize a partition into two
+  ansible.mysql.mysql_partition:
+    table: events
+    schema: mydb
+    action: reorganize
+    partitions:
+      - p2024
+    into:
+      - name: p2024h1
+        value: "2024"
+      - name: p2024h2
+        value: "2025"
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Truncate a partition
+  ansible.mysql.mysql_partition:
+    table: events
+    schema: mydb
+    action: truncate
+    partitions:
+      - p2020
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Analyze all partitions
+  ansible.mysql.mysql_partition:
+    table: events
+    schema: mydb
+    action: analyze
+    partitions:
+      - ALL
+    login_unix_socket: /run/mysqld/mysqld.sock
+
+- name: Monthly partition rotation
+  block:
+    - name: Add next month partition
+      ansible.mysql.mysql_partition:
+        table: events
+        schema: mydb
+        action: add
+        partition_name: p202502
+        value: "'2025-03-01'"
+        login_unix_socket: /run/mysqld/mysqld.sock
+
+    - name: Drop oldest partition
+      ansible.mysql.mysql_partition:
+        table: events
+        schema: mydb
+        action: drop
+        partitions:
+          - p202401
+        login_unix_socket: /run/mysqld/mysqld.sock
+'''
+
+RETURN = r'''
+queries:
+  description: List of SQL queries executed or predicted.
+  returned: always
+  type: list
+  elements: str
+  sample: ["ALTER TABLE `mydb`.`events` ADD PARTITION (PARTITION `p2025` VALUES LESS THAN (2026))"]
+partition_info:
+  description: Partition metadata from C(INFORMATION_SCHEMA.PARTITIONS) after the operation.
+  returned: success
+  type: list
+  elements: dict
+msg:
+  description: Human-readable description of the result.
+  returned: always
+  type: str
+  sample: "Partition p2025 added."
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+from ansible_collections.ansible.mysql.plugins.module_utils.database import (
+    check_input,
+    mysql_quote_identifier,
+)
+from ansible_collections.ansible.mysql.plugins.module_utils.mysql import (
+    get_server_implementation,
+    mysql_common_argument_spec,
+    mysql_connect,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+
+
+PARTITION_QUERY = (
+    "SELECT PARTITION_NAME, PARTITION_METHOD, PARTITION_EXPRESSION, "
+    "PARTITION_DESCRIPTION, PARTITION_ORDINAL_POSITION, TABLE_ROWS "
+    "FROM INFORMATION_SCHEMA.PARTITIONS "
+    "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s "
+    "AND PARTITION_NAME IS NOT NULL "
+    "ORDER BY PARTITION_ORDINAL_POSITION"
+)
+
+HASH_KEY_METHODS = frozenset(('HASH', 'LINEAR HASH', 'KEY', 'LINEAR KEY'))
+RANGE_METHODS = frozenset(('RANGE', 'RANGE COLUMNS'))
+LIST_METHODS = frozenset(('LIST', 'LIST COLUMNS'))
+MAINTENANCE_ACTIONS = frozenset(('check', 'repair', 'analyze', 'optimize'))
+
+
+def quote_partition(name):
+    return '`%s`' % name.replace('`', '``')
+
+
+def get_table_ref(schema, table):
+    if schema:
+        return mysql_quote_identifier('%s.%s' % (schema, table), 'table')
+    return mysql_quote_identifier(table, 'table')
+
+
+def get_current_schema(cursor):
+    cursor.execute("SELECT DATABASE()")
+    row = cursor.fetchone()
+    if row:
+        return row.get('DATABASE()')
+    return None
+
+
+def get_partition_info(cursor, schema, table):
+    cursor.execute(PARTITION_QUERY, (schema, table))
+    return [dict(row) for row in cursor.fetchall()]
+
+
+def partition_exists(partitions, name):
+    return any(p['PARTITION_NAME'] == name for p in partitions)
+
+
+def get_partition_method(partitions):
+    if not partitions:
+        return None
+    return partitions[0]['PARTITION_METHOD']
+
+
+def build_add_query(table_ref, partition_method, partition_name, value, number):
+    if partition_method in HASH_KEY_METHODS:
+        return 'ALTER TABLE %s ADD PARTITION PARTITIONS %d' % (table_ref, number)
+
+    pname = quote_partition(partition_name)
+    if partition_method in RANGE_METHODS:
+        return 'ALTER TABLE %s ADD PARTITION (PARTITION %s VALUES LESS THAN (%s))' % (
+            table_ref, pname, value)
+
+    return 'ALTER TABLE %s ADD PARTITION (PARTITION %s VALUES IN (%s))' % (
+        table_ref, pname, value)
+
+
+def build_drop_query(table_ref, partitions):
+    quoted = ', '.join(quote_partition(p) for p in partitions)
+    return 'ALTER TABLE %s DROP PARTITION %s' % (table_ref, quoted)
+
+
+def build_reorganize_query(table_ref, partition_method, source_partitions, into):
+    source = ', '.join(quote_partition(p) for p in source_partitions)
+
+    defs = []
+    for part in into:
+        pname = quote_partition(part['name'])
+        val = part['value']
+        if partition_method in RANGE_METHODS:
+            defs.append('PARTITION %s VALUES LESS THAN (%s)' % (pname, val))
+        else:
+            defs.append('PARTITION %s VALUES IN (%s)' % (pname, val))
+
+    return 'ALTER TABLE %s REORGANIZE PARTITION %s INTO (%s)' % (
+        table_ref, source, ', '.join(defs))
+
+
+def build_truncate_query(table_ref, partitions):
+    if len(partitions) == 1 and partitions[0].upper() == 'ALL':
+        return 'ALTER TABLE %s TRUNCATE PARTITION ALL' % table_ref
+    quoted = ', '.join(quote_partition(p) for p in partitions)
+    return 'ALTER TABLE %s TRUNCATE PARTITION %s' % (table_ref, quoted)
+
+
+def build_maintenance_query(table_ref, action, partitions):
+    if len(partitions) == 1 and partitions[0].upper() == 'ALL':
+        return 'ALTER TABLE %s %s PARTITION ALL' % (table_ref, action.upper())
+    quoted = ', '.join(quote_partition(p) for p in partitions)
+    return 'ALTER TABLE %s %s PARTITION %s' % (table_ref, action.upper(), quoted)
+
+
+def validate_inputs(module, action, partition_method, partition_name, value, number, partitions, into):
+    if action == 'add':
+        if partition_method in HASH_KEY_METHODS:
+            if number is None:
+                module.fail_json(msg='number is required when adding %s partitions.' % partition_method)
+            if number < 1:
+                module.fail_json(msg='number must be at least 1.')
+        else:
+            if not partition_name:
+                module.fail_json(msg='partition_name is required when adding %s partitions.' % partition_method)
+            if value is None:
+                module.fail_json(msg='value is required when adding %s partitions.' % partition_method)
+
+    elif action == 'drop':
+        if not partitions:
+            module.fail_json(msg='partitions is required for drop.')
+        if partition_method in HASH_KEY_METHODS:
+            module.fail_json(
+                msg='DROP PARTITION is not supported for %s partitions.' % partition_method)
+
+    elif action == 'reorganize':
+        if not partitions:
+            module.fail_json(msg='partitions is required for reorganize (source partitions).')
+        if not into:
+            module.fail_json(msg='into is required for reorganize (target partition definitions).')
+        if partition_method in HASH_KEY_METHODS:
+            module.fail_json(
+                msg='REORGANIZE PARTITION with value definitions is not supported for %s partitions.' % partition_method)
+
+    elif action in ('truncate',) or action in MAINTENANCE_ACTIONS:
+        if not partitions:
+            module.fail_json(msg='partitions is required for %s.' % action)
+
+
+def handle_add(module, cursor, table_ref, schema, table, partition_method, current_partitions):
+    partition_name = module.params['partition_name']
+    value = module.params['value']
+    number = module.params['number']
+
+    if partition_method in HASH_KEY_METHODS:
+        query = build_add_query(table_ref, partition_method, None, None, number)
+    else:
+        if partition_exists(current_partitions, partition_name):
+            module.exit_json(
+                changed=False, queries=[],
+                partition_info=current_partitions,
+                msg='Partition %s already exists.' % partition_name)
+
+        query = build_add_query(table_ref, partition_method, partition_name, value, None)
+
+    queries = [query]
+    if module.check_mode:
+        module.exit_json(
+            changed=True, queries=queries,
+            partition_info=current_partitions,
+            msg='Partition would be added.')
+
+    try:
+        cursor.execute(query)
+    except Exception as e:
+        module.fail_json(msg='Failed to add partition: %s' % to_native(e), queries=queries)
+
+    return queries
+
+
+def handle_drop(module, cursor, table_ref, schema, table, current_partitions):
+    partitions = module.params['partitions']
+
+    existing = [p for p in partitions if partition_exists(current_partitions, p)]
+    if not existing:
+        module.exit_json(
+            changed=False, queries=[],
+            partition_info=current_partitions,
+            msg='No matching partitions to drop.')
+
+    query = build_drop_query(table_ref, existing)
+    queries = [query]
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True, queries=queries,
+            partition_info=current_partitions,
+            msg='Partitions would be dropped.')
+
+    try:
+        cursor.execute(query)
+    except Exception as e:
+        module.fail_json(msg='Failed to drop partition: %s' % to_native(e), queries=queries)
+
+    return queries
+
+
+def handle_reorganize(module, cursor, table_ref, partition_method, current_partitions):
+    partitions = module.params['partitions']
+    into = module.params['into']
+
+    query = build_reorganize_query(table_ref, partition_method, partitions, into)
+    queries = [query]
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True, queries=queries,
+            partition_info=current_partitions,
+            msg='Partitions would be reorganized.')
+
+    try:
+        cursor.execute(query)
+    except Exception as e:
+        module.fail_json(msg='Failed to reorganize partitions: %s' % to_native(e), queries=queries)
+
+    return queries
+
+
+def handle_truncate(module, cursor, table_ref, current_partitions):
+    partitions = module.params['partitions']
+
+    query = build_truncate_query(table_ref, partitions)
+    queries = [query]
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True, queries=queries,
+            partition_info=current_partitions,
+            msg='Partitions would be truncated.')
+
+    try:
+        cursor.execute(query)
+    except Exception as e:
+        module.fail_json(msg='Failed to truncate partition: %s' % to_native(e), queries=queries)
+
+    return queries
+
+
+def handle_maintenance(module, cursor, table_ref, action, current_partitions):
+    partitions = module.params['partitions']
+
+    query = build_maintenance_query(table_ref, action, partitions)
+    queries = [query]
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True, queries=queries,
+            partition_info=current_partitions,
+            msg='%s PARTITION would be executed.' % action.upper())
+
+    try:
+        cursor.execute(query)
+    except Exception as e:
+        module.fail_json(msg='Failed to %s partition: %s' % (action, to_native(e)), queries=queries)
+
+    return queries
+
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        table=dict(type='str', required=True),
+        schema=dict(type='str'),
+        action=dict(type='str', required=True, choices=[
+            'add', 'drop', 'reorganize', 'truncate',
+            'check', 'repair', 'analyze', 'optimize',
+        ]),
+        partition_name=dict(type='str'),
+        value=dict(type='str'),
+        number=dict(type='int'),
+        partitions=dict(type='list', elements='str'),
+        into=dict(type='list', elements='dict', options=dict(
+            name=dict(type='str', required=True),
+            value=dict(type='str', required=True),
+        )),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    action = module.params['action']
+    table = module.params['table']
+    schema = module.params['schema']
+
+    check_input(module, table, schema, module.params['partition_name'], module.params['value'])
+    if module.params['partitions']:
+        check_input(module, module.params['partitions'])
+    if module.params['into']:
+        for item in module.params['into']:
+            check_input(module, item['name'], item['value'])
+
+    try:
+        cursor, db_conn = mysql_connect(
+            module,
+            module.params['login_user'],
+            module.params['login_password'],
+            module.params['config_file'],
+            module.params['client_cert'],
+            module.params['client_key'],
+            module.params['ca_cert'],
+            connect_timeout=module.params['connect_timeout'],
+            check_hostname=module.params['check_hostname'],
+            cursor_class='DictCursor',
+            autocommit=True,
+        )
+    except Exception as e:
+        module.fail_json(msg='unable to connect to database: %s' % to_native(e))
+
+    if get_server_implementation(cursor) != 'mysql':
+        module.fail_json(msg='mysql_partition is supported only by MySQL. MariaDB is not supported.')
+
+    if not schema:
+        schema = get_current_schema(cursor)
+        if not schema:
+            module.fail_json(msg='No database selected and schema parameter not specified.')
+
+    current_partitions = get_partition_info(cursor, schema, table)
+    if not current_partitions:
+        module.fail_json(msg='Table %s.%s does not exist or is not partitioned.' % (schema, table))
+
+    partition_method = get_partition_method(current_partitions)
+    table_ref = get_table_ref(schema, table)
+
+    validate_inputs(
+        module, action, partition_method,
+        module.params['partition_name'], module.params['value'],
+        module.params['number'], module.params['partitions'],
+        module.params['into'])
+
+    if action == 'add':
+        queries = handle_add(module, cursor, table_ref, schema, table, partition_method, current_partitions)
+    elif action == 'drop':
+        queries = handle_drop(module, cursor, table_ref, schema, table, current_partitions)
+    elif action == 'reorganize':
+        queries = handle_reorganize(module, cursor, table_ref, partition_method, current_partitions)
+    elif action == 'truncate':
+        queries = handle_truncate(module, cursor, table_ref, current_partitions)
+    else:
+        queries = handle_maintenance(module, cursor, table_ref, action, current_partitions)
+
+    updated_partitions = get_partition_info(cursor, schema, table)
+
+    module.exit_json(
+        changed=True,
+        queries=queries,
+        partition_info=updated_partitions,
+        msg='%s partition operation completed.' % action.upper(),
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/test_mysql_partition/defaults/main.yml
+++ b/tests/integration/targets/test_mysql_partition/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+mysql_user: root
+mysql_password: msandbox
+mysql_host: '{{ gateway_addr }}'
+mysql_primary_port: 3307
+test_db: partition_test_db

--- a/tests/integration/targets/test_mysql_partition/meta/main.yml
+++ b/tests/integration/targets/test_mysql_partition/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_controller

--- a/tests/integration/targets/test_mysql_partition/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_partition/tasks/main.yml
@@ -1,0 +1,746 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: Partition | Run tests
+  vars:
+    mysql_parameters: &mysql_params
+      login_user: '{{ mysql_user }}'
+      login_password: '{{ mysql_password }}'
+      login_host: '{{ mysql_host }}'
+      login_port: '{{ mysql_primary_port }}'
+
+  block:
+    - name: Partition | Skip on MariaDB
+      ansible.builtin.meta: end_play
+      when: db_engine != 'mysql'
+
+    - name: Partition | Create test database
+      ansible.mysql.mysql_db:
+        <<: *mysql_params
+        name: '{{ test_db }}'
+        state: present
+
+    - name: Partition | Create RANGE partitioned table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: |
+          CREATE TABLE IF NOT EXISTS events (
+            id INT NOT NULL AUTO_INCREMENT,
+            created_year INT NOT NULL,
+            data VARCHAR(100),
+            PRIMARY KEY (id, created_year)
+          ) PARTITION BY RANGE (created_year) (
+            PARTITION p2020 VALUES LESS THAN (2021),
+            PARTITION p2021 VALUES LESS THAN (2022),
+            PARTITION p2022 VALUES LESS THAN (2023)
+          )
+
+    - name: Partition | Create LIST partitioned table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: |
+          CREATE TABLE IF NOT EXISTS sales (
+            id INT NOT NULL AUTO_INCREMENT,
+            region INT NOT NULL,
+            amount DECIMAL(10,2),
+            PRIMARY KEY (id, region)
+          ) PARTITION BY LIST (region) (
+            PARTITION p_east VALUES IN (1, 2, 3),
+            PARTITION p_west VALUES IN (4, 5, 6)
+          )
+
+    - name: Partition | Insert test data into RANGE table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: |
+          INSERT INTO events (created_year, data)
+          VALUES (2020, 'old_event'), (2021, 'mid_event'), (2022, 'new_event')
+
+    - name: Partition | Insert test data into LIST table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: |
+          INSERT INTO sales (region, amount)
+          VALUES (1, 100.00), (4, 200.00)
+
+    - name: Partition | Create non-partitioned table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: |
+          CREATE TABLE IF NOT EXISTS plain_table (id INT NOT NULL PRIMARY KEY)
+
+    - name: Partition | Fail on non-partitioned table
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: plain_table
+        schema: '{{ test_db }}'
+        action: check
+        partitions:
+          - ALL
+      register: result
+      ignore_errors: true
+
+    - name: Partition | Assert non-partitioned table failure
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'not partitioned' in result.msg or 'does not exist' in result.msg"
+
+    - name: Partition | Add RANGE partition in check mode
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: add
+        partition_name: p2023
+        value: "2024"
+      check_mode: true
+      register: result
+
+    - name: Partition | Assert add check mode
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 1
+          - "'ADD PARTITION' in result.queries[0]"
+          - "'p2023' in result.queries[0]"
+          - "'2024' in result.queries[0]"
+
+    - name: Partition | Verify partition not added after check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT PARTITION_NAME
+          FROM INFORMATION_SCHEMA.PARTITIONS
+          WHERE TABLE_SCHEMA = '{{ test_db }}' AND TABLE_NAME = 'events'
+          AND PARTITION_NAME = 'p2023'
+      register: result
+
+    - name: Partition | Assert partition absent after check mode
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 0
+
+    - name: Partition | Add RANGE partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: add
+        partition_name: p2023
+        value: "2024"
+      register: result
+
+    - name: Partition | Assert add result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 1
+          - result.partition_info | length == 4
+
+    - name: Partition | Verify partition exists
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT PARTITION_NAME
+          FROM INFORMATION_SCHEMA.PARTITIONS
+          WHERE TABLE_SCHEMA = '{{ test_db }}' AND TABLE_NAME = 'events'
+          AND PARTITION_NAME = 'p2023'
+      register: result
+
+    - name: Partition | Assert partition present
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 1
+
+    - name: Partition | Add RANGE partition idempotency
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: add
+        partition_name: p2023
+        value: "2024"
+      register: result
+
+    - name: Partition | Assert add idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - "'already exists' in result.msg"
+
+    - name: Partition | Add LIST partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: sales
+        schema: '{{ test_db }}'
+        action: add
+        partition_name: p_south
+        value: "7, 8, 9"
+      register: result
+
+    - name: Partition | Assert LIST add result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'VALUES IN' in result.queries[0]"
+          - result.partition_info | length == 3
+
+    - name: Partition | Add LIST partition idempotency
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: sales
+        schema: '{{ test_db }}'
+        action: add
+        partition_name: p_south
+        value: "7, 8, 9"
+      register: result
+
+    - name: Partition | Assert LIST add idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+
+    - name: Partition | Truncate partition in check mode
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: truncate
+        partitions:
+          - p2020
+      check_mode: true
+      register: result
+
+    - name: Partition | Assert truncate check mode
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'TRUNCATE PARTITION' in result.queries[0]"
+
+    - name: Partition | Verify data still present after truncate check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT COUNT(*) AS cnt FROM events PARTITION (p2020)
+      register: result
+
+    - name: Partition | Assert data still present
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['cnt'] == 1
+
+    - name: Partition | Truncate partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: truncate
+        partitions:
+          - p2020
+      register: result
+
+    - name: Partition | Assert truncate result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+
+    - name: Partition | Verify data removed after truncate
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT COUNT(*) AS cnt FROM events PARTITION (p2020)
+      register: result
+
+    - name: Partition | Assert data removed
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['cnt'] == 0
+
+    - name: Partition | Reorganize merge in check mode
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: reorganize
+        partitions:
+          - p2021
+          - p2022
+        into:
+          - name: p2021_2022
+            value: "2023"
+      check_mode: true
+      register: result
+
+    - name: Partition | Assert reorganize merge check mode
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'REORGANIZE PARTITION' in result.queries[0]"
+          - "'p2021_2022' in result.queries[0]"
+
+    - name: Partition | Verify partitions not merged after check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT PARTITION_NAME
+          FROM INFORMATION_SCHEMA.PARTITIONS
+          WHERE TABLE_SCHEMA = '{{ test_db }}' AND TABLE_NAME = 'events'
+          AND PARTITION_NAME IN ('p2021', 'p2022')
+      register: result
+
+    - name: Partition | Assert original partitions still exist
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 2
+
+    - name: Partition | Reorganize merge partitions
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: reorganize
+        partitions:
+          - p2021
+          - p2022
+        into:
+          - name: p2021_2022
+            value: "2023"
+      register: result
+
+    - name: Partition | Assert reorganize merge result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+
+    - name: Partition | Verify merged partition exists
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT PARTITION_NAME
+          FROM INFORMATION_SCHEMA.PARTITIONS
+          WHERE TABLE_SCHEMA = '{{ test_db }}' AND TABLE_NAME = 'events'
+          AND PARTITION_NAME = 'p2021_2022'
+      register: result
+
+    - name: Partition | Assert merged partition present
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 1
+
+    - name: Partition | Verify original partitions are gone
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT PARTITION_NAME
+          FROM INFORMATION_SCHEMA.PARTITIONS
+          WHERE TABLE_SCHEMA = '{{ test_db }}' AND TABLE_NAME = 'events'
+          AND PARTITION_NAME IN ('p2021', 'p2022')
+      register: result
+
+    - name: Partition | Assert original partitions removed
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 0
+
+    - name: Partition | Verify data survived merge
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT COUNT(*) AS cnt FROM events WHERE created_year IN (2021, 2022)
+      register: result
+
+    - name: Partition | Assert data intact after merge
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['cnt'] == 2
+
+    - name: Partition | Reorganize split partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: reorganize
+        partitions:
+          - p2021_2022
+        into:
+          - name: p2021_new
+            value: "2022"
+          - name: p2022_new
+            value: "2023"
+      register: result
+
+    - name: Partition | Assert reorganize split result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+
+    - name: Partition | Verify split partitions exist
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT PARTITION_NAME
+          FROM INFORMATION_SCHEMA.PARTITIONS
+          WHERE TABLE_SCHEMA = '{{ test_db }}' AND TABLE_NAME = 'events'
+          AND PARTITION_NAME IN ('p2021_new', 'p2022_new')
+      register: result
+
+    - name: Partition | Assert split partitions present
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 2
+
+    - name: Partition | Drop partition in check mode
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: drop
+        partitions:
+          - p2020
+      check_mode: true
+      register: result
+
+    - name: Partition | Assert drop check mode
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'DROP PARTITION' in result.queries[0]"
+
+    - name: Partition | Verify partition still exists after drop check mode
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT PARTITION_NAME
+          FROM INFORMATION_SCHEMA.PARTITIONS
+          WHERE TABLE_SCHEMA = '{{ test_db }}' AND TABLE_NAME = 'events'
+          AND PARTITION_NAME = 'p2020'
+      register: result
+
+    - name: Partition | Assert partition still present after drop check mode
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 1
+
+    - name: Partition | Drop partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: drop
+        partitions:
+          - p2020
+      register: result
+
+    - name: Partition | Assert drop result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.queries | length == 1
+
+    - name: Partition | Verify partition removed
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT PARTITION_NAME
+          FROM INFORMATION_SCHEMA.PARTITIONS
+          WHERE TABLE_SCHEMA = '{{ test_db }}' AND TABLE_NAME = 'events'
+          AND PARTITION_NAME = 'p2020'
+      register: result
+
+    - name: Partition | Assert partition removed
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 0
+
+    - name: Partition | Drop partition idempotency
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: drop
+        partitions:
+          - p2020
+      register: result
+
+    - name: Partition | Assert drop idempotency
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+
+    - name: Partition | Check partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: check
+        partitions:
+          - p2021_new
+      register: result
+
+    - name: Partition | Assert check result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'CHECK PARTITION' in result.queries[0]"
+
+    - name: Partition | Analyze all partitions
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: analyze
+        partitions:
+          - ALL
+      register: result
+
+    - name: Partition | Assert analyze result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'ANALYZE PARTITION ALL' in result.queries[0]"
+
+    - name: Partition | Optimize partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: optimize
+        partitions:
+          - p2021_new
+      register: result
+
+    - name: Partition | Assert optimize result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'OPTIMIZE PARTITION' in result.queries[0]"
+
+    - name: Partition | Repair partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: repair
+        partitions:
+          - p2021_new
+      register: result
+
+    - name: Partition | Assert repair result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'REPAIR PARTITION' in result.queries[0]"
+
+    - name: Partition | Check partition in check mode
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: check
+        partitions:
+          - p2021_new
+      check_mode: true
+      register: result
+
+    - name: Partition | Assert maintenance check mode
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'CHECK PARTITION' in result.queries[0]"
+
+    - name: Partition | Fail add without partition_name
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: add
+        value: "2030"
+      register: result
+      ignore_errors: true
+
+    - name: Partition | Assert missing partition_name error
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'partition_name is required' in result.msg"
+
+    - name: Partition | Fail add without value
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: add
+        partition_name: ptest
+      register: result
+      ignore_errors: true
+
+    - name: Partition | Assert missing value error
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'value is required' in result.msg"
+
+    - name: Partition | Fail drop without partitions
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: drop
+      register: result
+      ignore_errors: true
+
+    - name: Partition | Assert missing partitions error
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'partitions is required' in result.msg"
+
+    - name: Partition | Fail reorganize without into
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: reorganize
+        partitions:
+          - p2021
+      register: result
+      ignore_errors: true
+
+    - name: Partition | Assert missing into error
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'into is required' in result.msg"
+
+    - name: Partition | Create HASH partitioned table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: |
+          CREATE TABLE IF NOT EXISTS sessions (
+            id INT NOT NULL AUTO_INCREMENT,
+            user_id INT NOT NULL,
+            data VARCHAR(100),
+            PRIMARY KEY (id, user_id)
+          ) PARTITION BY HASH (user_id)
+          PARTITIONS 4
+
+    - name: Partition | Add HASH partitions
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: sessions
+        schema: '{{ test_db }}'
+        action: add
+        number: 2
+      register: result
+
+    - name: Partition | Assert HASH add result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'ADD PARTITION PARTITIONS 2' in result.queries[0]"
+          - result.partition_info | length == 6
+
+    - name: Partition | Fail drop on HASH table
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: sessions
+        schema: '{{ test_db }}'
+        action: drop
+        partitions:
+          - p0
+      register: result
+      ignore_errors: true
+
+    - name: Partition | Assert HASH drop failure
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'not supported' in result.msg"
+
+    - name: Partition | Fail add HASH without number
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: sessions
+        schema: '{{ test_db }}'
+        action: add
+        partition_name: ptest
+        value: "1"
+      register: result
+      ignore_errors: true
+
+    - name: Partition | Assert HASH add without number failure
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'number is required' in result.msg"
+
+    - name: Partition | Check HASH partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: sessions
+        schema: '{{ test_db }}'
+        action: check
+        partitions:
+          - ALL
+      register: result
+
+    - name: Partition | Assert HASH check result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+
+    - name: Partition | Truncate ALL partitions
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: truncate
+        partitions:
+          - ALL
+      register: result
+
+    - name: Partition | Assert truncate ALL result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'TRUNCATE PARTITION ALL' in result.queries[0]"
+
+    - name: Partition | Verify all data removed
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT COUNT(*) AS cnt FROM events
+      register: result
+
+    - name: Partition | Assert all data removed
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['cnt'] == 0
+
+    - name: Partition | Drop test database
+      ansible.mysql.mysql_db:
+        <<: *mysql_params
+        name: '{{ test_db }}'
+        state: absent

--- a/tests/integration/targets/test_mysql_partition/tasks/main.yml
+++ b/tests/integration/targets/test_mysql_partition/tasks/main.yml
@@ -23,6 +23,24 @@
         name: '{{ test_db }}'
         state: present
 
+    - name: Partition | Create config file for default database fallback
+      ansible.builtin.tempfile:
+        state: file
+        suffix: .cnf
+      register: mysql_partition_config_file
+
+    - name: Partition | Write config file for default database fallback
+      ansible.builtin.copy:
+        dest: '{{ mysql_partition_config_file.path }}'
+        mode: '0600'
+        content: |
+          [client]
+          user={{ mysql_user }}
+          password={{ mysql_password }}
+          host={{ mysql_host }}
+          port={{ mysql_primary_port }}
+          database={{ test_db }}
+
     - name: Partition | Create RANGE partitioned table
       ansible.mysql.mysql_query:
         <<: *mysql_params
@@ -54,6 +72,62 @@
             PARTITION p_west VALUES IN (4, 5, 6)
           )
 
+    - name: Partition | Create RANGE COLUMNS partitioned table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: |
+          CREATE TABLE IF NOT EXISTS events_by_month (
+            id INT NOT NULL,
+            created_on DATE NOT NULL,
+            data VARCHAR(100),
+            PRIMARY KEY (id, created_on)
+          ) PARTITION BY RANGE COLUMNS (created_on) (
+            PARTITION p202401 VALUES LESS THAN ('2024-02-01'),
+            PARTITION p202402 VALUES LESS THAN ('2024-03-01')
+          )
+
+    - name: Partition | Create LIST COLUMNS partitioned table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: |
+          CREATE TABLE IF NOT EXISTS sales_regions (
+            id INT NOT NULL,
+            region_code CHAR(2) NOT NULL,
+            amount DECIMAL(10,2),
+            PRIMARY KEY (id, region_code)
+          ) PARTITION BY LIST COLUMNS (region_code) (
+            PARTITION p_eu VALUES IN ('de', 'fr'),
+            PARTITION p_us VALUES IN ('us')
+          )
+
+    - name: Partition | Create HASH partitioned table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: |
+          CREATE TABLE IF NOT EXISTS sessions (
+            id INT NOT NULL AUTO_INCREMENT,
+            user_id INT NOT NULL,
+            data VARCHAR(100),
+            PRIMARY KEY (id, user_id)
+          ) PARTITION BY HASH (user_id)
+          PARTITIONS 4
+
+    - name: Partition | Create KEY partitioned table
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: |
+          CREATE TABLE IF NOT EXISTS key_sessions (
+            id INT NOT NULL,
+            session_key VARCHAR(32) NOT NULL,
+            data VARCHAR(100),
+            PRIMARY KEY (id, session_key)
+          ) PARTITION BY KEY (session_key)
+          PARTITIONS 2
+
     - name: Partition | Insert test data into RANGE table
       ansible.mysql.mysql_query:
         <<: *mysql_params
@@ -83,8 +157,7 @@
         table: plain_table
         schema: '{{ test_db }}'
         action: check
-        partitions:
-          - ALL
+        name: ALL
       register: result
       ignore_errors: true
 
@@ -100,7 +173,7 @@
         table: events
         schema: '{{ test_db }}'
         action: add
-        partition_name: p2023
+        name: p2023
         value: "2024"
       check_mode: true
       register: result
@@ -136,7 +209,7 @@
         table: events
         schema: '{{ test_db }}'
         action: add
-        partition_name: p2023
+        name: p2023
         value: "2024"
       register: result
 
@@ -146,6 +219,10 @@
           - result is changed
           - result.queries | length == 1
           - result.partition_info | length == 4
+          - "(result.partition_info | selectattr('PARTITION_NAME', 'equalto', 'p2023') | list | length) == 1"
+          - "(result.partition_info | selectattr('PARTITION_NAME', 'equalto', 'p2023') | map(attribute='PARTITION_METHOD') | list | first) == 'RANGE'"
+          - "(result.partition_info | selectattr('PARTITION_NAME', 'equalto', 'p2023') | map(attribute='PARTITION_DESCRIPTION') | list | first) == '2024'"
+          - "(result.partition_info[0] | dict2items | map(attribute='key') | list | sort) == ['PARTITION_DESCRIPTION', 'PARTITION_EXPRESSION', 'PARTITION_METHOD', 'PARTITION_NAME', 'PARTITION_ORDINAL_POSITION', 'TABLE_ROWS']"
 
     - name: Partition | Verify partition exists
       ansible.mysql.mysql_query:
@@ -169,7 +246,7 @@
         table: events
         schema: '{{ test_db }}'
         action: add
-        partition_name: p2023
+        name: p2023
         value: "2024"
       register: result
 
@@ -179,13 +256,46 @@
           - result is not changed
           - "'already exists' in result.msg"
 
+    - name: Partition | Use schema fallback from selected database
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        config_file: '{{ mysql_partition_config_file.path }}'
+        table: events
+        action: check
+        name: ALL
+      register: result
+
+    - name: Partition | Assert schema fallback
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'CHECK PARTITION ALL' in result.queries[0]"
+          - test_db in result.queries[0]
+
+    - name: Partition | Add RANGE COLUMNS partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events_by_month
+        schema: '{{ test_db }}'
+        action: add
+        name: p202403
+        value: "'2024-04-01'"
+      register: result
+
+    - name: Partition | Assert RANGE COLUMNS add result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'VALUES LESS THAN' in result.queries[0]"
+          - "(result.partition_info | selectattr('PARTITION_NAME', 'equalto', 'p202403') | list | length) == 1"
+
     - name: Partition | Add LIST partition
       ansible.mysql.mysql_partition:
         <<: *mysql_params
         table: sales
         schema: '{{ test_db }}'
         action: add
-        partition_name: p_south
+        name: p_south
         value: "7, 8, 9"
       register: result
 
@@ -195,6 +305,7 @@
           - result is changed
           - "'VALUES IN' in result.queries[0]"
           - result.partition_info | length == 3
+          - "(result.partition_info | selectattr('PARTITION_NAME', 'equalto', 'p_south') | list | length) == 1"
 
     - name: Partition | Add LIST partition idempotency
       ansible.mysql.mysql_partition:
@@ -202,7 +313,7 @@
         table: sales
         schema: '{{ test_db }}'
         action: add
-        partition_name: p_south
+        name: p_south
         value: "7, 8, 9"
       register: result
 
@@ -211,14 +322,30 @@
         that:
           - result is not changed
 
+    - name: Partition | Add LIST COLUMNS partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: sales_regions
+        schema: '{{ test_db }}'
+        action: add
+        name: p_apac
+        value: "'jp', 'sg'"
+      register: result
+
+    - name: Partition | Assert LIST COLUMNS add result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'VALUES IN' in result.queries[0]"
+          - "(result.partition_info | selectattr('PARTITION_NAME', 'equalto', 'p_apac') | list | length) == 1"
+
     - name: Partition | Truncate partition in check mode
       ansible.mysql.mysql_partition:
         <<: *mysql_params
         table: events
         schema: '{{ test_db }}'
         action: truncate
-        partitions:
-          - p2020
+        name: p2020
       check_mode: true
       register: result
 
@@ -247,8 +374,7 @@
         table: events
         schema: '{{ test_db }}'
         action: truncate
-        partitions:
-          - p2020
+        name: p2020
       register: result
 
     - name: Partition | Assert truncate result
@@ -275,7 +401,7 @@
         table: events
         schema: '{{ test_db }}'
         action: reorganize
-        partitions:
+        name:
           - p2021
           - p2022
         into:
@@ -313,7 +439,7 @@
         table: events
         schema: '{{ test_db }}'
         action: reorganize
-        partitions:
+        name:
           - p2021
           - p2022
         into:
@@ -377,8 +503,7 @@
         table: events
         schema: '{{ test_db }}'
         action: reorganize
-        partitions:
-          - p2021_2022
+        name: p2021_2022
         into:
           - name: p2021_new
             value: "2022"
@@ -407,14 +532,49 @@
         that:
           - result.rowcount[0] == 2
 
+    - name: Partition | Reorganize LIST partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: sales
+        schema: '{{ test_db }}'
+        action: reorganize
+        name: p_south
+        into:
+          - name: p_central
+            value: "7,8"
+          - name: p_south_new
+            value: "9"
+      register: result
+
+    - name: Partition | Assert LIST reorganize result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'REORGANIZE PARTITION' in result.queries[0]"
+
+    - name: Partition | Verify LIST reorganize partitions exist
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT PARTITION_NAME
+          FROM INFORMATION_SCHEMA.PARTITIONS
+          WHERE TABLE_SCHEMA = '{{ test_db }}' AND TABLE_NAME = 'sales'
+          AND PARTITION_NAME IN ('p_central', 'p_south_new')
+      register: result
+
+    - name: Partition | Assert LIST reorganize partitions present
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 2
+
     - name: Partition | Drop partition in check mode
       ansible.mysql.mysql_partition:
         <<: *mysql_params
         table: events
         schema: '{{ test_db }}'
         action: drop
-        partitions:
-          - p2020
+        name: p2020
       check_mode: true
       register: result
 
@@ -446,8 +606,7 @@
         table: events
         schema: '{{ test_db }}'
         action: drop
-        partitions:
-          - p2020
+        name: p2020
       register: result
 
     - name: Partition | Assert drop result
@@ -478,8 +637,7 @@
         table: events
         schema: '{{ test_db }}'
         action: drop
-        partitions:
-          - p2020
+        name: p2020
       register: result
 
     - name: Partition | Assert drop idempotency
@@ -493,8 +651,7 @@
         table: events
         schema: '{{ test_db }}'
         action: check
-        partitions:
-          - p2021_new
+        name: p2021_new
       register: result
 
     - name: Partition | Assert check result
@@ -509,8 +666,7 @@
         table: events
         schema: '{{ test_db }}'
         action: analyze
-        partitions:
-          - ALL
+        name: ALL
       register: result
 
     - name: Partition | Assert analyze result
@@ -525,8 +681,7 @@
         table: events
         schema: '{{ test_db }}'
         action: optimize
-        partitions:
-          - p2021_new
+        name: p2021_new
       register: result
 
     - name: Partition | Assert optimize result
@@ -541,8 +696,7 @@
         table: events
         schema: '{{ test_db }}'
         action: repair
-        partitions:
-          - p2021_new
+        name: p2021_new
       register: result
 
     - name: Partition | Assert repair result
@@ -557,8 +711,7 @@
         table: events
         schema: '{{ test_db }}'
         action: check
-        partitions:
-          - p2021_new
+        name: p2021_new
       check_mode: true
       register: result
 
@@ -568,7 +721,42 @@
           - result is changed
           - "'CHECK PARTITION' in result.queries[0]"
 
-    - name: Partition | Fail add without partition_name
+    - name: Partition | Drop multiple partitions
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: events
+        schema: '{{ test_db }}'
+        action: drop
+        name:
+          - p2021_new
+          - p2022_new
+      register: result
+
+    - name: Partition | Assert multiple drop result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'DROP PARTITION' in result.queries[0]"
+          - "'p2021_new' in result.queries[0]"
+          - "'p2022_new' in result.queries[0]"
+
+    - name: Partition | Verify dropped partitions are gone
+      ansible.mysql.mysql_query:
+        <<: *mysql_params
+        login_db: '{{ test_db }}'
+        query: >
+          SELECT PARTITION_NAME
+          FROM INFORMATION_SCHEMA.PARTITIONS
+          WHERE TABLE_SCHEMA = '{{ test_db }}' AND TABLE_NAME = 'events'
+          AND PARTITION_NAME IN ('p2021_new', 'p2022_new')
+      register: result
+
+    - name: Partition | Assert dropped partitions removed
+      ansible.builtin.assert:
+        that:
+          - result.rowcount[0] == 0
+
+    - name: Partition | Fail add without name
       ansible.mysql.mysql_partition:
         <<: *mysql_params
         table: events
@@ -578,11 +766,11 @@
       register: result
       ignore_errors: true
 
-    - name: Partition | Assert missing partition_name error
+    - name: Partition | Assert missing name error
       ansible.builtin.assert:
         that:
           - result is failed
-          - "'partition_name is required' in result.msg"
+          - "'name is required' in result.msg"
 
     - name: Partition | Fail add without value
       ansible.mysql.mysql_partition:
@@ -590,7 +778,7 @@
         table: events
         schema: '{{ test_db }}'
         action: add
-        partition_name: ptest
+        name: ptest
       register: result
       ignore_errors: true
 
@@ -600,7 +788,7 @@
           - result is failed
           - "'value is required' in result.msg"
 
-    - name: Partition | Fail drop without partitions
+    - name: Partition | Fail drop without name
       ansible.mysql.mysql_partition:
         <<: *mysql_params
         table: events
@@ -609,11 +797,11 @@
       register: result
       ignore_errors: true
 
-    - name: Partition | Assert missing partitions error
+    - name: Partition | Assert missing name error for drop
       ansible.builtin.assert:
         that:
           - result is failed
-          - "'partitions is required' in result.msg"
+          - "'name is required' in result.msg"
 
     - name: Partition | Fail reorganize without into
       ansible.mysql.mysql_partition:
@@ -621,8 +809,7 @@
         table: events
         schema: '{{ test_db }}'
         action: reorganize
-        partitions:
-          - p2021
+        name: p2021
       register: result
       ignore_errors: true
 
@@ -632,18 +819,37 @@
           - result is failed
           - "'into is required' in result.msg"
 
-    - name: Partition | Create HASH partitioned table
+    - name: Partition | Add HASH partitions in check mode
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: sessions
+        schema: '{{ test_db }}'
+        action: add
+        number: 2
+      check_mode: true
+      register: result
+
+    - name: Partition | Assert HASH add check mode
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'ADD PARTITION PARTITIONS 2' in result.queries[0]"
+
+    - name: Partition | Verify HASH partition count unchanged after check mode
       ansible.mysql.mysql_query:
         <<: *mysql_params
         login_db: '{{ test_db }}'
-        query: |
-          CREATE TABLE IF NOT EXISTS sessions (
-            id INT NOT NULL AUTO_INCREMENT,
-            user_id INT NOT NULL,
-            data VARCHAR(100),
-            PRIMARY KEY (id, user_id)
-          ) PARTITION BY HASH (user_id)
-          PARTITIONS 4
+        query: >
+          SELECT COUNT(*) AS cnt
+          FROM INFORMATION_SCHEMA.PARTITIONS
+          WHERE TABLE_SCHEMA = '{{ test_db }}' AND TABLE_NAME = 'sessions'
+          AND SUBPARTITION_NAME IS NULL
+      register: result
+
+    - name: Partition | Assert HASH partition count unchanged
+      ansible.builtin.assert:
+        that:
+          - result.query_result[0][0]['cnt'] == 4
 
     - name: Partition | Add HASH partitions
       ansible.mysql.mysql_partition:
@@ -661,14 +867,28 @@
           - "'ADD PARTITION PARTITIONS 2' in result.queries[0]"
           - result.partition_info | length == 6
 
+    - name: Partition | Add HASH partitions again
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: sessions
+        schema: '{{ test_db }}'
+        action: add
+        number: 2
+      register: result
+
+    - name: Partition | Assert HASH add is not idempotent
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.partition_info | length == 8
+
     - name: Partition | Fail drop on HASH table
       ansible.mysql.mysql_partition:
         <<: *mysql_params
         table: sessions
         schema: '{{ test_db }}'
         action: drop
-        partitions:
-          - p0
+        name: p0
       register: result
       ignore_errors: true
 
@@ -684,8 +904,7 @@
         table: sessions
         schema: '{{ test_db }}'
         action: add
-        partition_name: ptest
-        value: "1"
+        name: ptest
       register: result
       ignore_errors: true
 
@@ -701,11 +920,59 @@
         table: sessions
         schema: '{{ test_db }}'
         action: check
-        partitions:
-          - ALL
+        name: ALL
       register: result
 
     - name: Partition | Assert HASH check result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+
+    - name: Partition | Fail reorganize on HASH table
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: sessions
+        schema: '{{ test_db }}'
+        action: reorganize
+        name: p0
+        into:
+          - name: p_new
+            value: "1"
+      register: result
+      ignore_errors: true
+
+    - name: Partition | Assert HASH reorganize failure
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'not supported' in result.msg"
+
+    - name: Partition | Add KEY partitions
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: key_sessions
+        schema: '{{ test_db }}'
+        action: add
+        number: 2
+      register: result
+
+    - name: Partition | Assert KEY add result
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - "'ADD PARTITION PARTITIONS 2' in result.queries[0]"
+          - result.partition_info | length == 4
+
+    - name: Partition | Check KEY partition
+      ansible.mysql.mysql_partition:
+        <<: *mysql_params
+        table: key_sessions
+        schema: '{{ test_db }}'
+        action: check
+        name: ALL
+      register: result
+
+    - name: Partition | Assert KEY check result
       ansible.builtin.assert:
         that:
           - result is changed
@@ -716,8 +983,7 @@
         table: events
         schema: '{{ test_db }}'
         action: truncate
-        partitions:
-          - ALL
+        name: ALL
       register: result
 
     - name: Partition | Assert truncate ALL result

--- a/tests/unit/plugins/modules/test_mysql_partition.py
+++ b/tests/unit/plugins/modules/test_mysql_partition.py
@@ -841,7 +841,7 @@ def _patch_main(monkeypatch, module, cursor, server_impl='mysql', partition_rows
     )
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.modules.mysql_partition.get_server_implementation',
-        lambda _cursor: server_impl,
+        lambda _module, _cursor: server_impl,
     )
     monkeypatch.setattr(
         'ansible_collections.ansible.mysql.plugins.modules.mysql_partition.check_input',

--- a/tests/unit/plugins/modules/test_mysql_partition.py
+++ b/tests/unit/plugins/modules/test_mysql_partition.py
@@ -6,6 +6,7 @@ __metaclass__ = type
 import pytest
 
 from ansible_collections.ansible.mysql.plugins.modules.mysql_partition import (
+    PARTITION_QUERY,
     build_add_query,
     build_drop_query,
     build_maintenance_query,
@@ -177,6 +178,10 @@ def test_get_partition_info_returns_empty_for_non_partitioned():
     result = get_partition_info(cursor, 'mydb', 'plain')
 
     assert result == []
+
+
+def test_partition_query_excludes_subpartitions():
+    assert 'SUBPARTITION_NAME IS NULL' in PARTITION_QUERY
 
 
 # ── partition_exists ──────────────────────────────────────────────
@@ -409,92 +414,99 @@ def test_build_maintenance_query_multiple_partitions():
 # ── validate_inputs ───────────────────────────────────────────────
 
 
-def test_validate_inputs_add_range_missing_partition_name():
+def test_validate_inputs_add_range_missing_name():
     module = DummyModule()
 
-    with pytest.raises(RuntimeError, match='partition_name is required'):
-        validate_inputs(module, 'add', 'RANGE', None, '2024', None, None, None)
+    with pytest.raises(RuntimeError, match='name is required'):
+        validate_inputs(module, 'add', 'RANGE', None, '2024', None, None)
+
+
+def test_validate_inputs_add_range_requires_single_name():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='exactly one name is required'):
+        validate_inputs(module, 'add', 'RANGE', ['p2023', 'p2024'], '2024', None, None)
 
 
 def test_validate_inputs_add_range_missing_value():
     module = DummyModule()
 
     with pytest.raises(RuntimeError, match='value is required'):
-        validate_inputs(module, 'add', 'RANGE', 'p2023', None, None, None, None)
+        validate_inputs(module, 'add', 'RANGE', ['p2023'], None, None, None)
 
 
 def test_validate_inputs_add_hash_missing_number():
     module = DummyModule()
 
     with pytest.raises(RuntimeError, match='number is required'):
-        validate_inputs(module, 'add', 'HASH', None, None, None, None, None)
+        validate_inputs(module, 'add', 'HASH', None, None, None, None)
 
 
 def test_validate_inputs_add_hash_number_zero():
     module = DummyModule()
 
     with pytest.raises(RuntimeError, match='number must be at least 1'):
-        validate_inputs(module, 'add', 'HASH', None, None, 0, None, None)
+        validate_inputs(module, 'add', 'HASH', None, None, 0, None)
 
 
 def test_validate_inputs_add_linear_key_missing_number():
     module = DummyModule()
 
     with pytest.raises(RuntimeError, match='number is required'):
-        validate_inputs(module, 'add', 'LINEAR KEY', None, None, None, None, None)
+        validate_inputs(module, 'add', 'LINEAR KEY', None, None, None, None)
 
 
 def test_validate_inputs_add_range_valid():
     module = DummyModule()
 
-    validate_inputs(module, 'add', 'RANGE', 'p2023', '2024', None, None, None)
+    validate_inputs(module, 'add', 'RANGE', ['p2023'], '2024', None, None)
 
 
 def test_validate_inputs_add_hash_valid():
     module = DummyModule()
 
-    validate_inputs(module, 'add', 'HASH', None, None, 4, None, None)
+    validate_inputs(module, 'add', 'HASH', None, None, 4, None)
 
 
-def test_validate_inputs_drop_missing_partitions():
+def test_validate_inputs_drop_missing_name():
     module = DummyModule()
 
-    with pytest.raises(RuntimeError, match='partitions is required for drop'):
-        validate_inputs(module, 'drop', 'RANGE', None, None, None, None, None)
+    with pytest.raises(RuntimeError, match='name is required for drop'):
+        validate_inputs(module, 'drop', 'RANGE', None, None, None, None)
 
 
 def test_validate_inputs_drop_hash_rejected():
     module = DummyModule()
 
     with pytest.raises(RuntimeError, match='not supported for HASH'):
-        validate_inputs(module, 'drop', 'HASH', None, None, None, ['p0'], None)
+        validate_inputs(module, 'drop', 'HASH', ['p0'], None, None, None)
 
 
 def test_validate_inputs_drop_linear_hash_rejected():
     module = DummyModule()
 
     with pytest.raises(RuntimeError, match='not supported for LINEAR HASH'):
-        validate_inputs(module, 'drop', 'LINEAR HASH', None, None, None, ['p0'], None)
+        validate_inputs(module, 'drop', 'LINEAR HASH', ['p0'], None, None, None)
 
 
 def test_validate_inputs_drop_key_rejected():
     module = DummyModule()
 
     with pytest.raises(RuntimeError, match='not supported for KEY'):
-        validate_inputs(module, 'drop', 'KEY', None, None, None, ['p0'], None)
+        validate_inputs(module, 'drop', 'KEY', ['p0'], None, None, None)
 
 
 def test_validate_inputs_drop_range_valid():
     module = DummyModule()
 
-    validate_inputs(module, 'drop', 'RANGE', None, None, None, ['p2020'], None)
+    validate_inputs(module, 'drop', 'RANGE', ['p2020'], None, None, None)
 
 
-def test_validate_inputs_reorganize_missing_partitions():
+def test_validate_inputs_reorganize_missing_name():
     module = DummyModule()
 
-    with pytest.raises(RuntimeError, match='partitions is required for reorganize'):
-        validate_inputs(module, 'reorganize', 'RANGE', None, None, None, None,
+    with pytest.raises(RuntimeError, match='name is required for reorganize'):
+        validate_inputs(module, 'reorganize', 'RANGE', None, None, None,
                         [{'name': 'px', 'value': '1'}])
 
 
@@ -502,37 +514,37 @@ def test_validate_inputs_reorganize_missing_into():
     module = DummyModule()
 
     with pytest.raises(RuntimeError, match='into is required for reorganize'):
-        validate_inputs(module, 'reorganize', 'RANGE', None, None, None, ['p0'], None)
+        validate_inputs(module, 'reorganize', 'RANGE', ['p0'], None, None, None)
 
 
 def test_validate_inputs_reorganize_hash_rejected():
     module = DummyModule()
 
     with pytest.raises(RuntimeError, match='not supported for HASH'):
-        validate_inputs(module, 'reorganize', 'HASH', None, None, None,
-                        ['p0'], [{'name': 'px', 'value': '1'}])
+        validate_inputs(module, 'reorganize', 'HASH', ['p0'], None, None,
+                        [{'name': 'px', 'value': '1'}])
 
 
 def test_validate_inputs_reorganize_valid():
     module = DummyModule()
 
-    validate_inputs(module, 'reorganize', 'LIST', None, None, None,
-                    ['p_old'], [{'name': 'px', 'value': '1, 2'}])
+    validate_inputs(module, 'reorganize', 'LIST', ['p_old'], None, None,
+                    [{'name': 'px', 'value': '1, 2'}])
 
 
 @pytest.mark.parametrize('action', ['truncate', 'check', 'repair', 'analyze', 'optimize'])
-def test_validate_inputs_maintenance_missing_partitions(action):
+def test_validate_inputs_maintenance_missing_name(action):
     module = DummyModule()
 
-    with pytest.raises(RuntimeError, match='partitions is required for %s' % action):
-        validate_inputs(module, action, 'RANGE', None, None, None, None, None)
+    with pytest.raises(RuntimeError, match='name is required for %s' % action):
+        validate_inputs(module, action, 'RANGE', None, None, None, None)
 
 
 @pytest.mark.parametrize('action', ['truncate', 'check', 'repair', 'analyze', 'optimize'])
 def test_validate_inputs_maintenance_valid(action):
     module = DummyModule()
 
-    validate_inputs(module, action, 'RANGE', None, None, None, ['p0'], None)
+    validate_inputs(module, action, 'RANGE', ['p0'], None, None, None)
 
 
 # ── handle_add ────────────────────────────────────────────────────
@@ -540,7 +552,7 @@ def test_validate_inputs_maintenance_valid(action):
 
 def test_handle_add_range_existing_partition_is_idempotent():
     module = DummyModule(params={
-        'partition_name': 'p2020', 'value': '2021', 'number': None,
+        'name': ['p2020'], 'value': '2021', 'number': None,
     })
     cursor = DummyCursor()
 
@@ -554,7 +566,7 @@ def test_handle_add_range_existing_partition_is_idempotent():
 
 def test_handle_add_range_new_partition():
     module = DummyModule(params={
-        'partition_name': 'p2023', 'value': '2024', 'number': None,
+        'name': ['p2023'], 'value': '2024', 'number': None,
     })
     cursor = DummyCursor()
 
@@ -568,7 +580,7 @@ def test_handle_add_range_new_partition():
 
 def test_handle_add_range_check_mode():
     module = DummyModule(params={
-        'partition_name': 'p2023', 'value': '2024', 'number': None,
+        'name': ['p2023'], 'value': '2024', 'number': None,
     })
     module.check_mode = True
     cursor = DummyCursor()
@@ -584,7 +596,7 @@ def test_handle_add_range_check_mode():
 
 def test_handle_add_hash():
     module = DummyModule(params={
-        'partition_name': None, 'value': None, 'number': 2,
+        'name': None, 'value': None, 'number': 2,
     })
     cursor = DummyCursor()
 
@@ -595,7 +607,7 @@ def test_handle_add_hash():
 
 def test_handle_add_execute_error():
     module = DummyModule(params={
-        'partition_name': 'p2023', 'value': '2024', 'number': None,
+        'name': ['p2023'], 'value': '2024', 'number': None,
     })
     cursor = FailingCursor('Duplicate partition name')
 
@@ -607,7 +619,7 @@ def test_handle_add_execute_error():
 
 
 def test_handle_drop_no_matching_partitions():
-    module = DummyModule(params={'partitions': ['p9999']})
+    module = DummyModule(params={'name': ['p9999']})
     cursor = DummyCursor()
 
     with pytest.raises(SystemExit) as exc:
@@ -619,7 +631,7 @@ def test_handle_drop_no_matching_partitions():
 
 
 def test_handle_drop_filters_to_existing():
-    module = DummyModule(params={'partitions': ['p2020', 'p9999']})
+    module = DummyModule(params={'name': ['p2020', 'p9999']})
     cursor = DummyCursor()
 
     queries = handle_drop(module, cursor, '`db`.`t`', 'db', 't', SAMPLE_RANGE_PARTITIONS)
@@ -630,7 +642,7 @@ def test_handle_drop_filters_to_existing():
 
 
 def test_handle_drop_check_mode():
-    module = DummyModule(params={'partitions': ['p2020']})
+    module = DummyModule(params={'name': ['p2020']})
     module.check_mode = True
     cursor = DummyCursor()
 
@@ -644,7 +656,7 @@ def test_handle_drop_check_mode():
 
 
 def test_handle_drop_executes():
-    module = DummyModule(params={'partitions': ['p2020']})
+    module = DummyModule(params={'name': ['p2020']})
     cursor = DummyCursor()
 
     queries = handle_drop(module, cursor, '`db`.`t`', 'db', 't', SAMPLE_RANGE_PARTITIONS)
@@ -654,7 +666,7 @@ def test_handle_drop_executes():
 
 
 def test_handle_drop_execute_error():
-    module = DummyModule(params={'partitions': ['p2020']})
+    module = DummyModule(params={'name': ['p2020']})
     cursor = FailingCursor('Cannot remove all partitions')
 
     with pytest.raises(RuntimeError, match='Failed to drop partition'):
@@ -666,7 +678,7 @@ def test_handle_drop_execute_error():
 
 def test_handle_reorganize_executes():
     module = DummyModule(params={
-        'partitions': ['p2020', 'p2021'],
+        'name': ['p2020', 'p2021'],
         'into': [{'name': 'p_merged', 'value': '2022'}],
     })
     cursor = DummyCursor()
@@ -681,7 +693,7 @@ def test_handle_reorganize_executes():
 
 def test_handle_reorganize_check_mode():
     module = DummyModule(params={
-        'partitions': ['p2020'],
+        'name': ['p2020'],
         'into': [{'name': 'pa', 'value': '2020'}, {'name': 'pb', 'value': '2021'}],
     })
     module.check_mode = True
@@ -698,7 +710,7 @@ def test_handle_reorganize_check_mode():
 
 def test_handle_reorganize_execute_error():
     module = DummyModule(params={
-        'partitions': ['p2020'],
+        'name': ['p2020'],
         'into': [{'name': 'px', 'value': '2021'}],
     })
     cursor = FailingCursor('VALUES LESS THAN value must be strictly increasing')
@@ -707,11 +719,42 @@ def test_handle_reorganize_execute_error():
         handle_reorganize(module, cursor, '`t`', 'RANGE', SAMPLE_RANGE_PARTITIONS)
 
 
+def test_handle_reorganize_missing_source_partition():
+    module = DummyModule(params={
+        'name': ['p9999'],
+        'into': [{'name': 'px', 'value': '2021'}],
+    })
+    cursor = DummyCursor()
+
+    with pytest.raises(RuntimeError, match='Source partitions do not exist'):
+        handle_reorganize(module, cursor, '`t`', 'RANGE', SAMPLE_RANGE_PARTITIONS)
+
+
+def test_handle_reorganize_idempotent_when_target_layout_matches():
+    module = DummyModule(params={
+        'name': ['p2020', 'p2021'],
+        'into': [{'name': 'p_merged', 'value': '2022'}],
+    })
+    cursor = DummyCursor()
+    current_partitions = [
+        {'PARTITION_NAME': 'p_merged', 'PARTITION_METHOD': 'RANGE',
+         'PARTITION_EXPRESSION': 'year', 'PARTITION_DESCRIPTION': '2022',
+         'PARTITION_ORDINAL_POSITION': 1, 'TABLE_ROWS': 30},
+    ]
+
+    with pytest.raises(SystemExit) as exc:
+        handle_reorganize(module, cursor, '`t`', 'RANGE', current_partitions)
+
+    result = exc.value.args[0]
+    assert result['changed'] is False
+    assert 'already match requested layout' in result['msg']
+
+
 # ── handle_truncate ───────────────────────────────────────────────
 
 
 def test_handle_truncate_executes():
-    module = DummyModule(params={'partitions': ['p2020']})
+    module = DummyModule(params={'name': ['p2020']})
     cursor = DummyCursor()
 
     queries = handle_truncate(module, cursor, '`db`.`t`', SAMPLE_RANGE_PARTITIONS)
@@ -721,7 +764,7 @@ def test_handle_truncate_executes():
 
 
 def test_handle_truncate_all():
-    module = DummyModule(params={'partitions': ['ALL']})
+    module = DummyModule(params={'name': ['ALL']})
     cursor = DummyCursor()
 
     queries = handle_truncate(module, cursor, '`t`', SAMPLE_RANGE_PARTITIONS)
@@ -730,7 +773,7 @@ def test_handle_truncate_all():
 
 
 def test_handle_truncate_check_mode():
-    module = DummyModule(params={'partitions': ['p2020']})
+    module = DummyModule(params={'name': ['p2020']})
     module.check_mode = True
     cursor = DummyCursor()
 
@@ -744,7 +787,7 @@ def test_handle_truncate_check_mode():
 
 
 def test_handle_truncate_execute_error():
-    module = DummyModule(params={'partitions': ['p2020']})
+    module = DummyModule(params={'name': ['p2020']})
     cursor = FailingCursor('Unknown partition')
 
     with pytest.raises(RuntimeError, match='Failed to truncate'):
@@ -756,7 +799,7 @@ def test_handle_truncate_execute_error():
 
 @pytest.mark.parametrize('action', ['check', 'repair', 'analyze', 'optimize'])
 def test_handle_maintenance_executes(action):
-    module = DummyModule(params={'partitions': ['p2020']})
+    module = DummyModule(params={'name': ['p2020']})
     cursor = DummyCursor()
 
     queries = handle_maintenance(module, cursor, '`db`.`t`', action, SAMPLE_RANGE_PARTITIONS)
@@ -767,7 +810,7 @@ def test_handle_maintenance_executes(action):
 
 @pytest.mark.parametrize('action', ['check', 'repair', 'analyze', 'optimize'])
 def test_handle_maintenance_check_mode(action):
-    module = DummyModule(params={'partitions': ['p2020']})
+    module = DummyModule(params={'name': ['p2020']})
     module.check_mode = True
     cursor = DummyCursor()
 
@@ -781,7 +824,7 @@ def test_handle_maintenance_check_mode(action):
 
 
 def test_handle_maintenance_execute_error():
-    module = DummyModule(params={'partitions': ['p2020']})
+    module = DummyModule(params={'name': ['p2020']})
     cursor = FailingCursor('Table not found')
 
     with pytest.raises(RuntimeError, match='Failed to check partition'):
@@ -789,7 +832,7 @@ def test_handle_maintenance_execute_error():
 
 
 def test_handle_maintenance_all():
-    module = DummyModule(params={'partitions': ['ALL']})
+    module = DummyModule(params={'name': ['ALL']})
     cursor = DummyCursor()
 
     queries = handle_maintenance(module, cursor, '`t`', 'analyze', SAMPLE_RANGE_PARTITIONS)
@@ -804,6 +847,7 @@ def _make_main_module(action='check', table='events', schema='mydb', **overrides
     params = {
         'login_user': 'root',
         'login_password': 'secret',
+        'login_db': None,
         'config_file': '~/.my.cnf',
         'client_cert': None,
         'client_key': None,
@@ -813,10 +857,9 @@ def _make_main_module(action='check', table='events', schema='mydb', **overrides
         'table': table,
         'schema': schema,
         'action': action,
-        'partition_name': None,
+        'name': ['p2020'],
         'value': None,
         'number': None,
-        'partitions': ['p2020'],
         'into': None,
     }
     params.update(overrides)
@@ -887,8 +930,7 @@ def test_main_fails_for_non_partitioned_table(monkeypatch):
 
 def test_main_check_mode_add(monkeypatch):
     module = _make_main_module(
-        action='add', partition_name='p2023', value='2024',
-        partitions=None,
+        action='add', name=['p2023'], value='2024',
     )
     module.check_mode = True
     cursor = DummyCursor()
@@ -903,7 +945,7 @@ def test_main_check_mode_add(monkeypatch):
 
 
 def test_main_successful_drop(monkeypatch):
-    module = _make_main_module(action='drop', partitions=['p2020'])
+    module = _make_main_module(action='drop', name=['p2020'])
     cursor = DummyCursor()
     _patch_main(monkeypatch, module, cursor)
 
@@ -916,7 +958,7 @@ def test_main_successful_drop(monkeypatch):
 
 
 def test_main_successful_truncate(monkeypatch):
-    module = _make_main_module(action='truncate', partitions=['ALL'])
+    module = _make_main_module(action='truncate', name=['ALL'])
     cursor = DummyCursor()
     _patch_main(monkeypatch, module, cursor)
 
@@ -930,7 +972,7 @@ def test_main_successful_truncate(monkeypatch):
 def test_main_successful_reorganize(monkeypatch):
     module = _make_main_module(
         action='reorganize',
-        partitions=['p2020', 'p2021'],
+        name=['p2020', 'p2021'],
         into=[{'name': 'p_merged', 'value': '2022'}],
     )
     cursor = DummyCursor()
@@ -945,7 +987,7 @@ def test_main_successful_reorganize(monkeypatch):
 
 @pytest.mark.parametrize('action', ['check', 'repair', 'analyze', 'optimize'])
 def test_main_successful_maintenance(monkeypatch, action):
-    module = _make_main_module(action=action, partitions=['p2020'])
+    module = _make_main_module(action=action, name=['p2020'])
     cursor = DummyCursor()
     _patch_main(monkeypatch, module, cursor)
 
@@ -958,7 +1000,7 @@ def test_main_successful_maintenance(monkeypatch, action):
 
 
 def test_main_resolves_schema_from_connection(monkeypatch):
-    module = _make_main_module(action='check', schema=None, partitions=['p2020'])
+    module = _make_main_module(action='check', schema=None, name=['p2020'])
     cursor = DummyCursor()
     _patch_main(monkeypatch, module, cursor)
 
@@ -976,8 +1018,7 @@ def test_main_resolves_schema_from_connection(monkeypatch):
 
 def test_main_add_idempotent_existing_partition(monkeypatch):
     module = _make_main_module(
-        action='add', partition_name='p2020', value='2021',
-        partitions=None,
+        action='add', name=['p2020'], value='2021',
     )
     cursor = DummyCursor()
     _patch_main(monkeypatch, module, cursor)
@@ -991,7 +1032,7 @@ def test_main_add_idempotent_existing_partition(monkeypatch):
 
 
 def test_main_drop_idempotent_missing_partition(monkeypatch):
-    module = _make_main_module(action='drop', partitions=['p9999'])
+    module = _make_main_module(action='drop', name=['p9999'])
     cursor = DummyCursor()
     _patch_main(monkeypatch, module, cursor)
 

--- a/tests/unit/plugins/modules/test_mysql_partition.py
+++ b/tests/unit/plugins/modules/test_mysql_partition.py
@@ -1,0 +1,1003 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.ansible.mysql.plugins.modules.mysql_partition import (
+    build_add_query,
+    build_drop_query,
+    build_maintenance_query,
+    build_reorganize_query,
+    build_truncate_query,
+    get_current_schema,
+    get_partition_info,
+    get_partition_method,
+    get_table_ref,
+    handle_add,
+    handle_drop,
+    handle_maintenance,
+    handle_reorganize,
+    handle_truncate,
+    main,
+    partition_exists,
+    quote_partition,
+    validate_inputs,
+)
+
+
+SAMPLE_RANGE_PARTITIONS = [
+    {'PARTITION_NAME': 'p2020', 'PARTITION_METHOD': 'RANGE',
+     'PARTITION_EXPRESSION': 'year', 'PARTITION_DESCRIPTION': '2021',
+     'PARTITION_ORDINAL_POSITION': 1, 'TABLE_ROWS': 10},
+    {'PARTITION_NAME': 'p2021', 'PARTITION_METHOD': 'RANGE',
+     'PARTITION_EXPRESSION': 'year', 'PARTITION_DESCRIPTION': '2022',
+     'PARTITION_ORDINAL_POSITION': 2, 'TABLE_ROWS': 20},
+]
+
+SAMPLE_LIST_PARTITIONS = [
+    {'PARTITION_NAME': 'p_east', 'PARTITION_METHOD': 'LIST',
+     'PARTITION_EXPRESSION': 'region', 'PARTITION_DESCRIPTION': '1,2,3',
+     'PARTITION_ORDINAL_POSITION': 1, 'TABLE_ROWS': 5},
+]
+
+SAMPLE_HASH_PARTITIONS = [
+    {'PARTITION_NAME': 'p0', 'PARTITION_METHOD': 'HASH',
+     'PARTITION_EXPRESSION': 'id', 'PARTITION_DESCRIPTION': None,
+     'PARTITION_ORDINAL_POSITION': 1, 'TABLE_ROWS': 0},
+    {'PARTITION_NAME': 'p1', 'PARTITION_METHOD': 'HASH',
+     'PARTITION_EXPRESSION': 'id', 'PARTITION_DESCRIPTION': None,
+     'PARTITION_ORDINAL_POSITION': 2, 'TABLE_ROWS': 0},
+]
+
+
+class DummyModule(object):
+    def __init__(self, params=None):
+        self.msg = None
+        self.exit_kwargs = None
+        self.check_mode = False
+        self.params = params or {}
+
+    def fail_json(self, msg=None, **kwargs):
+        self.msg = msg
+        raise RuntimeError(msg)
+
+    def exit_json(self, **kwargs):
+        self.exit_kwargs = kwargs
+        raise SystemExit(kwargs)
+
+
+class DummyCursor(object):
+    def __init__(self, fetchone_results=None, fetchall_results=None):
+        self.fetchone_results = list(fetchone_results or [])
+        self.fetchall_results = list(fetchall_results or [])
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchone(self):
+        if self.fetchone_results:
+            return self.fetchone_results.pop(0)
+        return None
+
+    def fetchall(self):
+        if self.fetchall_results:
+            return self.fetchall_results.pop(0)
+        return []
+
+    def close(self):
+        return None
+
+
+class FailingCursor(DummyCursor):
+    def __init__(self, error_message, trigger_prefix='ALTER TABLE'):
+        super(FailingCursor, self).__init__()
+        self.error_message = error_message
+        self.trigger_prefix = trigger_prefix
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+        if query.startswith(self.trigger_prefix):
+            raise RuntimeError(self.error_message)
+
+
+class DummyConnection(object):
+    def close(self):
+        return None
+
+
+# ── quote_partition ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    'name,expected',
+    [
+        ('p2020', '`p2020`'),
+        ('my`part', '`my``part`'),
+        ('simple', '`simple`'),
+    ]
+)
+def test_quote_partition(name, expected):
+    assert quote_partition(name) == expected
+
+
+# ── get_table_ref ─────────────────────────────────────────────────
+
+
+def test_get_table_ref_with_schema():
+    assert get_table_ref('mydb', 'events') == '`mydb`.`events`'
+
+
+def test_get_table_ref_without_schema():
+    assert get_table_ref(None, 'events') == '`events`'
+
+
+# ── get_current_schema ────────────────────────────────────────────
+
+
+def test_get_current_schema_returns_database():
+    cursor = DummyCursor(fetchone_results=[{'DATABASE()': 'testdb'}])
+
+    assert get_current_schema(cursor) == 'testdb'
+
+
+def test_get_current_schema_returns_none_when_no_database():
+    cursor = DummyCursor(fetchone_results=[{'DATABASE()': None}])
+
+    assert get_current_schema(cursor) is None
+
+
+def test_get_current_schema_returns_none_when_no_row():
+    cursor = DummyCursor(fetchone_results=[None])
+
+    assert get_current_schema(cursor) is None
+
+
+# ── get_partition_info ────────────────────────────────────────────
+
+
+def test_get_partition_info_returns_list_of_dicts():
+    rows = [
+        {'PARTITION_NAME': 'p0', 'PARTITION_METHOD': 'RANGE'},
+        {'PARTITION_NAME': 'p1', 'PARTITION_METHOD': 'RANGE'},
+    ]
+    cursor = DummyCursor(fetchall_results=[rows])
+
+    result = get_partition_info(cursor, 'mydb', 'events')
+
+    assert result == rows
+    assert cursor.executed[0][1] == ('mydb', 'events')
+
+
+def test_get_partition_info_returns_empty_for_non_partitioned():
+    cursor = DummyCursor(fetchall_results=[[]])
+
+    result = get_partition_info(cursor, 'mydb', 'plain')
+
+    assert result == []
+
+
+# ── partition_exists ──────────────────────────────────────────────
+
+
+def test_partition_exists_returns_true():
+    assert partition_exists(SAMPLE_RANGE_PARTITIONS, 'p2020') is True
+
+
+def test_partition_exists_returns_false():
+    assert partition_exists(SAMPLE_RANGE_PARTITIONS, 'p9999') is False
+
+
+def test_partition_exists_empty_list():
+    assert partition_exists([], 'p2020') is False
+
+
+# ── get_partition_method ──────────────────────────────────────────
+
+
+def test_get_partition_method_returns_method():
+    assert get_partition_method(SAMPLE_RANGE_PARTITIONS) == 'RANGE'
+
+
+def test_get_partition_method_returns_none_for_empty():
+    assert get_partition_method([]) is None
+
+
+def test_get_partition_method_hash():
+    assert get_partition_method(SAMPLE_HASH_PARTITIONS) == 'HASH'
+
+
+# ── build_add_query ───────────────────────────────────────────────
+
+
+def test_build_add_query_range():
+    result = build_add_query('`mydb`.`events`', 'RANGE', 'p2023', '2024', None)
+
+    assert result == (
+        "ALTER TABLE `mydb`.`events` ADD PARTITION "
+        "(PARTITION `p2023` VALUES LESS THAN (2024))"
+    )
+
+
+def test_build_add_query_range_columns():
+    result = build_add_query('`mydb`.`events`', 'RANGE COLUMNS', 'p2023', "'2024-01-01'", None)
+
+    assert result == (
+        "ALTER TABLE `mydb`.`events` ADD PARTITION "
+        "(PARTITION `p2023` VALUES LESS THAN ('2024-01-01'))"
+    )
+
+
+def test_build_add_query_list():
+    result = build_add_query('`mydb`.`sales`', 'LIST', 'p_south', '7, 8, 9', None)
+
+    assert result == (
+        "ALTER TABLE `mydb`.`sales` ADD PARTITION "
+        "(PARTITION `p_south` VALUES IN (7, 8, 9))"
+    )
+
+
+def test_build_add_query_list_columns():
+    result = build_add_query('`mydb`.`sales`', 'LIST COLUMNS', 'p_south', "'x', 'y'", None)
+
+    assert result == (
+        "ALTER TABLE `mydb`.`sales` ADD PARTITION "
+        "(PARTITION `p_south` VALUES IN ('x', 'y'))"
+    )
+
+
+def test_build_add_query_hash():
+    result = build_add_query('`mydb`.`sessions`', 'HASH', None, None, 4)
+
+    assert result == 'ALTER TABLE `mydb`.`sessions` ADD PARTITION PARTITIONS 4'
+
+
+def test_build_add_query_linear_hash():
+    result = build_add_query('`t`', 'LINEAR HASH', None, None, 2)
+
+    assert result == 'ALTER TABLE `t` ADD PARTITION PARTITIONS 2'
+
+
+def test_build_add_query_key():
+    result = build_add_query('`t`', 'KEY', None, None, 3)
+
+    assert result == 'ALTER TABLE `t` ADD PARTITION PARTITIONS 3'
+
+
+def test_build_add_query_linear_key():
+    result = build_add_query('`t`', 'LINEAR KEY', None, None, 1)
+
+    assert result == 'ALTER TABLE `t` ADD PARTITION PARTITIONS 1'
+
+
+def test_build_add_query_range_maxvalue():
+    result = build_add_query('`t`', 'RANGE', 'pmax', 'MAXVALUE', None)
+
+    assert result == (
+        "ALTER TABLE `t` ADD PARTITION "
+        "(PARTITION `pmax` VALUES LESS THAN (MAXVALUE))"
+    )
+
+
+# ── build_drop_query ──────────────────────────────────────────────
+
+
+def test_build_drop_query_single():
+    result = build_drop_query('`mydb`.`events`', ['p2020'])
+
+    assert result == 'ALTER TABLE `mydb`.`events` DROP PARTITION `p2020`'
+
+
+def test_build_drop_query_multiple():
+    result = build_drop_query('`mydb`.`events`', ['p2020', 'p2021'])
+
+    assert result == 'ALTER TABLE `mydb`.`events` DROP PARTITION `p2020`, `p2021`'
+
+
+# ── build_reorganize_query ────────────────────────────────────────
+
+
+def test_build_reorganize_query_range_split():
+    into = [
+        {'name': 'p2022h1', 'value': '2022'},
+        {'name': 'p2022h2', 'value': '2023'},
+    ]
+
+    result = build_reorganize_query('`db`.`t`', 'RANGE', ['p2022'], into)
+
+    assert result == (
+        "ALTER TABLE `db`.`t` REORGANIZE PARTITION `p2022` INTO "
+        "(PARTITION `p2022h1` VALUES LESS THAN (2022), "
+        "PARTITION `p2022h2` VALUES LESS THAN (2023))"
+    )
+
+
+def test_build_reorganize_query_range_merge():
+    into = [{'name': 'p_merged', 'value': '2023'}]
+
+    result = build_reorganize_query('`db`.`t`', 'RANGE', ['p2021', 'p2022'], into)
+
+    assert result == (
+        "ALTER TABLE `db`.`t` REORGANIZE PARTITION `p2021`, `p2022` INTO "
+        "(PARTITION `p_merged` VALUES LESS THAN (2023))"
+    )
+
+
+def test_build_reorganize_query_range_columns():
+    into = [{'name': 'pa', 'value': "'2023-01-01'"}]
+
+    result = build_reorganize_query('`t`', 'RANGE COLUMNS', ['px'], into)
+
+    assert 'VALUES LESS THAN' in result
+
+
+def test_build_reorganize_query_list():
+    into = [
+        {'name': 'p_a', 'value': '1, 2'},
+        {'name': 'p_b', 'value': '3, 4'},
+    ]
+
+    result = build_reorganize_query('`db`.`t`', 'LIST', ['p_old'], into)
+
+    assert result == (
+        "ALTER TABLE `db`.`t` REORGANIZE PARTITION `p_old` INTO "
+        "(PARTITION `p_a` VALUES IN (1, 2), "
+        "PARTITION `p_b` VALUES IN (3, 4))"
+    )
+
+
+def test_build_reorganize_query_list_columns():
+    into = [{'name': 'px', 'value': "'a', 'b'"}]
+
+    result = build_reorganize_query('`t`', 'LIST COLUMNS', ['py'], into)
+
+    assert 'VALUES IN' in result
+
+
+# ── build_truncate_query ──────────────────────────────────────────
+
+
+def test_build_truncate_query_named():
+    result = build_truncate_query('`db`.`t`', ['p2020'])
+
+    assert result == 'ALTER TABLE `db`.`t` TRUNCATE PARTITION `p2020`'
+
+
+def test_build_truncate_query_multiple():
+    result = build_truncate_query('`db`.`t`', ['p1', 'p2'])
+
+    assert result == 'ALTER TABLE `db`.`t` TRUNCATE PARTITION `p1`, `p2`'
+
+
+def test_build_truncate_query_all():
+    result = build_truncate_query('`db`.`t`', ['ALL'])
+
+    assert result == 'ALTER TABLE `db`.`t` TRUNCATE PARTITION ALL'
+
+
+def test_build_truncate_query_all_lowercase():
+    result = build_truncate_query('`db`.`t`', ['all'])
+
+    assert result == 'ALTER TABLE `db`.`t` TRUNCATE PARTITION ALL'
+
+
+# ── build_maintenance_query ───────────────────────────────────────
+
+
+@pytest.mark.parametrize('action', ['check', 'repair', 'analyze', 'optimize'])
+def test_build_maintenance_query_named(action):
+    result = build_maintenance_query('`db`.`t`', action, ['p0'])
+
+    assert result == 'ALTER TABLE `db`.`t` %s PARTITION `p0`' % action.upper()
+
+
+@pytest.mark.parametrize('action', ['check', 'repair', 'analyze', 'optimize'])
+def test_build_maintenance_query_all(action):
+    result = build_maintenance_query('`db`.`t`', action, ['ALL'])
+
+    assert result == 'ALTER TABLE `db`.`t` %s PARTITION ALL' % action.upper()
+
+
+def test_build_maintenance_query_multiple_partitions():
+    result = build_maintenance_query('`t`', 'check', ['p0', 'p1', 'p2'])
+
+    assert result == 'ALTER TABLE `t` CHECK PARTITION `p0`, `p1`, `p2`'
+
+
+# ── validate_inputs ───────────────────────────────────────────────
+
+
+def test_validate_inputs_add_range_missing_partition_name():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='partition_name is required'):
+        validate_inputs(module, 'add', 'RANGE', None, '2024', None, None, None)
+
+
+def test_validate_inputs_add_range_missing_value():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='value is required'):
+        validate_inputs(module, 'add', 'RANGE', 'p2023', None, None, None, None)
+
+
+def test_validate_inputs_add_hash_missing_number():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='number is required'):
+        validate_inputs(module, 'add', 'HASH', None, None, None, None, None)
+
+
+def test_validate_inputs_add_hash_number_zero():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='number must be at least 1'):
+        validate_inputs(module, 'add', 'HASH', None, None, 0, None, None)
+
+
+def test_validate_inputs_add_linear_key_missing_number():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='number is required'):
+        validate_inputs(module, 'add', 'LINEAR KEY', None, None, None, None, None)
+
+
+def test_validate_inputs_add_range_valid():
+    module = DummyModule()
+
+    validate_inputs(module, 'add', 'RANGE', 'p2023', '2024', None, None, None)
+
+
+def test_validate_inputs_add_hash_valid():
+    module = DummyModule()
+
+    validate_inputs(module, 'add', 'HASH', None, None, 4, None, None)
+
+
+def test_validate_inputs_drop_missing_partitions():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='partitions is required for drop'):
+        validate_inputs(module, 'drop', 'RANGE', None, None, None, None, None)
+
+
+def test_validate_inputs_drop_hash_rejected():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='not supported for HASH'):
+        validate_inputs(module, 'drop', 'HASH', None, None, None, ['p0'], None)
+
+
+def test_validate_inputs_drop_linear_hash_rejected():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='not supported for LINEAR HASH'):
+        validate_inputs(module, 'drop', 'LINEAR HASH', None, None, None, ['p0'], None)
+
+
+def test_validate_inputs_drop_key_rejected():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='not supported for KEY'):
+        validate_inputs(module, 'drop', 'KEY', None, None, None, ['p0'], None)
+
+
+def test_validate_inputs_drop_range_valid():
+    module = DummyModule()
+
+    validate_inputs(module, 'drop', 'RANGE', None, None, None, ['p2020'], None)
+
+
+def test_validate_inputs_reorganize_missing_partitions():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='partitions is required for reorganize'):
+        validate_inputs(module, 'reorganize', 'RANGE', None, None, None, None,
+                        [{'name': 'px', 'value': '1'}])
+
+
+def test_validate_inputs_reorganize_missing_into():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='into is required for reorganize'):
+        validate_inputs(module, 'reorganize', 'RANGE', None, None, None, ['p0'], None)
+
+
+def test_validate_inputs_reorganize_hash_rejected():
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='not supported for HASH'):
+        validate_inputs(module, 'reorganize', 'HASH', None, None, None,
+                        ['p0'], [{'name': 'px', 'value': '1'}])
+
+
+def test_validate_inputs_reorganize_valid():
+    module = DummyModule()
+
+    validate_inputs(module, 'reorganize', 'LIST', None, None, None,
+                    ['p_old'], [{'name': 'px', 'value': '1, 2'}])
+
+
+@pytest.mark.parametrize('action', ['truncate', 'check', 'repair', 'analyze', 'optimize'])
+def test_validate_inputs_maintenance_missing_partitions(action):
+    module = DummyModule()
+
+    with pytest.raises(RuntimeError, match='partitions is required for %s' % action):
+        validate_inputs(module, action, 'RANGE', None, None, None, None, None)
+
+
+@pytest.mark.parametrize('action', ['truncate', 'check', 'repair', 'analyze', 'optimize'])
+def test_validate_inputs_maintenance_valid(action):
+    module = DummyModule()
+
+    validate_inputs(module, action, 'RANGE', None, None, None, ['p0'], None)
+
+
+# ── handle_add ────────────────────────────────────────────────────
+
+
+def test_handle_add_range_existing_partition_is_idempotent():
+    module = DummyModule(params={
+        'partition_name': 'p2020', 'value': '2021', 'number': None,
+    })
+    cursor = DummyCursor()
+
+    with pytest.raises(SystemExit) as exc:
+        handle_add(module, cursor, '`db`.`t`', 'db', 't', 'RANGE', SAMPLE_RANGE_PARTITIONS)
+
+    result = exc.value.args[0]
+    assert result['changed'] is False
+    assert 'already exists' in result['msg']
+
+
+def test_handle_add_range_new_partition():
+    module = DummyModule(params={
+        'partition_name': 'p2023', 'value': '2024', 'number': None,
+    })
+    cursor = DummyCursor()
+
+    queries = handle_add(module, cursor, '`db`.`t`', 'db', 't', 'RANGE', SAMPLE_RANGE_PARTITIONS)
+
+    assert len(queries) == 1
+    assert 'ADD PARTITION' in queries[0]
+    assert 'p2023' in queries[0]
+    assert len(cursor.executed) == 1
+
+
+def test_handle_add_range_check_mode():
+    module = DummyModule(params={
+        'partition_name': 'p2023', 'value': '2024', 'number': None,
+    })
+    module.check_mode = True
+    cursor = DummyCursor()
+
+    with pytest.raises(SystemExit) as exc:
+        handle_add(module, cursor, '`db`.`t`', 'db', 't', 'RANGE', SAMPLE_RANGE_PARTITIONS)
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+    assert 'would be added' in result['msg']
+    assert len(cursor.executed) == 0
+
+
+def test_handle_add_hash():
+    module = DummyModule(params={
+        'partition_name': None, 'value': None, 'number': 2,
+    })
+    cursor = DummyCursor()
+
+    queries = handle_add(module, cursor, '`t`', 'db', 't', 'HASH', SAMPLE_HASH_PARTITIONS)
+
+    assert 'ADD PARTITION PARTITIONS 2' in queries[0]
+
+
+def test_handle_add_execute_error():
+    module = DummyModule(params={
+        'partition_name': 'p2023', 'value': '2024', 'number': None,
+    })
+    cursor = FailingCursor('Duplicate partition name')
+
+    with pytest.raises(RuntimeError, match='Failed to add partition'):
+        handle_add(module, cursor, '`t`', 'db', 't', 'RANGE', SAMPLE_RANGE_PARTITIONS)
+
+
+# ── handle_drop ───────────────────────────────────────────────────
+
+
+def test_handle_drop_no_matching_partitions():
+    module = DummyModule(params={'partitions': ['p9999']})
+    cursor = DummyCursor()
+
+    with pytest.raises(SystemExit) as exc:
+        handle_drop(module, cursor, '`db`.`t`', 'db', 't', SAMPLE_RANGE_PARTITIONS)
+
+    result = exc.value.args[0]
+    assert result['changed'] is False
+    assert 'No matching' in result['msg']
+
+
+def test_handle_drop_filters_to_existing():
+    module = DummyModule(params={'partitions': ['p2020', 'p9999']})
+    cursor = DummyCursor()
+
+    queries = handle_drop(module, cursor, '`db`.`t`', 'db', 't', SAMPLE_RANGE_PARTITIONS)
+
+    assert len(queries) == 1
+    assert 'p2020' in queries[0]
+    assert 'p9999' not in queries[0]
+
+
+def test_handle_drop_check_mode():
+    module = DummyModule(params={'partitions': ['p2020']})
+    module.check_mode = True
+    cursor = DummyCursor()
+
+    with pytest.raises(SystemExit) as exc:
+        handle_drop(module, cursor, '`db`.`t`', 'db', 't', SAMPLE_RANGE_PARTITIONS)
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+    assert 'would be dropped' in result['msg']
+    assert len(cursor.executed) == 0
+
+
+def test_handle_drop_executes():
+    module = DummyModule(params={'partitions': ['p2020']})
+    cursor = DummyCursor()
+
+    queries = handle_drop(module, cursor, '`db`.`t`', 'db', 't', SAMPLE_RANGE_PARTITIONS)
+
+    assert 'DROP PARTITION' in queries[0]
+    assert len(cursor.executed) == 1
+
+
+def test_handle_drop_execute_error():
+    module = DummyModule(params={'partitions': ['p2020']})
+    cursor = FailingCursor('Cannot remove all partitions')
+
+    with pytest.raises(RuntimeError, match='Failed to drop partition'):
+        handle_drop(module, cursor, '`t`', 'db', 't', SAMPLE_RANGE_PARTITIONS)
+
+
+# ── handle_reorganize ────────────────────────────────────────────
+
+
+def test_handle_reorganize_executes():
+    module = DummyModule(params={
+        'partitions': ['p2020', 'p2021'],
+        'into': [{'name': 'p_merged', 'value': '2022'}],
+    })
+    cursor = DummyCursor()
+
+    queries = handle_reorganize(module, cursor, '`db`.`t`', 'RANGE', SAMPLE_RANGE_PARTITIONS)
+
+    assert 'REORGANIZE PARTITION' in queries[0]
+    assert '`p2020`, `p2021`' in queries[0]
+    assert 'p_merged' in queries[0]
+    assert len(cursor.executed) == 1
+
+
+def test_handle_reorganize_check_mode():
+    module = DummyModule(params={
+        'partitions': ['p2020'],
+        'into': [{'name': 'pa', 'value': '2020'}, {'name': 'pb', 'value': '2021'}],
+    })
+    module.check_mode = True
+    cursor = DummyCursor()
+
+    with pytest.raises(SystemExit) as exc:
+        handle_reorganize(module, cursor, '`t`', 'RANGE', SAMPLE_RANGE_PARTITIONS)
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+    assert 'would be reorganized' in result['msg']
+    assert len(cursor.executed) == 0
+
+
+def test_handle_reorganize_execute_error():
+    module = DummyModule(params={
+        'partitions': ['p2020'],
+        'into': [{'name': 'px', 'value': '2021'}],
+    })
+    cursor = FailingCursor('VALUES LESS THAN value must be strictly increasing')
+
+    with pytest.raises(RuntimeError, match='Failed to reorganize'):
+        handle_reorganize(module, cursor, '`t`', 'RANGE', SAMPLE_RANGE_PARTITIONS)
+
+
+# ── handle_truncate ───────────────────────────────────────────────
+
+
+def test_handle_truncate_executes():
+    module = DummyModule(params={'partitions': ['p2020']})
+    cursor = DummyCursor()
+
+    queries = handle_truncate(module, cursor, '`db`.`t`', SAMPLE_RANGE_PARTITIONS)
+
+    assert 'TRUNCATE PARTITION' in queries[0]
+    assert len(cursor.executed) == 1
+
+
+def test_handle_truncate_all():
+    module = DummyModule(params={'partitions': ['ALL']})
+    cursor = DummyCursor()
+
+    queries = handle_truncate(module, cursor, '`t`', SAMPLE_RANGE_PARTITIONS)
+
+    assert 'TRUNCATE PARTITION ALL' in queries[0]
+
+
+def test_handle_truncate_check_mode():
+    module = DummyModule(params={'partitions': ['p2020']})
+    module.check_mode = True
+    cursor = DummyCursor()
+
+    with pytest.raises(SystemExit) as exc:
+        handle_truncate(module, cursor, '`t`', SAMPLE_RANGE_PARTITIONS)
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+    assert 'would be truncated' in result['msg']
+    assert len(cursor.executed) == 0
+
+
+def test_handle_truncate_execute_error():
+    module = DummyModule(params={'partitions': ['p2020']})
+    cursor = FailingCursor('Unknown partition')
+
+    with pytest.raises(RuntimeError, match='Failed to truncate'):
+        handle_truncate(module, cursor, '`t`', SAMPLE_RANGE_PARTITIONS)
+
+
+# ── handle_maintenance ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize('action', ['check', 'repair', 'analyze', 'optimize'])
+def test_handle_maintenance_executes(action):
+    module = DummyModule(params={'partitions': ['p2020']})
+    cursor = DummyCursor()
+
+    queries = handle_maintenance(module, cursor, '`db`.`t`', action, SAMPLE_RANGE_PARTITIONS)
+
+    assert '%s PARTITION' % action.upper() in queries[0]
+    assert len(cursor.executed) == 1
+
+
+@pytest.mark.parametrize('action', ['check', 'repair', 'analyze', 'optimize'])
+def test_handle_maintenance_check_mode(action):
+    module = DummyModule(params={'partitions': ['p2020']})
+    module.check_mode = True
+    cursor = DummyCursor()
+
+    with pytest.raises(SystemExit) as exc:
+        handle_maintenance(module, cursor, '`t`', action, SAMPLE_RANGE_PARTITIONS)
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+    assert action.upper() in result['msg']
+    assert len(cursor.executed) == 0
+
+
+def test_handle_maintenance_execute_error():
+    module = DummyModule(params={'partitions': ['p2020']})
+    cursor = FailingCursor('Table not found')
+
+    with pytest.raises(RuntimeError, match='Failed to check partition'):
+        handle_maintenance(module, cursor, '`t`', 'check', SAMPLE_RANGE_PARTITIONS)
+
+
+def test_handle_maintenance_all():
+    module = DummyModule(params={'partitions': ['ALL']})
+    cursor = DummyCursor()
+
+    queries = handle_maintenance(module, cursor, '`t`', 'analyze', SAMPLE_RANGE_PARTITIONS)
+
+    assert 'ANALYZE PARTITION ALL' in queries[0]
+
+
+# ── main ──────────────────────────────────────────────────────────
+
+
+def _make_main_module(action='check', table='events', schema='mydb', **overrides):
+    params = {
+        'login_user': 'root',
+        'login_password': 'secret',
+        'config_file': '~/.my.cnf',
+        'client_cert': None,
+        'client_key': None,
+        'ca_cert': None,
+        'check_hostname': None,
+        'connect_timeout': 30,
+        'table': table,
+        'schema': schema,
+        'action': action,
+        'partition_name': None,
+        'value': None,
+        'number': None,
+        'partitions': ['p2020'],
+        'into': None,
+    }
+    params.update(overrides)
+    return DummyModule(params=params)
+
+
+def _patch_main(monkeypatch, module, cursor, server_impl='mysql', partition_rows=None):
+    if partition_rows is None:
+        partition_rows = SAMPLE_RANGE_PARTITIONS
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_partition.AnsibleModule',
+        lambda **kwargs: module,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_partition.mysql_driver',
+        object(),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_partition.mysql_connect',
+        lambda *args, **kwargs: (cursor, DummyConnection()),
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_partition.get_server_implementation',
+        lambda _cursor: server_impl,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_partition.check_input',
+        lambda *args: None,
+    )
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_partition.get_partition_info',
+        lambda _cursor, _schema, _table: list(partition_rows),
+    )
+
+
+def test_main_rejects_mariadb(monkeypatch):
+    module = _make_main_module()
+    cursor = DummyCursor()
+    _patch_main(monkeypatch, module, cursor, server_impl='mariadb')
+
+    with pytest.raises(RuntimeError, match='MariaDB is not supported'):
+        main()
+
+
+def test_main_fails_when_no_schema_and_no_default(monkeypatch):
+    module = _make_main_module(schema=None)
+    cursor = DummyCursor(fetchone_results=[{'DATABASE()': None}])
+    _patch_main(monkeypatch, module, cursor)
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_partition.get_current_schema',
+        lambda _cursor: None,
+    )
+
+    with pytest.raises(RuntimeError, match='No database selected'):
+        main()
+
+
+def test_main_fails_for_non_partitioned_table(monkeypatch):
+    module = _make_main_module()
+    cursor = DummyCursor()
+    _patch_main(monkeypatch, module, cursor, partition_rows=[])
+
+    with pytest.raises(RuntimeError, match='does not exist or is not partitioned'):
+        main()
+
+
+def test_main_check_mode_add(monkeypatch):
+    module = _make_main_module(
+        action='add', partition_name='p2023', value='2024',
+        partitions=None,
+    )
+    module.check_mode = True
+    cursor = DummyCursor()
+    _patch_main(monkeypatch, module, cursor)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+    assert 'would be added' in result['msg']
+
+
+def test_main_successful_drop(monkeypatch):
+    module = _make_main_module(action='drop', partitions=['p2020'])
+    cursor = DummyCursor()
+    _patch_main(monkeypatch, module, cursor)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+    assert 'DROP' in result['msg']
+
+
+def test_main_successful_truncate(monkeypatch):
+    module = _make_main_module(action='truncate', partitions=['ALL'])
+    cursor = DummyCursor()
+    _patch_main(monkeypatch, module, cursor)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+
+
+def test_main_successful_reorganize(monkeypatch):
+    module = _make_main_module(
+        action='reorganize',
+        partitions=['p2020', 'p2021'],
+        into=[{'name': 'p_merged', 'value': '2022'}],
+    )
+    cursor = DummyCursor()
+    _patch_main(monkeypatch, module, cursor)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+
+
+@pytest.mark.parametrize('action', ['check', 'repair', 'analyze', 'optimize'])
+def test_main_successful_maintenance(monkeypatch, action):
+    module = _make_main_module(action=action, partitions=['p2020'])
+    cursor = DummyCursor()
+    _patch_main(monkeypatch, module, cursor)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+    assert action.upper() in result['msg']
+
+
+def test_main_resolves_schema_from_connection(monkeypatch):
+    module = _make_main_module(action='check', schema=None, partitions=['p2020'])
+    cursor = DummyCursor()
+    _patch_main(monkeypatch, module, cursor)
+
+    monkeypatch.setattr(
+        'ansible_collections.ansible.mysql.plugins.modules.mysql_partition.get_current_schema',
+        lambda _cursor: 'resolved_db',
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result['changed'] is True
+
+
+def test_main_add_idempotent_existing_partition(monkeypatch):
+    module = _make_main_module(
+        action='add', partition_name='p2020', value='2021',
+        partitions=None,
+    )
+    cursor = DummyCursor()
+    _patch_main(monkeypatch, module, cursor)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result['changed'] is False
+    assert 'already exists' in result['msg']
+
+
+def test_main_drop_idempotent_missing_partition(monkeypatch):
+    module = _make_main_module(action='drop', partitions=['p9999'])
+    cursor = DummyCursor()
+    _patch_main(monkeypatch, module, cursor)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    result = exc.value.args[0]
+    assert result['changed'] is False
+    assert 'No matching' in result['msg']


### PR DESCRIPTION
#### SUMMARY
- add `mysql_partition` module to manage add, drop, reorganize, truncate, and maintenance partition operations for MySQL partitioned tables
- support RANGE, LIST, HASH, and KEY partition handling with idempotency, check mode, and MySQL-only validation

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/mysql_partition.py
- tests/unit/plugins/modules/test_mysql_partition.py
- tests/integration/targets/test_mysql_partition/defaults/main.yml
- tests/integration/targets/test_mysql_partition/meta/main.yml
- tests/integration/targets/test_mysql_partition/tasks/main.yml

#### ADDITIONAL INFORMATION
- Supports only mysql as mariadb splits to another collection
- Implemented using Claude Opus4.6 with Human in the loop and manual testing