### PR TITLE
chore(galaxy.yml): add dev files to build_ignore

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,3 +25,12 @@ build_ignore:
   - .claude
   - .gitignore
   - .venv
+  - AGENTS.md
+  - antsibull-nox.toml
+  - codecov.yml
+  - MAINTAINERS
+  - Makefile
+  - noxfile.py
+  - run_all_tests.py
+  - TESTING.md
+  - MAINTAINING.md


### PR DESCRIPTION
##### SUMMARY
chore(galaxy.yml): add dev files to build_ignore